### PR TITLE
feat: add consent-gated MCP agent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ The timer invokes the collector every minute, matching GitHub's advertised polli
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and areas where help is needed.
 
+## 🤖 MCP Server
+
+DevGlobe includes a stdio MCP server for public developer discovery and consent-gated agent introductions. It exposes developer search, public profile lookup, introduction requests, and request status polling.
+
+```bash
+npm run mcp
+```
+
+See [docs/mcp-server.md](docs/mcp-server.md) for credential provisioning, Cosmos DB setup, client configuration, and the consent lifecycle.
+
 ## 📄 License
 
 MIT — see [LICENSE](LICENSE) for details.

--- a/app/api/agent/introductions/route.js
+++ b/app/api/agent/introductions/route.js
@@ -1,0 +1,143 @@
+import { NextResponse } from 'next/server';
+import {
+  AgentRequestValidationError,
+  authenticateAgent,
+  createIntroductionDocument,
+  normalizeIntroductionRequest,
+  parseAgentKeys,
+} from '../../../../lib/agent-introductions.js';
+import { getPublicAiProfile } from '../../../../lib/ai-profile.js';
+import { getCosmosContainer } from '../../../../lib/cosmos.js';
+
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+function getRateLimit() {
+  const configured = Number.parseInt(process.env.DEVGLOBE_AGENT_RATE_LIMIT || '10', 10);
+  return Number.isFinite(configured) && configured > 0 ? Math.min(configured, 100) : 10;
+}
+
+function authenticateRequest(request) {
+  const configuredKeys = parseAgentKeys(process.env.DEVGLOBE_AGENT_KEYS);
+  return authenticateAgent(request.headers.get('authorization'), configuredKeys);
+}
+
+export async function GET(request) {
+  let agent;
+  try {
+    agent = authenticateRequest(request);
+  } catch (error) {
+    console.error('Agent key configuration error:', error.message);
+    return NextResponse.json({ error: 'Agent authentication is not configured' }, { status: 503 });
+  }
+  if (!agent) return NextResponse.json({ error: 'Invalid or missing agent credentials' }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  const developerLogin = searchParams.get('developerLogin');
+  if (!/^[a-f\d-]{36}$/i.test(id || '') || !developerLogin) {
+    return NextResponse.json({ error: 'Request id and developer login are required' }, { status: 400 });
+  }
+
+  const introductions = getCosmosContainer(process.env.COSMOS_INTRODUCTIONS_CONTAINER || 'agent-introductions');
+  if (!introductions) return NextResponse.json({ error: 'Introduction requests are not configured' }, { status: 503 });
+
+  try {
+    const { resource } = await introductions.item(id, developerLogin).read();
+    if (!resource || resource.agentId !== agent.id) {
+      return NextResponse.json({ error: 'Introduction request not found' }, { status: 404 });
+    }
+    const expired = resource.status === 'pending' && resource.expiresAt <= new Date().toISOString();
+    const status = expired ? 'expired' : resource.status;
+    return NextResponse.json({
+      request: {
+        id: resource.id,
+        developerLogin: resource.developerLogin,
+        status,
+        createdAt: resource.createdAt,
+        expiresAt: resource.expiresAt,
+        ...(status === 'accepted' && {
+          contact: {
+            type: 'github',
+            url: `https://github.com/${encodeURIComponent(resource.developerLogin)}`,
+          },
+        }),
+      },
+    }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    if (error.code === 404) return NextResponse.json({ error: 'Introduction request not found' }, { status: 404 });
+    console.error('Agent introduction status error:', error.message);
+    return NextResponse.json({ error: 'Failed to load introduction request' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  let agent;
+  try {
+    agent = authenticateRequest(request);
+  } catch (error) {
+    console.error('Agent key configuration error:', error.message);
+    return NextResponse.json({ error: 'Agent authentication is not configured' }, { status: 503 });
+  }
+
+  if (!agent) {
+    return NextResponse.json({ error: 'Invalid or missing agent credentials' }, { status: 401 });
+  }
+
+  let input;
+  try {
+    input = normalizeIntroductionRequest(await request.json());
+  } catch (error) {
+    const message = error instanceof AgentRequestValidationError ? error.message : 'Invalid request body';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const developers = getCosmosContainer();
+  const introductions = getCosmosContainer(process.env.COSMOS_INTRODUCTIONS_CONTAINER || 'agent-introductions');
+  if (!developers || !introductions) {
+    return NextResponse.json({ error: 'Introduction requests are not configured' }, { status: 503 });
+  }
+
+  try {
+    const { resources: matches } = await developers.items.query({
+      query: `SELECT TOP 1 c.login, c.aiProfile
+        FROM c
+        WHERE c.login = @login
+          AND c.claimed = true
+          AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')`,
+      parameters: [{ name: '@login', value: input.developerLogin }],
+    }).fetchAll();
+    const publicAiProfile = getPublicAiProfile(matches[0]?.aiProfile);
+    if (!publicAiProfile?.acceptsAgentRequests || publicAiProfile.contactPolicy !== 'verified-agents') {
+      return NextResponse.json({ error: 'Developer is not accepting verified agent requests' }, { status: 409 });
+    }
+
+    const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS).toISOString();
+    const { resources: counts } = await introductions.items.query({
+      query: 'SELECT VALUE COUNT(1) FROM c WHERE c.agentId = @agentId AND c.createdAt >= @since',
+      parameters: [
+        { name: '@agentId', value: agent.id },
+        { name: '@since', value: since },
+      ],
+    }).fetchAll();
+    if ((counts[0] || 0) >= getRateLimit()) {
+      return NextResponse.json({ error: 'Agent introduction rate limit exceeded' }, { status: 429 });
+    }
+
+    const document = createIntroductionDocument(input, agent);
+    await introductions.items.create(document, { disableAutomaticIdGeneration: true });
+
+    return NextResponse.json({
+      request: {
+        id: document.id,
+        developerLogin: document.developerLogin,
+        status: document.status,
+        createdAt: document.createdAt,
+        expiresAt: document.expiresAt,
+      },
+      message: 'The developer must approve this introduction before any further contact.',
+    }, { status: 201 });
+  } catch (error) {
+    console.error('Agent introduction error:', error.message);
+    return NextResponse.json({ error: 'Failed to create introduction request' }, { status: 500 });
+  }
+}

--- a/app/api/introductions/route.js
+++ b/app/api/introductions/route.js
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../lib/auth.js';
+import { getCosmosContainer } from '../../../lib/cosmos.js';
+import {
+  AgentRequestValidationError,
+  normalizeIntroductionDecision,
+} from '../../../lib/agent-introductions.js';
+
+function getContainer() {
+  return getCosmosContainer(process.env.COSMOS_INTRODUCTIONS_CONTAINER || 'agent-introductions');
+}
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+  const container = getContainer();
+  if (!container) return NextResponse.json({ requests: [] }, { headers: { 'Cache-Control': 'no-store' } });
+
+  try {
+    const { resources } = await container.items.query({
+      query: `SELECT c.id, c.developerLogin, c.requesterAgent, c.reason, c.project,
+        c.status, c.createdAt, c.expiresAt, c.respondedAt
+        FROM c
+        WHERE c.developerLogin = @login
+        ORDER BY c.createdAt DESC`,
+      parameters: [{ name: '@login', value: session.login }],
+    }, { partitionKey: session.login }).fetchAll();
+
+    return NextResponse.json({ requests: resources }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('Introduction inbox error:', error.message);
+    return NextResponse.json({ error: 'Failed to load introduction requests' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+  let decision;
+  try {
+    decision = normalizeIntroductionDecision(await request.json());
+  } catch (error) {
+    const message = error instanceof AgentRequestValidationError ? error.message : 'Invalid request body';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const container = getContainer();
+  if (!container) return NextResponse.json({ error: 'Introduction requests are not configured' }, { status: 503 });
+
+  try {
+    const item = container.item(decision.id, session.login);
+    const { resource } = await item.read();
+    if (!resource || resource.developerLogin !== session.login) {
+      return NextResponse.json({ error: 'Introduction request not found' }, { status: 404 });
+    }
+    if (resource.status !== 'pending' || resource.expiresAt <= new Date().toISOString()) {
+      return NextResponse.json({ error: 'Introduction request can no longer be changed' }, { status: 409 });
+    }
+
+    const updated = {
+      ...resource,
+      status: decision.status,
+      respondedAt: new Date().toISOString(),
+    };
+    await item.replace(updated);
+
+    return NextResponse.json({
+      request: {
+        id: updated.id,
+        status: updated.status,
+        respondedAt: updated.respondedAt,
+      },
+    });
+  } catch (error) {
+    if (error.code === 404) return NextResponse.json({ error: 'Introduction request not found' }, { status: 404 });
+    console.error('Introduction decision error:', error.message);
+    return NextResponse.json({ error: 'Failed to update introduction request' }, { status: 500 });
+  }
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -9,6 +9,7 @@ import ComparePanel from '../components/ComparePanel.jsx';
 import LoadingOverlay from '../components/LoadingOverlay.jsx';
 import AddMeModal from '../components/AddMeModal.jsx';
 import AiProfileModal from '../components/AiProfileModal.jsx';
+import IntroductionInboxModal from '../components/IntroductionInboxModal.jsx';
 import QuickTour from '../components/QuickTour.jsx';
 import { scoreAll } from '../lib/scoring.js';
 import { addDeveloperRanks } from '../lib/ranking.js';
@@ -36,6 +37,7 @@ export default function Home() {
   const [cardContext, setCardContext] = useState(null);
   const [showAddMe, setShowAddMe] = useState(false);
   const [showAiProfile, setShowAiProfile] = useState(false);
+  const [showIntroductions, setShowIntroductions] = useState(false);
   const [tourStep, setTourStep] = useState(null);
   const [tourMatch, setTourMatch] = useState(null);
   const globeRef = useRef(null);
@@ -92,6 +94,7 @@ export default function Home() {
     setUser(null);
     setClaimStatus('unclaimed');
     setShowAiProfile(false);
+    setShowIntroductions(false);
   }, []);
 
   const handleAiProfileSaved = useCallback((aiProfile) => {
@@ -358,6 +361,7 @@ export default function Home() {
         onLogout={handleLogout}
         onClaim={handleClaim}
         onEditAiProfile={() => setShowAiProfile(true)}
+        onOpenIntroductions={() => setShowIntroductions(true)}
         claimStatus={claimStatus}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={handleToggleSidebar}
@@ -443,6 +447,7 @@ export default function Home() {
             onSaved={handleAiProfileSaved}
           />
         )}
+        {showIntroductions && <IntroductionInboxModal onClose={() => setShowIntroductions(false)} />}
       </main>
     </div>
   );

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import UserMenu from './UserMenu.jsx';
 
-export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
+export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
   return (
     <header className="header">
       <div className="header__brand" onClick={onHome} style={{ cursor: 'pointer' }}>
@@ -91,7 +91,7 @@ export default function Header({ onHome, theme, onToggleTheme, user, onLogout, o
           </svg>
           <span className="btn__label">Sponsor</span>
         </a>
-        <UserMenu user={user} onLogout={onLogout} onClaim={onClaim} onEditAiProfile={onEditAiProfile} claimStatus={claimStatus} />
+        <UserMenu user={user} onLogout={onLogout} onClaim={onClaim} onEditAiProfile={onEditAiProfile} onOpenIntroductions={onOpenIntroductions} claimStatus={claimStatus} />
       </div>
     </header>
   );

--- a/components/IntroductionInboxModal.jsx
+++ b/components/IntroductionInboxModal.jsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function IntroductionInboxModal({ onClose }) {
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [updatingId, setUpdatingId] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/introductions', { cache: 'no-store' })
+      .then(async response => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Failed to load agent requests');
+        if (!cancelled) setRequests(data.requests);
+      })
+      .catch(loadError => { if (!cancelled) setError(loadError.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const decide = async (id, status) => {
+    setUpdatingId(id);
+    setError('');
+    try {
+      const response = await fetch('/api/introductions', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, status }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Failed to update request');
+      setRequests(current => current.map(item => item.id === id
+        ? { ...item, status: data.request.status, respondedAt: data.request.respondedAt }
+        : item));
+    } catch (updateError) {
+      setError(updateError.message);
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const displayStatus = request => request.status === 'pending' && request.expiresAt <= new Date().toISOString()
+    ? 'expired'
+    : request.status;
+
+  return (
+    <div className="introduction-inbox__backdrop" role="presentation" onMouseDown={event => event.target === event.currentTarget && onClose()}>
+      <section className="introduction-inbox" role="dialog" aria-modal="true" aria-labelledby="introduction-inbox-title">
+        <button type="button" className="introduction-inbox__close" onClick={onClose} aria-label="Close agent requests">&times;</button>
+        <span className="introduction-inbox__eyebrow">CONSENT INBOX</span>
+        <h2 id="introduction-inbox-title">Agent requests</h2>
+        <p className="introduction-inbox__intro">Review verified-agent introduction requests. Acceptance shares only your public GitHub profile.</p>
+
+        {loading && <p className="introduction-inbox__empty">Loading requests...</p>}
+        {!loading && requests.length === 0 && !error && <p className="introduction-inbox__empty">No agent requests yet.</p>}
+        {error && <p className="introduction-inbox__error">{error}</p>}
+
+        <div className="introduction-inbox__list">
+          {requests.map(request => {
+            const status = displayStatus(request);
+            return (
+              <article className="introduction-request" key={request.id}>
+                <header>
+                  <div>
+                    <strong>{request.requesterAgent.name}</strong>
+                    <span>{request.requesterAgent.owner}</span>
+                  </div>
+                  <small className={`introduction-request__status introduction-request__status--${status}`}>{status}</small>
+                </header>
+                <dl>
+                  <div><dt>Project</dt><dd>{request.project}</dd></div>
+                  <div><dt>Reason</dt><dd>{request.reason}</dd></div>
+                </dl>
+                {status === 'pending' && (
+                  <div className="introduction-request__actions">
+                    <button type="button" disabled={updatingId === request.id} onClick={() => decide(request.id, 'declined')}>Decline</button>
+                    <button type="button" className="introduction-request__accept" disabled={updatingId === request.id} onClick={() => decide(request.id, 'accepted')}>Accept</button>
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/UserMenu.jsx
+++ b/components/UserMenu.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 
-export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, claimStatus }) {
+export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, claimStatus }) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef(null);
 
@@ -80,6 +80,12 @@ export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, cla
                   <path d="M15 13v2" />
                 </svg>
                 AI collaboration settings
+              </button>
+              <button className="user-menu__item" onClick={() => { onOpenIntroductions(); setOpen(false); }}>
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M21 15a4 4 0 01-4 4H8l-5 3V7a4 4 0 014-4h10a4 4 0 014 4z" />
+                </svg>
+                Agent requests
               </button>
             </>
           )}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,67 @@
+# DevGlobe MCP Server
+
+DevGlobe provides a stdio Model Context Protocol server for developer discovery and consent-gated introductions.
+
+## Tools
+
+- `search_developers` searches public profiles and can require agent availability.
+- `get_developer_profile` returns one public profile.
+- `request_introduction` creates a pending request for an opted-in developer.
+- `get_introduction_status` lets the requesting agent poll its request. After acceptance it returns only the developer's public GitHub URL.
+
+Private AI profile settings and private contact details are never returned.
+
+## Application Setup
+
+Create the introduction request container:
+
+```bash
+npm run setup-introductions-container
+```
+
+Issue a credential for an agent owner:
+
+```bash
+npm run create-agent-key -- --id=engineering-agent --name="Engineering Agent" --owner="Example Org"
+```
+
+Give the generated token to the agent owner once. Add the generated object to the server environment as a JSON array:
+
+```env
+DEVGLOBE_AGENT_KEYS=[{"id":"engineering-agent","name":"Engineering Agent","owner":"Example Org","tokenHash":"sha256-hash"}]
+COSMOS_INTRODUCTIONS_CONTAINER=agent-introductions
+DEVGLOBE_AGENT_RATE_LIMIT=10
+```
+
+Restart the application after changing credentials. Never store raw agent tokens in the application environment or repository.
+
+## MCP Client Setup
+
+Install dependencies in this repository, then configure a stdio MCP server. A VS Code `mcp.json` entry can use:
+
+```json
+{
+  "servers": {
+    "devglobe": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["C:/absolute/path/to/devglobe/scripts/devglobe-mcp-server.js"],
+      "env": {
+        "DEVGLOBE_API_URL": "https://www.devglobe.dev",
+        "DEVGLOBE_AGENT_TOKEN": "issued-token"
+      }
+    }
+  }
+}
+```
+
+The token is required only for introduction tools. Public search and profile lookup work without one.
+
+## Consent Lifecycle
+
+1. An authenticated agent requests an introduction to a public, opted-in profile.
+2. DevGlobe rate-limits the agent and stores a pending request with a 14-day response window.
+3. The developer reviews the request from **Agent requests** in their user menu.
+4. The developer accepts or declines. Decisions cannot be changed.
+5. The agent polls `get_introduction_status`.
+6. Acceptance returns the developer's already-public GitHub URL. Declined and expired requests disclose nothing further.

--- a/docs/prd/ai-collaboration-profiles.md
+++ b/docs/prd/ai-collaboration-profiles.md
@@ -1,6 +1,6 @@
 # PRD: AI Collaboration Profiles
 
-**Status:** MVP implementation  
+**Status:** MCP connection phase implemented
 **Issue:** [#135](https://github.com/sajeetharan/devglobe/issues/135)  
 **Owner:** DevGlobe  
 **Last updated:** 2026-08-13
@@ -101,15 +101,16 @@ Usage levels are `experimenting`, `regular`, and `daily`.
 4. Saving updates the claimed Cosmos DB developer document.
 5. Public settings appear in the developer detail panel.
 
-## Future Connection Flow
+## MCP Connection Flow
 
-An authenticated MCP server will eventually expose:
+The authenticated MCP server exposes:
 
 - `search_developers(skills, location, language, availability)`
 - `get_developer_profile(login)`
 - `request_introduction(login, reason, project)`
+- `get_introduction_status(id, developerLogin)`
 
-Introduction requests will be stored separately, rate-limited, audited, and shown to the developer for explicit acceptance. No email address or private contact method will be returned to an agent.
+Introduction requests are stored separately, rate-limited, audited, and shown to the developer for explicit acceptance. Accepted requests return only the developer's public GitHub URL. No email address or private contact method is stored or returned to an agent.
 
 ## Success Metrics
 
@@ -126,10 +127,14 @@ Introduction requests will be stored separately, rate-limited, audited, and show
 - Public developer responses include only public AI profiles.
 - The detail panel renders self-declared tools and opt-in status.
 - The application test suite and production build pass.
+- MCP discovery tools return only public developer data.
+- Only issued agent credentials can create or inspect introduction requests.
+- Developers can accept or decline requests addressed to their GitHub identity.
+- Accepted requests reveal only the developer's public GitHub URL.
 
 ## Rollout
 
 1. Ship the profile schema, authenticated editor, and public display.
 2. Measure adoption and refine the tool catalog.
-3. Add verified agent identities and introduction request storage.
+3. Add issued agent identities and introduction request storage.
 4. Publish read-only discovery and consent-gated introductions through MCP.

--- a/lib/agent-introductions.js
+++ b/lib/agent-introductions.js
@@ -1,0 +1,116 @@
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+
+const GITHUB_LOGIN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+
+export class AgentRequestValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AgentRequestValidationError';
+  }
+}
+
+export function hashAgentToken(token) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function parseAgentKeys(value) {
+  if (!value) return [];
+
+  let keys;
+  try {
+    keys = JSON.parse(value);
+  } catch {
+    throw new Error('DEVGLOBE_AGENT_KEYS must be valid JSON');
+  }
+
+  if (!Array.isArray(keys)) {
+    throw new Error('DEVGLOBE_AGENT_KEYS must be a JSON array');
+  }
+
+  return keys.map(key => {
+    if (!key || typeof key !== 'object' || !key.id || !key.name || !key.owner) {
+      throw new Error('Each agent key requires id, name, owner, and tokenHash');
+    }
+    if (!/^[a-f\d]{64}$/i.test(key.tokenHash || '')) {
+      throw new Error(`Agent key ${key.id} requires a SHA-256 tokenHash`);
+    }
+    return {
+      id: String(key.id).slice(0, 100),
+      name: String(key.name).slice(0, 120),
+      owner: String(key.owner).slice(0, 200),
+      tokenHash: key.tokenHash.toLowerCase(),
+    };
+  });
+}
+
+export function authenticateAgent(authorization, configuredKeys) {
+  const match = /^Bearer ([^\s]+)$/.exec(authorization || '');
+  if (!match) return null;
+
+  const candidate = Buffer.from(hashAgentToken(match[1]), 'hex');
+  for (const key of configuredKeys) {
+    const expected = Buffer.from(key.tokenHash, 'hex');
+    if (timingSafeEqual(candidate, expected)) {
+      const { tokenHash, ...identity } = key;
+      return identity;
+    }
+  }
+  return null;
+}
+
+export function normalizeIntroductionRequest(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new AgentRequestValidationError('Request body must be an object');
+  }
+
+  const developerLogin = String(input.developerLogin || '').trim();
+  const reason = String(input.reason || '').trim();
+  const project = String(input.project || '').trim();
+
+  if (!GITHUB_LOGIN.test(developerLogin)) {
+    throw new AgentRequestValidationError('A valid developer login is required');
+  }
+  if (reason.length < 20 || reason.length > 1000) {
+    throw new AgentRequestValidationError('Reason must be between 20 and 1000 characters');
+  }
+  if (project.length < 2 || project.length > 200) {
+    throw new AgentRequestValidationError('Project must be between 2 and 200 characters');
+  }
+
+  return { developerLogin, reason, project };
+}
+
+export function normalizeIntroductionDecision(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new AgentRequestValidationError('Decision must be an object');
+  }
+  const id = String(input.id || '').trim();
+  if (!/^[a-f\d-]{36}$/i.test(id)) {
+    throw new AgentRequestValidationError('A valid request id is required');
+  }
+  if (input.status !== 'accepted' && input.status !== 'declined') {
+    throw new AgentRequestValidationError('Status must be accepted or declined');
+  }
+  return { id, status: input.status };
+}
+
+export function createIntroductionDocument(input, agent, now = new Date()) {
+  const request = normalizeIntroductionRequest(input);
+  const expiresAt = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
+
+  return {
+    id: randomUUID(),
+    developerLogin: request.developerLogin,
+    agentId: agent.id,
+    requesterAgent: {
+      id: agent.id,
+      name: agent.name,
+      owner: agent.owner,
+    },
+    reason: request.reason,
+    project: request.project,
+    status: 'pending',
+    createdAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  };
+}

--- a/lib/devglobe-mcp-client.js
+++ b/lib/devglobe-mcp-client.js
@@ -1,0 +1,74 @@
+function normalizeBaseUrl(value) {
+  const url = new URL(value || 'https://www.devglobe.dev');
+  if (url.protocol !== 'https:' && url.hostname !== 'localhost') {
+    throw new Error('DEVGLOBE_API_URL must use HTTPS');
+  }
+  return url.origin;
+}
+
+async function readJson(response) {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(data.error || `DevGlobe API returned ${response.status}`);
+  return data;
+}
+
+export function createDevGlobeMcpClient({
+  baseUrl = process.env.DEVGLOBE_API_URL,
+  agentToken = process.env.DEVGLOBE_AGENT_TOKEN,
+  fetchImpl = fetch,
+} = {}) {
+  const origin = normalizeBaseUrl(baseUrl);
+
+  return {
+    async searchDevelopers({ query, location, language, availableForAgents = false, limit = 10 }) {
+      const searchText = [query, location, language].filter(Boolean).join(' ');
+      const searchUrl = new URL('/api/search', origin);
+      searchUrl.searchParams.set('q', searchText);
+      searchUrl.searchParams.set('mode', 'text');
+      searchUrl.searchParams.set('top', String(Math.min(limit, 20)));
+      const search = await readJson(await fetchImpl(searchUrl));
+
+      const developers = await Promise.all(search.results.map(async result => {
+        const profileUrl = new URL('/api/developer', origin);
+        profileUrl.searchParams.set('id', result.login || result.id);
+        return readJson(await fetchImpl(profileUrl));
+      }));
+
+      return developers.filter(developer => {
+        const matchesLocation = !location || developer.location?.toLowerCase().includes(location.toLowerCase());
+        const matchesLanguage = !language || developer.topLanguage?.toLowerCase() === language.toLowerCase();
+        const matchesAvailability = !availableForAgents || developer.aiProfile?.acceptsAgentRequests === true;
+        return matchesLocation && matchesLanguage && matchesAvailability;
+      }).slice(0, limit);
+    },
+
+    async getDeveloperProfile(login) {
+      const url = new URL('/api/developer', origin);
+      url.searchParams.set('id', login);
+      return readJson(await fetchImpl(url));
+    },
+
+    async requestIntroduction(input) {
+      if (!agentToken) throw new Error('DEVGLOBE_AGENT_TOKEN is required for introduction requests');
+      const url = new URL('/api/agent/introductions', origin);
+      return readJson(await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${agentToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(input),
+      }));
+    },
+
+    async getIntroductionStatus({ id, developerLogin }) {
+      if (!agentToken) throw new Error('DEVGLOBE_AGENT_TOKEN is required for introduction requests');
+      const url = new URL('/api/agent/introductions', origin);
+      url.searchParams.set('id', id);
+      url.searchParams.set('developerLogin', developerLogin);
+      return readJson(await fetchImpl(url, {
+        headers: { Authorization: `Bearer ${agentToken}` },
+      }));
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@azure/cosmos": "^4.10.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/og": "^0.11.1",
         "d3": "^7.9.0",
@@ -19,7 +20,8 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-globe.gl": "^2.38.0",
-        "simple-icons": "^16.28.0"
+        "simple-icons": "^16.28.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "eslint": "^9.0.0",
@@ -403,6 +405,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha1-wYI+G5rda90UgH+7/sObi4BhSyU=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -936,6 +950,68 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha1-36ikg0fsLSwNR5F9fcV/dU439f8=",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1482,9 +1558,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1961,6 +2037,19 @@
         "sharp": "^0.34.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/accessor-fn": {
       "version": "1.5.3",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accessor-fn/-/accessor-fn-1.5.3.tgz",
@@ -2018,6 +2107,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha1-PV3HYryhdnnDwup+kK1rdTIwlXg=",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -2281,10 +2409,63 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2303,6 +2484,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -2328,7 +2518,6 @@
       "version": "1.0.2",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2342,7 +2531,6 @@
       "version": "1.0.4",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2452,11 +2640,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha1-89t4nHUtRVZMx+nh4LMXkNSjjhc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha1-/13Wm9leVHUDgg0pq6T4+vjf7JY=",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3094,6 +3338,15 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3133,7 +3386,6 @@
       "version": "1.0.1",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3150,6 +3402,12 @@
       "integrity": "sha1-dK7BlVWn4odzQpgmcp0uS/6xkCI=",
       "license": "ISC"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -3164,6 +3422,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/es-abstract": {
@@ -3258,7 +3525,6 @@
       "version": "1.0.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3268,7 +3534,6 @@
       "version": "1.3.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3306,7 +3571,6 @@
       "version": "1.1.2",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3791,11 +4055,102 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha1-EVdiLi9Td7tq7yEUNycougwVaYk=",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha1-ThmOuRzTM9Co3cwDZQKzYYol9Ek=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express/-/express-5.2.1.tgz",
+      "integrity": "sha1-jyHRW20yf5K0eU7PjLCKcvlWrAQ=",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha1-Gmx/tsX1qDiDwU8dGY/N/2AIfF0=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3840,6 +4195,22 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3904,6 +4275,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha1-osUXplWYUrzbBtH4vX9Rto+tgJk=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3986,6 +4378,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/frame-ticker": {
       "version": "1.0.3",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/frame-ticker/-/frame-ticker-1.0.3.tgz",
@@ -3995,11 +4396,19 @@
         "simplesignal": "^2.1.6"
       }
     },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4053,7 +4462,6 @@
       "version": "1.3.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4078,7 +4486,6 @@
       "version": "1.0.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4183,7 +4590,6 @@
       "version": "1.2.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4259,7 +4665,6 @@
       "version": "1.1.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4288,7 +4693,6 @@
       "version": "2.0.4",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4307,6 +4711,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha1-rBuhZQtP2cvlPhe+oFJfU8tlgT0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha1-NtL2W8kJyHkAGN02+02T2myq4Gs=",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4393,6 +4826,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4415,6 +4854,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha1-xZELxUG26uKHdl0eSEa+AwigXZM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4690,6 +5147,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha1-Qv+fhCBsGZHSbev1IN1cAQQt0vM=",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-regex/-/is-regex-1.2.1.tgz",
@@ -4846,7 +5309,6 @@
       "version": "2.0.0",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4892,9 +5354,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+      "version": "4.3.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
       "funding": [
         {
@@ -4927,6 +5389,12 @@
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha1-6Y7nsYmf9KGEU00fFnwojGa77/Q=",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5075,10 +5543,34 @@
       "version": "1.1.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha1-bwNUAN/jq51WB7x3VGzjDML5xrg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -5103,6 +5595,31 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -5135,9 +5652,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
+      "version": "3.3.17",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
       "funding": [
         {
           "type": "github",
@@ -5174,6 +5691,15 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "15.5.22",
@@ -5307,7 +5833,6 @@
       "version": "1.13.4",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5416,6 +5941,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/optionator/-/optionator-0.9.4.tgz",
@@ -5514,6 +6060,15 @@
         "hex-rgb": "^4.1.0"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
@@ -5528,7 +6083,6 @@
       "version": "3.1.1",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5540,6 +6094,16 @@
       "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha1-eVxCDE98pFxbiHNm9iLuDJhSzM0=",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5558,6 +6122,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha1-O0RGhlsXsXRems4gFqMfSN32Iw0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/point-in-polygon-hao": {
@@ -5670,6 +6243,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
@@ -5678,6 +6264,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5700,6 +6302,50 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha1-1/Gb6BK7YnIUcrRdO+IZ7wlXK0c=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -5804,6 +6450,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve/-/resolve-2.0.0-next.7.tgz",
@@ -5864,6 +6519,22 @@
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/robust-predicates/-/robust-predicates-3.0.3.tgz",
       "integrity": "sha1-EJkGGzNJ4sWr7GwqsKzUQNJNQGI=",
       "license": "Unlicense"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/router/-/router-2.2.0.tgz",
+      "integrity": "sha1-AZvmILcRyHZBFnzHm5kJDwCxRu8=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -6005,6 +6676,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/send/-/send-1.2.1.tgz",
+      "integrity": "sha1-nqt0O4dPNVD0CiaGe/KGrWDT8+0=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha1-fxhqSk5fW2Y616QpT/G/N88OmKk=",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -6053,6 +6769,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ=",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -6103,7 +6825,6 @@
       "version": "2.0.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6116,7 +6837,6 @@
       "version": "3.0.0",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6126,7 +6846,6 @@
       "version": "1.1.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6146,7 +6865,6 @@
       "version": "1.0.1",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6163,7 +6881,6 @@
       "version": "1.0.1",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6182,7 +6899,6 @@
       "version": "1.0.2",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6238,6 +6954,15 @@
       "integrity": "sha1-lOiDeq6sW00PYx0pcq3vKSS0Amk=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6629,6 +7354,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6672,6 +7406,37 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6796,6 +7561,15 @@
         "tiny-inflate": "^1.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -6844,6 +7618,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -6857,7 +7640,6 @@
       "version": "2.0.2",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6968,6 +7750,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6986,6 +7774,24 @@
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha1-0tG6BvDoHC62UMPlrYsLSt3h6EM=",
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha1-P6eZp7rdVUVBRy+2WEP9xGCy5ao=",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "test": "node --test tests/*.test.js",
     "start": "next start",
+    "mcp": "node scripts/devglobe-mcp-server.js",
     "lint": "next lint",
     "build-data": "node scripts/build-dataset.js",
     "fetch-github": "node scripts/fetch-github.js",
@@ -20,11 +21,14 @@
     "rescore-developers": "node scripts/rescore-developers.js",
     "populate-special-tags": "node scripts/populate-special-tags.js",
     "setup-activity-container": "node scripts/setup-activity-container.js",
+    "setup-introductions-container": "node scripts/setup-introductions-container.js",
+    "create-agent-key": "node scripts/create-agent-key.js",
     "review-nominations": "node scripts/review-nominations.js",
     "seed-emulator": "node scripts/seed-emulator.js"
   },
   "dependencies": {
     "@azure/cosmos": "^4.10.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/og": "^0.11.1",
     "d3": "^7.9.0",
@@ -35,7 +39,8 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-globe.gl": "^2.38.0",
-    "simple-icons": "^16.28.0"
+    "simple-icons": "^16.28.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "eslint": "^9.0.0",

--- a/scripts/create-agent-key.js
+++ b/scripts/create-agent-key.js
@@ -1,0 +1,25 @@
+import { randomBytes } from 'node:crypto';
+import { hashAgentToken } from '../lib/agent-introductions.js';
+
+const values = Object.fromEntries(process.argv.slice(2).map(argument => {
+  const [key, ...parts] = argument.replace(/^--/, '').split('=');
+  return [key, parts.join('=')];
+}));
+
+if (!values.id || !values.name || !values.owner) {
+  console.error('Usage: npm run create-agent-key -- --id=agent-id --name="Agent name" --owner="Owner"');
+  process.exit(1);
+}
+
+const token = randomBytes(32).toString('base64url');
+const key = {
+  id: values.id,
+  name: values.name,
+  owner: values.owner,
+  tokenHash: hashAgentToken(token),
+};
+
+console.log('Agent token (show once to the agent owner):');
+console.log(token);
+console.log('\nAdd this object to the DEVGLOBE_AGENT_KEYS JSON array:');
+console.log(JSON.stringify(key, null, 2));

--- a/scripts/devglobe-mcp-server.js
+++ b/scripts/devglobe-mcp-server.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { createDevGlobeMcpClient } from '../lib/devglobe-mcp-client.js';
+
+const client = createDevGlobeMcpClient();
+const server = new McpServer({ name: 'devglobe', version: '1.0.0' });
+
+function toolResult(value) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function toolError(error) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: error instanceof Error ? error.message : 'Unexpected DevGlobe error' }],
+  };
+}
+
+server.registerTool('search_developers', {
+  description: 'Search public DevGlobe developer profiles by expertise, location, language, and agent availability.',
+  inputSchema: {
+    query: z.string().min(1).max(200).describe('Skills, expertise, name, or other search intent'),
+    location: z.string().max(100).optional(),
+    language: z.string().max(50).optional(),
+    availableForAgents: z.boolean().default(false),
+    limit: z.number().int().min(1).max(20).default(10),
+  },
+}, async input => {
+  try {
+    return toolResult(await client.searchDevelopers(input));
+  } catch (error) {
+    return toolError(error);
+  }
+});
+
+server.registerTool('get_developer_profile', {
+  description: 'Get one public DevGlobe developer profile. Private AI collaboration settings are never returned.',
+  inputSchema: {
+    login: z.string().min(1).max(39).describe('GitHub login'),
+  },
+}, async ({ login }) => {
+  try {
+    return toolResult(await client.getDeveloperProfile(login));
+  } catch (error) {
+    return toolError(error);
+  }
+});
+
+server.registerTool('request_introduction', {
+  description: 'Request a consent-gated introduction to an opted-in developer. This creates a pending request and never returns private contact details.',
+  inputSchema: {
+    developerLogin: z.string().min(1).max(39),
+    reason: z.string().min(20).max(1000),
+    project: z.string().min(2).max(200),
+  },
+}, async input => {
+  try {
+    return toolResult(await client.requestIntroduction(input));
+  } catch (error) {
+    return toolError(error);
+  }
+});
+
+server.registerTool('get_introduction_status', {
+  description: 'Check an introduction request owned by this agent. An accepted request returns only the developer public GitHub contact route.',
+  inputSchema: {
+    id: z.string().uuid(),
+    developerLogin: z.string().min(1).max(39),
+  },
+}, async input => {
+  try {
+    return toolResult(await client.getIntroductionStatus(input));
+  } catch (error) {
+    return toolError(error);
+  }
+});
+
+await server.connect(new StdioServerTransport());
+console.error('DevGlobe MCP server running on stdio');

--- a/scripts/setup-introductions-container.js
+++ b/scripts/setup-introductions-container.js
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { CosmosClient } from '@azure/cosmos';
+
+const endpoint = process.env.COSMOS_ENDPOINT?.trim();
+const key = process.env.COSMOS_KEY?.trim();
+const databaseId = process.env.COSMOS_DATABASE || 'devglobe';
+const containerId = process.env.COSMOS_INTRODUCTIONS_CONTAINER || 'agent-introductions';
+
+if (!endpoint || !key) {
+  console.error('COSMOS_ENDPOINT and COSMOS_KEY are required.');
+  process.exit(1);
+}
+
+const client = new CosmosClient({ endpoint, key });
+const database = client.database(databaseId);
+const { resource, statusCode } = await database.containers.createIfNotExists({
+  id: containerId,
+  partitionKey: { paths: ['/developerLogin'], kind: 'Hash' },
+  defaultTtl: 30 * 24 * 60 * 60,
+  indexingPolicy: {
+    indexingMode: 'consistent',
+    automatic: true,
+    includedPaths: [{ path: '/*' }],
+    excludedPaths: [{ path: '/"_etag"/?' }],
+    compositeIndexes: [[
+      { path: '/developerLogin', order: 'ascending' },
+      { path: '/createdAt', order: 'descending' },
+    ]],
+  },
+});
+
+console.log(`${statusCode === 201 ? 'Created' : 'Verified'} ${databaseId}/${resource.id} with 30-day TTL.`);

--- a/styles/main.css
+++ b/styles/main.css
@@ -3123,6 +3123,188 @@ body {
   opacity: 0.65;
 }
 
+.introduction-inbox__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 520;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(4px);
+  animation: fadeIn 0.15s ease;
+}
+
+.introduction-inbox {
+  position: relative;
+  width: min(640px, 100%);
+  max-height: calc(100vh - 36px);
+  max-height: calc(100dvh - 36px);
+  overflow-y: auto;
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  box-shadow: var(--shadow-strong);
+}
+
+.introduction-inbox__close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.introduction-inbox__eyebrow {
+  color: #22d3ee;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.introduction-inbox h2 {
+  margin: 5px 40px 4px 0;
+  color: var(--text-primary);
+  font-size: 20px;
+}
+
+.introduction-inbox__intro {
+  margin: 0 40px 20px 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.introduction-inbox__empty,
+.introduction-inbox__error {
+  margin: 20px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.introduction-inbox__error {
+  color: #ef4444;
+}
+
+.introduction-inbox__list {
+  display: grid;
+  gap: 10px;
+}
+
+.introduction-request {
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--overlay-subtle);
+}
+
+.introduction-request header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.introduction-request header div {
+  display: grid;
+  gap: 2px;
+}
+
+.introduction-request header strong {
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.introduction-request header span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.introduction-request__status {
+  padding: 3px 7px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text-secondary);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.introduction-request__status--pending {
+  border-color: rgba(251, 191, 36, 0.45);
+  color: #fbbf24;
+}
+
+.introduction-request__status--accepted {
+  border-color: rgba(46, 164, 79, 0.45);
+  color: #2ea44f;
+}
+
+.introduction-request__status--declined,
+.introduction-request__status--expired {
+  color: var(--text-muted);
+}
+
+.introduction-request dl {
+  display: grid;
+  gap: 9px;
+  margin: 13px 0 0;
+}
+
+.introduction-request dl div {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.introduction-request dt {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.introduction-request dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.introduction-request__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.introduction-request__actions button {
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.introduction-request__actions .introduction-request__accept {
+  border-color: #0891b2;
+  background: #0891b2;
+  color: #fff;
+}
+
+.introduction-request__actions button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
 @media (max-width: 620px) {
   .ai-profile-modal {
     padding: 22px 16px;
@@ -3134,6 +3316,15 @@ body {
 
   .ai-collaboration__heading {
     flex-direction: column;
+  }
+
+  .introduction-inbox {
+    padding: 22px 16px;
+  }
+
+  .introduction-request dl div {
+    grid-template-columns: 1fr;
+    gap: 2px;
   }
 }
 

--- a/tests/mcp-agent.test.js
+++ b/tests/mcp-agent.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AgentRequestValidationError,
+  authenticateAgent,
+  createIntroductionDocument,
+  hashAgentToken,
+  normalizeIntroductionDecision,
+  normalizeIntroductionRequest,
+  parseAgentKeys,
+} from '../lib/agent-introductions.js';
+import { createDevGlobeMcpClient } from '../lib/devglobe-mcp-client.js';
+
+test('authenticates configured agents without exposing token hashes', () => {
+  const keys = parseAgentKeys(JSON.stringify([{
+    id: 'agent-1',
+    name: 'Build Agent',
+    owner: 'Example Org',
+    tokenHash: hashAgentToken('secret-token'),
+  }]));
+
+  assert.deepEqual(authenticateAgent('Bearer secret-token', keys), {
+    id: 'agent-1',
+    name: 'Build Agent',
+    owner: 'Example Org',
+  });
+  assert.equal(authenticateAgent('Bearer wrong-token', keys), null);
+});
+
+test('validates and creates expiring pending introduction requests', () => {
+  const input = normalizeIntroductionRequest({
+    developerLogin: 'octocat',
+    reason: 'We need help maintaining our React component library.',
+    project: 'UI Platform',
+  });
+  const document = createIntroductionDocument(input, {
+    id: 'agent-1', name: 'Build Agent', owner: 'Example Org',
+  }, new Date('2026-08-13T12:00:00.000Z'));
+
+  assert.equal(document.status, 'pending');
+  assert.equal(document.developerLogin, 'octocat');
+  assert.equal(document.expiresAt, '2026-08-27T12:00:00.000Z');
+  assert.equal('tokenHash' in document.requesterAgent, false);
+});
+
+test('rejects invalid introduction content', () => {
+  assert.throws(() => normalizeIntroductionRequest({
+    developerLogin: 'invalid login', reason: 'too short', project: 'x',
+  }), AgentRequestValidationError);
+});
+
+test('accepts only terminal developer decisions with UUID request ids', () => {
+  assert.deepEqual(normalizeIntroductionDecision({
+    id: 'e6fa6dc6-64df-48c4-8597-c70bfe089bec',
+    status: 'accepted',
+  }), {
+    id: 'e6fa6dc6-64df-48c4-8597-c70bfe089bec',
+    status: 'accepted',
+  });
+  assert.throws(() => normalizeIntroductionDecision({ id: 'bad', status: 'pending' }), AgentRequestValidationError);
+});
+
+test('MCP client filters hydrated public profiles by agent availability', async () => {
+  const responses = new Map([
+    ['/api/search', { results: [{ login: 'open-dev' }, { login: 'closed-dev' }] }],
+    ['/api/developer?id=open-dev', { login: 'open-dev', aiProfile: { acceptsAgentRequests: true } }],
+    ['/api/developer?id=closed-dev', { login: 'closed-dev' }],
+  ]);
+  const fetchImpl = async url => {
+    const parsed = new URL(url);
+    const key = parsed.pathname === '/api/search' ? parsed.pathname : `${parsed.pathname}?${parsed.searchParams}`;
+    return new Response(JSON.stringify(responses.get(key)), { status: 200 });
+  };
+  const client = createDevGlobeMcpClient({ baseUrl: 'http://localhost:3000', fetchImpl });
+
+  const results = await client.searchDevelopers({ query: 'React', availableForAgents: true, limit: 10 });
+  assert.deepEqual(results.map(result => result.login), ['open-dev']);
+});
+
+test('MCP client requires an issued token for introductions', async () => {
+  const client = createDevGlobeMcpClient({ baseUrl: 'https://devglobe.dev', fetchImpl: () => {} });
+  await assert.rejects(() => client.requestIntroduction({}), /DEVGLOBE_AGENT_TOKEN/);
+});
+
+test('MCP client authenticates introduction status requests', async () => {
+  let receivedAuthorization;
+  const client = createDevGlobeMcpClient({
+    baseUrl: 'https://devglobe.dev',
+    agentToken: 'issued-token',
+    fetchImpl: async (url, options) => {
+      receivedAuthorization = options.headers.Authorization;
+      return new Response(JSON.stringify({ request: { status: 'pending' } }), { status: 200 });
+    },
+  });
+
+  const result = await client.getIntroductionStatus({
+    id: 'e6fa6dc6-64df-48c4-8597-c70bfe089bec',
+    developerLogin: 'octocat',
+  });
+  assert.equal(receivedAuthorization, 'Bearer issued-token');
+  assert.equal(result.request.status, 'pending');
+});


### PR DESCRIPTION
## Summary
- add a stdio DevGlobe MCP server with developer search, public profile lookup, introduction requests, and status polling
- authenticate issued agent tokens by SHA-256 hash, rate-limit requests, and store expiring requests in a dedicated Cosmos DB container
- add a claimed-developer inbox for accepting or declining agent introductions
- reveal only the developer's existing public GitHub URL after explicit acceptance
- document MCP client configuration, credential issuance, deployment, and consent lifecycle

## Security and consent
- private AI profile settings and private contact details are never returned
- only public, claimed, opted-in developer profiles can receive requests
- agents can inspect only requests created with their issued identity
- developer decisions are terminal and pending requests expire after 14 days

## Deployment
1. Run `npm run setup-introductions-container`.
2. Issue credentials with `npm run create-agent-key -- --id=... --name=... --owner=...`.
3. Configure `DEVGLOBE_AGENT_KEYS`, `COSMOS_INTRODUCTIONS_CONTAINER`, and optionally `DEVGLOBE_AGENT_RATE_LIMIT`.

## Validation
- `npm test` (15 tests passing)
- `npm run build`
- MCP SDK stdio handshake and tool discovery
- desktop/mobile developer inbox smoke test

Fixes #135