### PR TITLE
feat: add country polygon filtering on globe

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ export default function App() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [flyTarget, setFlyTarget] = useState(null);
+  const [selectedCountry, setSelectedCountry] = useState('');
   const globeRef = useRef(null);
 
   useEffect(() => {
@@ -50,6 +51,17 @@ export default function App() {
     }
   }, []);
 
+  const handleSelectCountry = useCallback((country, view) => {
+    setSelectedCountry(country);
+    if (view) {
+      setFlyTarget({ lat: view.lat, lng: view.lng, altitude: view.altitude });
+    }
+  }, []);
+
+  const handleClearCountry = useCallback(() => {
+    setSelectedCountry('');
+  }, []);
+
   const handleCloseDetail = useCallback(() => {
     setSelectedDev(null);
   }, []);
@@ -58,6 +70,7 @@ export default function App() {
     setSelectedDev(null);
     setFiltered(developers);
     setFlyTarget(null);
+    setSelectedCountry('');
   }, [developers]);
 
   if (loading || error) {
@@ -77,12 +90,17 @@ export default function App() {
           ref={globeRef}
           developers={filtered}
           flyTarget={flyTarget}
+          selectedCountry={selectedCountry}
           onSelectDev={handleSelectDev}
+          onSelectCountry={handleSelectCountry}
+          onClearCountry={handleClearCountry}
         />
         <Leaderboard
           developers={filtered}
           selectedLogin={selectedDev?.login}
           onSelectDev={handleSelectDev}
+          countryFilter={selectedCountry}
+          onCountryFilterChange={setSelectedCountry}
         />
         {selectedDev && (
           <DetailPanel dev={selectedDev} onClose={handleCloseDetail} />

--- a/src/components/Globe.jsx
+++ b/src/components/Globe.jsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef, useMemo, useState, forwardRef, useImperativeH
 import GlobeGL from 'react-globe.gl';
 import { getPlatformColor } from '../utils/scoring.js';
 import { formatNum } from '../utils/format.js';
-import { extractCountry, countryKey } from './Leaderboard.jsx';
+import { extractCountry, countryKey } from '../utils/country.js';
 
-// Low-res Natural Earth countries (177 features). Second entry is a mirror.
+// Low-res Natural Earth countries (177 features), pinned to the commit that added
+// the dataset so the shapes can't change under us. Second entry is a mirror.
 const COUNTRY_GEOJSON_URLS = [
-  'https://cdn.jsdelivr.net/gh/vasturiano/react-globe.gl@master/example/datasets/ne_110m_admin_0_countries.geojson',
-  'https://raw.githubusercontent.com/vasturiano/react-globe.gl/master/example/datasets/ne_110m_admin_0_countries.geojson',
+  'https://cdn.jsdelivr.net/gh/vasturiano/react-globe.gl@507cfce3934e66349522bc80351d7a054e46ab6d/example/datasets/ne_110m_admin_0_countries.geojson',
+  'https://raw.githubusercontent.com/vasturiano/react-globe.gl/507cfce3934e66349522bc80351d7a054e46ab6d/example/datasets/ne_110m_admin_0_countries.geojson',
 ];
 
 // Kept below the lowest developer point (0.01) so points stay hoverable

--- a/src/components/Globe.jsx
+++ b/src/components/Globe.jsx
@@ -277,9 +277,10 @@ const Globe = forwardRef(function Globe({
 
     if (feat) {
       const name = featureName(feat);
+      const safeName = String(name).replace(/[&<>"']/g, ch => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
       const count = devCountByCountry.get(countryKey(name)) || 0;
       tooltip.innerHTML = `
-        <div class="tooltip__name">${name}</div>
+        <div class="tooltip__name">${safeName}</div>
         <div class="tooltip__score">${count ? `${formatNum(count)} developer${count === 1 ? '' : 's'}` : 'No developers yet'}</div>
         <div class="tooltip__meta"><span>Click to focus this country</span></div>
       `;

--- a/src/components/Globe.jsx
+++ b/src/components/Globe.jsx
@@ -1,7 +1,18 @@
-import React, { useEffect, useRef, useMemo, forwardRef, useImperativeHandle, useCallback } from 'react';
+import React, { useEffect, useRef, useMemo, useState, forwardRef, useImperativeHandle, useCallback } from 'react';
 import GlobeGL from 'react-globe.gl';
 import { getPlatformColor } from '../utils/scoring.js';
 import { formatNum } from '../utils/format.js';
+import { extractCountry, countryKey } from './Leaderboard.jsx';
+
+// Low-res Natural Earth countries (177 features). Second entry is a mirror.
+const COUNTRY_GEOJSON_URLS = [
+  'https://cdn.jsdelivr.net/gh/vasturiano/react-globe.gl@master/example/datasets/ne_110m_admin_0_countries.geojson',
+  'https://raw.githubusercontent.com/vasturiano/react-globe.gl/master/example/datasets/ne_110m_admin_0_countries.geojson',
+];
+
+// Kept below the lowest developer point (0.01) so points stay hoverable
+const POLYGON_ALTITUDE = 0.003;
+const POLYGON_ALTITUDE_ACTIVE = 0.009;
 
 // Score-based color gradient: blue → green → gold → red
 function getScoreColor(score) {
@@ -11,9 +22,105 @@ function getScoreColor(score) {
   return '#6366f1'; // indigo — emerging
 }
 
-const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, ref) {
+function featureName(feat) {
+  return feat?.properties?.ADMIN || feat?.properties?.NAME || '';
+}
+
+// Stable accessors — a new identity makes react-globe.gl rebuild the whole layer,
+// and hovering a country re-renders this component.
+const devLat = d => d.lat;
+const devLng = d => d.lng;
+const pointAltitude = d => 0.01 + (d.score / 100) * 0.06;
+const pointRadius = d => 0.3 + (d.score / 100) * 0.7;
+const pointColor = d => getScoreColor(d.score);
+const ringMaxRadius = d => d.maxR;
+const ringPropagationSpeed = d => d.propagationSpeed;
+const ringRepeatPeriod = d => d.repeatPeriod;
+const ringColor = d => () => d.color;
+const labelText = d => d.login;
+const labelSize = d => 0.6 + (d.score / 100) * 0.4;
+const labelColor = () => 'rgba(226, 232, 240, 0.75)';
+const noLabel = () => '';
+
+function ringArea(ring) {
+  let area = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    area += ring[j][0] * ring[i][1] - ring[i][0] * ring[j][1];
+  }
+  return Math.abs(area / 2);
+}
+
+// Biggest outer ring, so scattered countries (USA, Russia) target their mainland
+function mainRing(geometry) {
+  if (!geometry) return null;
+  const polygons = geometry.type === 'MultiPolygon' ? geometry.coordinates : [geometry.coordinates];
+  let best = null;
+  let bestArea = -1;
+  for (const polygon of polygons) {
+    const area = ringArea(polygon[0]);
+    if (area > bestArea) {
+      bestArea = area;
+      best = polygon[0];
+    }
+  }
+  return best;
+}
+
+// Centroid of a country plus a camera altitude that roughly frames it
+function countryView(feat) {
+  const ring = mainRing(feat?.geometry);
+  if (!ring || ring.length < 3) return null;
+
+  // Unwrap longitudes so rings crossing the antimeridian stay contiguous
+  const lng0 = ring[0][0];
+  const pts = ring.map(([lng, lat]) => [lng - 360 * Math.round((lng - lng0) / 360), lat]);
+
+  let twiceArea = 0;
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    const cross = pts[j][0] * pts[i][1] - pts[i][0] * pts[j][1];
+    twiceArea += cross;
+    cx += (pts[j][0] + pts[i][0]) * cross;
+    cy += (pts[j][1] + pts[i][1]) * cross;
+  }
+
+  let lat;
+  let lng;
+  if (Math.abs(twiceArea) < 1e-9) {
+    lng = pts.reduce((sum, p) => sum + p[0], 0) / pts.length;
+    lat = pts.reduce((sum, p) => sum + p[1], 0) / pts.length;
+  } else {
+    lng = cx / (3 * twiceArea);
+    lat = cy / (3 * twiceArea);
+  }
+  lng = ((lng + 540) % 360) - 180;
+
+  let minLat = Infinity, maxLat = -Infinity, minLng = Infinity, maxLng = -Infinity;
+  for (const [x, y] of pts) {
+    if (y < minLat) minLat = y;
+    if (y > maxLat) maxLat = y;
+    if (x < minLng) minLng = x;
+    if (x > maxLng) maxLng = x;
+  }
+  const span = Math.max(maxLat - minLat, (maxLng - minLng) * Math.cos(lat * Math.PI / 180));
+
+  return { lat, lng, altitude: Math.min(2.2, Math.max(0.55, span / 40)) };
+}
+
+const Globe = forwardRef(function Globe({
+  developers,
+  flyTarget,
+  selectedCountry,
+  onSelectDev,
+  onSelectCountry,
+  onClearCountry,
+}, ref) {
   const globeEl = useRef();
   const tooltipRef = useRef(null);
+  const pointerDownPos = useRef(null);
+  const [countryFeatures, setCountryFeatures] = useState([]);
+  const [hoverCountry, setHoverCountry] = useState(null);
 
   const geoDevs = useMemo(() => {
     return developers
@@ -39,6 +146,43 @@ const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, 
     }));
   }, [geoDevs]);
 
+  // Developers per country, keyed the same way the leaderboard filters
+  const devCountByCountry = useMemo(() => {
+    const counts = new Map();
+    developers.forEach(d => {
+      if (!d.location) return;
+      const key = countryKey(extractCountry(d.location));
+      if (key) counts.set(key, (counts.get(key) || 0) + 1);
+    });
+    return counts;
+  }, [developers]);
+
+  const selectedFeature = useMemo(() => {
+    if (!selectedCountry) return null;
+    const key = countryKey(selectedCountry);
+    return countryFeatures.find(f => countryKey(featureName(f)) === key) || null;
+  }, [selectedCountry, countryFeatures]);
+
+  // Country borders — the globe still works if the CDN is unreachable
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      for (const url of COUNTRY_GEOJSON_URLS) {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) continue;
+          const geo = await res.json();
+          if (cancelled) return;
+          setCountryFeatures((geo.features || []).filter(f => f.properties?.ISO_A2 !== 'AQ'));
+          return;
+        } catch {
+          // try the next mirror
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
   // Auto-rotate on mount
   useEffect(() => {
     const controls = globeEl.current?.controls();
@@ -52,7 +196,7 @@ const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, 
   // Fly to target
   useEffect(() => {
     if (flyTarget && globeEl.current) {
-      globeEl.current.pointOfView({ lat: flyTarget.lat, lng: flyTarget.lng, altitude: 1.5 }, 1000);
+      globeEl.current.pointOfView({ lat: flyTarget.lat, lng: flyTarget.lng, altitude: flyTarget.altitude ?? 1.5 }, 1000);
       const controls = globeEl.current.controls();
       if (controls) controls.autoRotate = false;
     }
@@ -64,10 +208,15 @@ const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, 
     },
   }));
 
+  const setAutoRotate = useCallback((on) => {
+    const controls = globeEl.current?.controls();
+    // Stay still while a country is in focus
+    if (controls) controls.autoRotate = on && !selectedCountry;
+  }, [selectedCountry]);
+
   const handleHover = useCallback((point) => {
     const tooltip = tooltipRef.current;
     if (!tooltip) return;
-    const controls = globeEl.current?.controls();
 
     if (point) {
       tooltip.innerHTML = `
@@ -90,16 +239,81 @@ const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, 
         </div>
       `;
       tooltip.classList.add('visible');
-      if (controls) controls.autoRotate = false;
+      setAutoRotate(false);
     } else {
       tooltip.classList.remove('visible');
-      if (controls) controls.autoRotate = true;
+      setAutoRotate(true);
     }
-  }, []);
+  }, [setAutoRotate]);
 
   const handleClick = useCallback((point) => {
     if (point) onSelectDev(point);
   }, [onSelectDev]);
+
+  const polygonAltitude = useCallback((f) => (
+    f === hoverCountry || f === selectedFeature ? POLYGON_ALTITUDE_ACTIVE : POLYGON_ALTITUDE
+  ), [hoverCountry, selectedFeature]);
+
+  const polygonCapColor = useCallback((f) => {
+    if (f === selectedFeature) return 'rgba(251, 191, 36, 0.28)';
+    if (f === hoverCountry) return 'rgba(96, 165, 250, 0.30)';
+    return 'rgba(59, 130, 246, 0.05)';
+  }, [hoverCountry, selectedFeature]);
+
+  const polygonSideColor = useCallback((f) => (
+    f === hoverCountry || f === selectedFeature ? 'rgba(96, 165, 250, 0.20)' : 'rgba(59, 130, 246, 0.06)'
+  ), [hoverCountry, selectedFeature]);
+
+  const polygonStrokeColor = useCallback((f) => {
+    if (f === selectedFeature) return '#fbbf24';
+    if (f === hoverCountry) return '#93c5fd';
+    return 'rgba(148, 163, 184, 0.35)';
+  }, [hoverCountry, selectedFeature]);
+
+  const handleCountryHover = useCallback((feat) => {
+    setHoverCountry(feat || null);
+    const tooltip = tooltipRef.current;
+    if (!tooltip) return;
+
+    if (feat) {
+      const name = featureName(feat);
+      const count = devCountByCountry.get(countryKey(name)) || 0;
+      tooltip.innerHTML = `
+        <div class="tooltip__name">${name}</div>
+        <div class="tooltip__score">${count ? `${formatNum(count)} developer${count === 1 ? '' : 's'}` : 'No developers yet'}</div>
+        <div class="tooltip__meta"><span>Click to focus this country</span></div>
+      `;
+      tooltip.classList.add('visible');
+      setAutoRotate(false);
+    } else {
+      tooltip.classList.remove('visible');
+      setAutoRotate(true);
+    }
+  }, [devCountByCountry, setAutoRotate]);
+
+  const handleCountryClick = useCallback((feat) => {
+    if (!feat) return;
+    onSelectCountry?.(featureName(feat), countryView(feat));
+  }, [onSelectCountry]);
+
+  // Ocean (globe surface not covered by a country polygon)
+  const handleGlobeClick = useCallback(() => {
+    onClearCountry?.();
+  }, [onClearCountry]);
+
+  const handlePointerDown = useCallback((e) => {
+    pointerDownPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  // Empty space around the globe — globe.gl has no callback for it
+  const handleContainerClick = useCallback((e) => {
+    const down = pointerDownPos.current;
+    pointerDownPos.current = null;
+    if (down && Math.hypot(e.clientX - down.x, e.clientY - down.y) > 4) return; // camera drag
+    const rect = e.currentTarget.getBoundingClientRect();
+    const coords = globeEl.current?.toGlobeCoords(e.clientX - rect.left, e.clientY - rect.top);
+    if (!coords) onClearCountry?.();
+  }, [onClearCountry]);
 
   // Track mouse for tooltip
   useEffect(() => {
@@ -115,7 +329,7 @@ const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, 
 
   return (
     <>
-      <div id="globe-container">
+      <div id="globe-container" onPointerDown={handlePointerDown} onClick={handleContainerClick}>
         <GlobeGL
           ref={globeEl}
           globeImageUrl="https://unpkg.com/three-globe@2.31.0/example/img/earth-night.jpg"
@@ -124,26 +338,36 @@ const Globe = forwardRef(function Globe({ developers, flyTarget, onSelectDev }, 
           showAtmosphere={true}
           atmosphereColor="#3a7ecf"
           atmosphereAltitude={0.25}
+          polygonsData={countryFeatures}
+          polygonAltitude={polygonAltitude}
+          polygonCapColor={polygonCapColor}
+          polygonSideColor={polygonSideColor}
+          polygonStrokeColor={polygonStrokeColor}
+          polygonLabel={noLabel}
+          polygonsTransitionDuration={250}
+          onPolygonHover={handleCountryHover}
+          onPolygonClick={handleCountryClick}
+          onGlobeClick={handleGlobeClick}
           pointsData={geoDevs}
-          pointLat={d => d.lat}
-          pointLng={d => d.lng}
-          pointAltitude={d => 0.01 + (d.score / 100) * 0.06}
-          pointRadius={d => 0.3 + (d.score / 100) * 0.7}
-          pointColor={d => getScoreColor(d.score)}
+          pointLat={devLat}
+          pointLng={devLng}
+          pointAltitude={pointAltitude}
+          pointRadius={pointRadius}
+          pointColor={pointColor}
           pointResolution={6}
           ringsData={ringsData}
-          ringLat={d => d.lat}
-          ringLng={d => d.lng}
-          ringMaxRadius={d => d.maxR}
-          ringPropagationSpeed={d => d.propagationSpeed}
-          ringRepeatPeriod={d => d.repeatPeriod}
-          ringColor={d => () => d.color}
+          ringLat={devLat}
+          ringLng={devLng}
+          ringMaxRadius={ringMaxRadius}
+          ringPropagationSpeed={ringPropagationSpeed}
+          ringRepeatPeriod={ringRepeatPeriod}
+          ringColor={ringColor}
           labelsData={labelDevs}
-          labelLat={d => d.lat}
-          labelLng={d => d.lng}
-          labelText={d => d.login}
-          labelSize={d => 0.6 + (d.score / 100) * 0.4}
-          labelColor={() => 'rgba(226, 232, 240, 0.75)'}
+          labelLat={devLat}
+          labelLng={devLng}
+          labelText={labelText}
+          labelSize={labelSize}
+          labelColor={labelColor}
           labelDotRadius={0.3}
           labelAltitude={0.02}
           onPointHover={handleHover}

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -1,98 +1,9 @@
 import React, { useMemo, useRef, useState, useEffect, useCallback } from 'react';
 import { formatNum } from '../utils/format.js';
+import { extractCountry, normalizeCountry, countryKey } from '../utils/country.js';
 
 const ITEM_HEIGHT = 62;
 const BUFFER = 10;
-
-// Map common cities to their country for better filtering
-const CITY_TO_COUNTRY = {
-  'colombo': 'Sri Lanka', 'kandy': 'Sri Lanka', 'galle': 'Sri Lanka', 'jaffna': 'Sri Lanka',
-  'bangalore': 'India', 'mumbai': 'India', 'delhi': 'India', 'hyderabad': 'India', 'pune': 'India', 'chennai': 'India', 'kolkata': 'India',
-  'london': 'UK', 'manchester': 'UK', 'edinburgh': 'UK', 'birmingham': 'UK',
-  'san francisco': 'USA', 'new york': 'USA', 'seattle': 'USA', 'austin': 'USA', 'los angeles': 'USA', 'boston': 'USA', 'chicago': 'USA',
-  'toronto': 'Canada', 'vancouver': 'Canada', 'montreal': 'Canada',
-  'berlin': 'Germany', 'munich': 'Germany', 'hamburg': 'Germany', 'frankfurt': 'Germany',
-  'paris': 'France', 'lyon': 'France',
-  'tokyo': 'Japan', 'osaka': 'Japan',
-  'sydney': 'Australia', 'melbourne': 'Australia', 'brisbane': 'Australia',
-  'beijing': 'China', 'shanghai': 'China', 'shenzhen': 'China', 'hangzhou': 'China',
-  'são paulo': 'Brazil', 'rio de janeiro': 'Brazil',
-  'amsterdam': 'Netherlands',
-  'stockholm': 'Sweden',
-  'singapore': 'Singapore',
-  'seoul': 'South Korea',
-  'tel aviv': 'Israel',
-  'istanbul': 'Turkey',
-  'lagos': 'Nigeria',
-  'nairobi': 'Kenya',
-  'cape town': 'South Africa',
-  'jakarta': 'Indonesia',
-  'bangkok': 'Thailand',
-  'kuala lumpur': 'Malaysia',
-};
-
-// Canonical names for the same country written differently by GitHub users and
-// by the Natural Earth GeoJSON used for the globe polygons (properties.ADMIN).
-const COUNTRY_ALIASES = {
-  'united states of america': 'USA', 'united states': 'USA', 'usa': 'USA', 'us': 'USA',
-  'u.s.': 'USA', 'u.s.a.': 'USA', 'america': 'USA',
-  'united kingdom': 'UK', 'great britain': 'UK', 'england': 'UK', 'scotland': 'UK',
-  'wales': 'UK', 'northern ireland': 'UK', 'uk': 'UK',
-  'republic of korea': 'South Korea', 'korea': 'South Korea',
-  'russian federation': 'Russia',
-  'czechia': 'Czech Republic',
-  "people's republic of china": 'China', 'prc': 'China',
-  'republic of india': 'India',
-  'deutschland': 'Germany',
-  'brasil': 'Brazil',
-  'españa': 'Spain', 'espana': 'Spain',
-  'the netherlands': 'Netherlands', 'nederland': 'Netherlands', 'holland': 'Netherlands',
-  'united arab emirates': 'UAE', 'uae': 'UAE',
-  'viet nam': 'Vietnam',
-  'islamic republic of iran': 'Iran',
-  'united republic of tanzania': 'Tanzania',
-  'democratic republic of the congo': 'DR Congo', 'republic of the congo': 'Congo',
-  'türkiye': 'Turkey', 'turkiye': 'Turkey',
-  'republic of serbia': 'Serbia',
-  'bosnia and herzegovina': 'Bosnia',
-  'hong kong s.a.r.': 'Hong Kong',
-  'macedonia': 'North Macedonia',
-};
-
-export function normalizeCountry(name) {
-  if (!name) return '';
-  const trimmed = name.trim();
-  return COUNTRY_ALIASES[trimmed.toLowerCase()] || trimmed;
-}
-
-// Comparable form — use whenever two country names from different sources are matched
-export function countryKey(name) {
-  return normalizeCountry(name).toLowerCase();
-}
-
-export function extractCountry(location) {
-  const parts = location.split(/[,\-–]/).map(s => s.trim());
-  const lastPart = parts[parts.length - 1];
-
-  // Check if last part is already a recognizable country
-  if (lastPart && lastPart.length > 2) {
-    // Normalize common abbreviations
-    if (/^(US|USA|U\.S\.?A?\.?)$/i.test(lastPart)) return 'USA';
-    if (/^(UK|United Kingdom|England|Scotland|Wales)$/i.test(lastPart)) return 'UK';
-  }
-
-  // If only one part (just a city), look up in city map
-  if (parts.length === 1) {
-    const mapped = CITY_TO_COUNTRY[lastPart.toLowerCase()];
-    if (mapped) return mapped;
-  }
-
-  // Try matching last part against city map (e.g. "Colombo 02, Sri Lanka" → "Sri Lanka")
-  const mapped = CITY_TO_COUNTRY[lastPart.toLowerCase()];
-  if (mapped) return mapped;
-
-  return lastPart;
-}
 
 export default function Leaderboard({
   developers,

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -31,7 +31,46 @@ const CITY_TO_COUNTRY = {
   'kuala lumpur': 'Malaysia',
 };
 
-function extractCountry(location) {
+// Canonical names for the same country written differently by GitHub users and
+// by the Natural Earth GeoJSON used for the globe polygons (properties.ADMIN).
+const COUNTRY_ALIASES = {
+  'united states of america': 'USA', 'united states': 'USA', 'usa': 'USA', 'us': 'USA',
+  'u.s.': 'USA', 'u.s.a.': 'USA', 'america': 'USA',
+  'united kingdom': 'UK', 'great britain': 'UK', 'england': 'UK', 'scotland': 'UK',
+  'wales': 'UK', 'northern ireland': 'UK', 'uk': 'UK',
+  'republic of korea': 'South Korea', 'korea': 'South Korea',
+  'russian federation': 'Russia',
+  'czechia': 'Czech Republic',
+  "people's republic of china": 'China', 'prc': 'China',
+  'republic of india': 'India',
+  'deutschland': 'Germany',
+  'brasil': 'Brazil',
+  'españa': 'Spain', 'espana': 'Spain',
+  'the netherlands': 'Netherlands', 'nederland': 'Netherlands', 'holland': 'Netherlands',
+  'united arab emirates': 'UAE', 'uae': 'UAE',
+  'viet nam': 'Vietnam',
+  'islamic republic of iran': 'Iran',
+  'united republic of tanzania': 'Tanzania',
+  'democratic republic of the congo': 'DR Congo', 'republic of the congo': 'Congo',
+  'türkiye': 'Turkey', 'turkiye': 'Turkey',
+  'republic of serbia': 'Serbia',
+  'bosnia and herzegovina': 'Bosnia',
+  'hong kong s.a.r.': 'Hong Kong',
+  'macedonia': 'North Macedonia',
+};
+
+export function normalizeCountry(name) {
+  if (!name) return '';
+  const trimmed = name.trim();
+  return COUNTRY_ALIASES[trimmed.toLowerCase()] || trimmed;
+}
+
+// Comparable form — use whenever two country names from different sources are matched
+export function countryKey(name) {
+  return normalizeCountry(name).toLowerCase();
+}
+
+export function extractCountry(location) {
   const parts = location.split(/[,\-–]/).map(s => s.trim());
   const lastPart = parts[parts.length - 1];
 
@@ -55,13 +94,18 @@ function extractCountry(location) {
   return lastPart;
 }
 
-export default function Leaderboard({ developers, selectedLogin, onSelectDev }) {
+export default function Leaderboard({
+  developers,
+  selectedLogin,
+  onSelectDev,
+  countryFilter = '',
+  onCountryFilterChange,
+}) {
   const listRef = useRef(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewHeight, setViewHeight] = useState(600);
 
-  // Filters
-  const [countryFilter, setCountryFilter] = useState('');
+  // Filters (country is owned by App so the globe can drive it too)
   const [langFilter, setLangFilter] = useState('');
   const [sortBy, setSortBy] = useState('score');
 
@@ -69,12 +113,24 @@ export default function Leaderboard({ developers, selectedLogin, onSelectDev }) 
     const map = new Map();
     developers.forEach(d => {
       if (d.location) {
-        const country = extractCountry(d.location);
-        if (country && country.length > 1) map.set(country, (map.get(country) || 0) + 1);
+        const country = normalizeCountry(extractCountry(d.location));
+        if (country && country.length > 1) {
+          const entry = map.get(country.toLowerCase());
+          if (entry) entry.count++;
+          else map.set(country.toLowerCase(), { name: country, count: 1 });
+        }
       }
     });
-    return [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, 50);
+    return [...map.values()].sort((a, b) => b.count - a.count).slice(0, 50);
   }, [developers]);
+
+  // A country picked on the globe may have no developers, or be spelled
+  // differently than the option built from developer locations.
+  const selectedCountryOption = useMemo(() => {
+    if (!countryFilter) return null;
+    const key = countryKey(countryFilter);
+    return countries.find(c => c.name.toLowerCase() === key) || null;
+  }, [countries, countryFilter]);
 
   const languages = useMemo(() => {
     const set = new Set();
@@ -83,9 +139,10 @@ export default function Leaderboard({ developers, selectedLogin, onSelectDev }) 
   }, [developers]);
 
   const filtered = useMemo(() => {
+    const wantedCountry = countryKey(countryFilter);
     let result = developers.filter(d => {
       const matchLang = !langFilter || d.topLanguage === langFilter;
-      const matchCountry = !countryFilter || (d.location && extractCountry(d.location) === countryFilter);
+      const matchCountry = !wantedCountry || (d.location && countryKey(extractCountry(d.location)) === wantedCountry);
       return matchLang && matchCountry;
     });
 
@@ -139,7 +196,7 @@ export default function Leaderboard({ developers, selectedLogin, onSelectDev }) 
 
   const hasActiveFilter = countryFilter || langFilter;
   const clearFilters = () => {
-    setCountryFilter('');
+    onCountryFilterChange?.('');
     setLangFilter('');
   };
 
@@ -156,10 +213,18 @@ export default function Leaderboard({ developers, selectedLogin, onSelectDev }) 
         </div>
         <div className="sidebar__count">{filtered.length} developer{filtered.length !== 1 ? 's' : ''}</div>
         <div className="sidebar__filters">
-          <select value={countryFilter} onChange={e => setCountryFilter(e.target.value)}>
+          <select
+            value={selectedCountryOption ? selectedCountryOption.name : countryFilter}
+            onChange={e => onCountryFilterChange?.(e.target.value)}
+          >
             <option value="">All Countries</option>
-            {countries.map(([c, n]) => (
-              <option key={c} value={c}>{c.length > 15 ? c.slice(0, 14) + '…' : c} ({n})</option>
+            {countryFilter && !selectedCountryOption && (
+              <option value={countryFilter}>
+                {countryFilter.length > 15 ? countryFilter.slice(0, 14) + '…' : countryFilter} (0)
+              </option>
+            )}
+            {countries.map(({ name, count }) => (
+              <option key={name} value={name}>{name.length > 15 ? name.slice(0, 14) + '…' : name} ({count})</option>
             ))}
           </select>
           <select value={langFilter} onChange={e => setLangFilter(e.target.value)}>

--- a/src/utils/country.js
+++ b/src/utils/country.js
@@ -1,0 +1,89 @@
+// Map common cities to their country for better filtering
+const CITY_TO_COUNTRY = {
+  'colombo': 'Sri Lanka', 'kandy': 'Sri Lanka', 'galle': 'Sri Lanka', 'jaffna': 'Sri Lanka',
+  'bangalore': 'India', 'mumbai': 'India', 'delhi': 'India', 'hyderabad': 'India', 'pune': 'India', 'chennai': 'India', 'kolkata': 'India',
+  'london': 'UK', 'manchester': 'UK', 'edinburgh': 'UK', 'birmingham': 'UK',
+  'san francisco': 'USA', 'new york': 'USA', 'seattle': 'USA', 'austin': 'USA', 'los angeles': 'USA', 'boston': 'USA', 'chicago': 'USA',
+  'toronto': 'Canada', 'vancouver': 'Canada', 'montreal': 'Canada',
+  'berlin': 'Germany', 'munich': 'Germany', 'hamburg': 'Germany', 'frankfurt': 'Germany',
+  'paris': 'France', 'lyon': 'France',
+  'tokyo': 'Japan', 'osaka': 'Japan',
+  'sydney': 'Australia', 'melbourne': 'Australia', 'brisbane': 'Australia',
+  'beijing': 'China', 'shanghai': 'China', 'shenzhen': 'China', 'hangzhou': 'China',
+  'são paulo': 'Brazil', 'rio de janeiro': 'Brazil',
+  'amsterdam': 'Netherlands',
+  'stockholm': 'Sweden',
+  'singapore': 'Singapore',
+  'seoul': 'South Korea',
+  'tel aviv': 'Israel',
+  'istanbul': 'Turkey',
+  'lagos': 'Nigeria',
+  'nairobi': 'Kenya',
+  'cape town': 'South Africa',
+  'jakarta': 'Indonesia',
+  'bangkok': 'Thailand',
+  'kuala lumpur': 'Malaysia',
+};
+
+// Canonical names for the same country written differently by GitHub users and
+// by the Natural Earth GeoJSON used for the globe polygons (properties.ADMIN).
+const COUNTRY_ALIASES = {
+  'united states of america': 'USA', 'united states': 'USA', 'usa': 'USA', 'us': 'USA',
+  'u.s.': 'USA', 'u.s.a.': 'USA', 'america': 'USA',
+  'united kingdom': 'UK', 'great britain': 'UK', 'england': 'UK', 'scotland': 'UK',
+  'wales': 'UK', 'northern ireland': 'UK', 'uk': 'UK',
+  'republic of korea': 'South Korea', 'korea': 'South Korea',
+  'russian federation': 'Russia',
+  'czechia': 'Czech Republic',
+  "people's republic of china": 'China', 'prc': 'China',
+  'republic of india': 'India',
+  'deutschland': 'Germany',
+  'brasil': 'Brazil',
+  'españa': 'Spain', 'espana': 'Spain',
+  'the netherlands': 'Netherlands', 'nederland': 'Netherlands', 'holland': 'Netherlands',
+  'united arab emirates': 'UAE', 'uae': 'UAE',
+  'viet nam': 'Vietnam',
+  'islamic republic of iran': 'Iran',
+  'united republic of tanzania': 'Tanzania',
+  'democratic republic of the congo': 'DR Congo', 'republic of the congo': 'Congo',
+  'türkiye': 'Turkey', 'turkiye': 'Turkey',
+  'republic of serbia': 'Serbia',
+  'bosnia and herzegovina': 'Bosnia',
+  'hong kong s.a.r.': 'Hong Kong',
+  'macedonia': 'North Macedonia',
+};
+
+export function normalizeCountry(name) {
+  if (!name) return '';
+  const trimmed = name.trim();
+  return COUNTRY_ALIASES[trimmed.toLowerCase()] || trimmed;
+}
+
+// Comparable form — use whenever two country names from different sources are matched
+export function countryKey(name) {
+  return normalizeCountry(name).toLowerCase();
+}
+
+export function extractCountry(location) {
+  const parts = location.split(/[,\-–]/).map(s => s.trim());
+  const lastPart = parts[parts.length - 1];
+
+  // Check if last part is already a recognizable country
+  if (lastPart && lastPart.length > 2) {
+    // Normalize common abbreviations
+    if (/^(US|USA|U\.S\.?A?\.?)$/i.test(lastPart)) return 'USA';
+    if (/^(UK|United Kingdom|England|Scotland|Wales)$/i.test(lastPart)) return 'UK';
+  }
+
+  // If only one part (just a city), look up in city map
+  if (parts.length === 1) {
+    const mapped = CITY_TO_COUNTRY[lastPart.toLowerCase()];
+    if (mapped) return mapped;
+  }
+
+  // Try matching last part against city map (e.g. "Colombo 02, Sri Lanka" → "Sri Lanka")
+  const mapped = CITY_TO_COUNTRY[lastPart.toLowerCase()];
+  if (mapped) return mapped;
+
+  return lastPart;
+}


### PR DESCRIPTION
## Summary

Added interactive country polygon boundaries to the globe and connected them with the leaderboard filtering system.

Users can now:
- Hover over countries to see the country name and developer count
- Click a country to zoom into it
- Automatically filter the leaderboard by the selected country
- Click the globe background/ocean to reset the country filter

## Changes

### src/components/Globe.jsx

- Added Natural Earth 110m country boundary GeoJSON support using `polygonsData`
- Added country hover highlighting with tooltip information
- Added country click handling to:
  - calculate country centroid
  - fly/zoom the globe to the selected country
  - send the selected country back to the application
- Added selected country highlighting
- Added background/ocean click handling to clear country selection
- Optimized globe rendering by keeping point/ring/label accessors stable during polygon hover updates

### src/components/Leaderboard.jsx

- Moved country parsing logic into shared helpers
- Added:
  - `normalizeCountry()` for country name aliases
  - `countryKey()` for country matching
  - exported `extractCountry()`
- Connected leaderboard country filtering with globe-selected countries
- Improved matching between GeoJSON country names and developer location data

### src/App.jsx

- Added selected country state management
- Connected globe country selection with leaderboard filtering
- Added country reset handling when returning home

## Testing

- Build completed successfully.
- Geometry calculations were checked for all country features.
- Local browser testing was limited because Cosmos DB credentials were not available in the local environment.

## Notes

- The implementation uses the low-resolution Natural Earth dataset for performance.
- Some city-states (for example Singapore) may not have clickable polygons in the low-resolution dataset, but developers still appear through leaderboard filtering.