### PR TITLE
feat: add live platform activity and enrich share cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ app/promo/
 public/promo/
 *.log
 dist/
+dashboards/
+docs/adx-growth-dashboard.md
+scripts/build-devglobe-growth-dashboard.cjs

--- a/app/api/activities/live/route.js
+++ b/app/api/activities/live/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { decodeActivityCursor, encodeActivityCursor, listActivities } from '../../../../lib/activity-store.js';
+import { createFallbackActivities } from '../../../../lib/platform-activity.js';
 
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
@@ -16,9 +17,14 @@ export async function GET(request) {
 
   try {
     const result = await listActivities({ limit, cursor, after });
+    const activities = !cursor && !after && result.activities.length === 0
+      ? createFallbackActivities().slice(0, limit)
+      : result.activities;
     return NextResponse.json({
       ...result,
-      afterCursor: encodeActivityCursor(result.activities[0]),
+      activities,
+      nextCursor: result.activities.length === 0 ? null : result.nextCursor,
+      afterCursor: encodeActivityCursor(activities[0]),
       sourceUpdatedAt: result.activities[0]?.ingestedAt || null,
       bestEffort: true,
     }, {

--- a/app/api/activities/platform/route.js
+++ b/app/api/activities/platform/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../../lib/auth.js';
+import { saveActivities } from '../../../../lib/activity-store.js';
+import { createPlatformActivity } from '../../../../lib/platform-activity.js';
+
+const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    if (body.type !== 'generated_card' || !LOGIN_PATTERN.test(body.targetLogin || '')) {
+      return NextResponse.json({ error: 'Invalid platform activity' }, { status: 400 });
+    }
+
+    const session = await getSession();
+    const activity = createPlatformActivity({
+      type: body.type,
+      login: session?.login || body.targetLogin,
+      avatarUrl: session?.avatarUrl,
+      targetLogin: body.targetLogin,
+    });
+    await saveActivities([activity]);
+    return NextResponse.json({ activity }, { status: 201 });
+  } catch (error) {
+    console.error('Platform activity write failed:', error.message);
+    return NextResponse.json({ error: 'Unable to record platform activity' }, { status: 500 });
+  }
+}

--- a/app/api/auth/callback/route.js
+++ b/app/api/auth/callback/route.js
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { headers } from 'next/headers';
 import { createSessionToken, buildSessionCookie } from '../../../../lib/auth.js';
+import { saveActivities } from '../../../../lib/activity-store.js';
+import { createPlatformActivity } from '../../../../lib/platform-activity.js';
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
@@ -73,6 +75,15 @@ export async function GET(request) {
 
     const response = NextResponse.redirect(baseUrl);
     response.cookies.set(cookie);
+    try {
+      await saveActivities([createPlatformActivity({
+        type: 'logged_in',
+        login: session.login,
+        avatarUrl: session.avatarUrl,
+      })]);
+    } catch (activityError) {
+      console.error('Login activity write failed:', activityError.message);
+    }
     return response;
   } catch (err) {
     console.error('OAuth callback error:', err);

--- a/app/api/card/route.jsx
+++ b/app/api/card/route.jsx
@@ -6,6 +6,7 @@ import { scoreAll } from '../../../lib/scoring.js';
 import { getSiteHostname } from '../../../lib/site.js';
 import { addDeveloperRanks } from '../../../lib/ranking.js';
 import { getCosmosContainer } from '../../../lib/cosmos.js';
+import { getPublicAiToolNames } from '../../../lib/ai-profile.js';
 
 export const runtime = 'nodejs';
 
@@ -14,7 +15,7 @@ async function getDeveloper(login) {
   if (cosmosContainer) {
     try {
       const { resources } = await cosmosContainer.items.query({
-        query: `SELECT TOP 1 c.id, c.login, c.name, c.avatarUrl, c.location, c.followers, c.totalStars, c.totalForks, c.totalWatchers, c.totalCommits, c.topLanguage, c.soReputation, c.soAnswers, c.soAcceptRate, c.soBadges, c.publicRepos, c.claimed, c.score, c.globalRank, c.globalTotal, c.country, c.countryRank, c.countryTotal, c.city, c.cityRank, c.cityTotal
+        query: `SELECT TOP 1 c.id, c.login, c.name, c.avatarUrl, c.location, c.followers, c.totalStars, c.totalForks, c.totalWatchers, c.totalCommits, c.topLanguage, c.soReputation, c.soAnswers, c.soAcceptRate, c.soBadges, c.publicRepos, c.claimed, c.score, c.globalRank, c.globalTotal, c.country, c.countryRank, c.countryTotal, c.city, c.cityRank, c.cityTotal, c.aiProfile
           FROM c
           WHERE (c.login = @login OR c.id = @login)
             AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')`,
@@ -87,6 +88,7 @@ export async function GET(request) {
   const rankCardWidth = hasCityRank ? '166' : dev.countryRank ? '255' : '522';
   const rankValueFontSize = hasCityRank ? '29' : '34';
   const rankTotalFontSize = hasCityRank ? '12' : '14';
+  const aiToolNames = getPublicAiToolNames(dev.aiProfile);
 
   return new ImageResponse(
     (
@@ -477,12 +479,33 @@ export async function GET(request) {
             ))}
           </div>
 
+          {aiToolNames.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '10',
+                marginTop: '14',
+                color: '#94a3b8',
+                fontSize: '12',
+                lineHeight: '1.4',
+              }}
+            >
+              <div style={{ display: 'flex', flexShrink: '0', color: '#67e8f9', fontSize: '10', fontWeight: '800', letterSpacing: '1.4' }}>
+                AI TOOLKIT
+              </div>
+              <div style={{ display: 'flex', flex: '1' }}>
+                {aiToolNames.join('  ·  ')}
+              </div>
+            </div>
+          )}
+
           {/* Language badge */}
           {dev.topLanguage && (
             <div
               style={{
                 display: 'flex',
-                marginTop: '20',
+                marginTop: aiToolNames.length > 0 ? '10' : '20',
                 gap: '8',
                 alignItems: 'center',
               }}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -8,9 +8,8 @@ import DetailPanel from '../components/DetailPanel.jsx';
 import ComparePanel from '../components/ComparePanel.jsx';
 import LoadingOverlay from '../components/LoadingOverlay.jsx';
 import AddMeModal from '../components/AddMeModal.jsx';
-import AiProfileModal from '../components/AiProfileModal.jsx';
-import IntroductionInboxModal from '../components/IntroductionInboxModal.jsx';
 import QuickTour from '../components/QuickTour.jsx';
+import PlatformActivityBanner from '../components/PlatformActivityBanner.jsx';
 import { scoreAll } from '../lib/scoring.js';
 import { addDeveloperRanks } from '../lib/ranking.js';
 import dynamic from 'next/dynamic';
@@ -36,8 +35,6 @@ export default function Home() {
   const [cardRequest, setCardRequest] = useState(0);
   const [cardContext, setCardContext] = useState(null);
   const [showAddMe, setShowAddMe] = useState(false);
-  const [showAiProfile, setShowAiProfile] = useState(false);
-  const [showIntroductions, setShowIntroductions] = useState(false);
   const [tourStep, setTourStep] = useState(null);
   const [tourMatch, setTourMatch] = useState(null);
   const globeRef = useRef(null);
@@ -93,13 +90,7 @@ export default function Home() {
     await fetch('/api/auth/logout', { method: 'POST' });
     setUser(null);
     setClaimStatus('unclaimed');
-    setShowAiProfile(false);
-    setShowIntroductions(false);
   }, []);
-
-  const handleAiProfileSaved = useCallback((aiProfile) => {
-    setSelectedDev(current => current?.login === user?.login ? { ...current, aiProfile } : current);
-  }, [user]);
 
   const handleClaim = useCallback(async () => {
     try {
@@ -203,8 +194,17 @@ export default function Home() {
     setFiltered(rankedResults);
   }, [developers]);
 
+  const recordCardActivity = useCallback((targetLogin) => {
+    fetch('/api/activities/platform', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'generated_card', targetLogin }),
+    }).catch(() => {});
+  }, []);
+
   const handleGenerateCard = useCallback((developer) => {
     const rankedDeveloper = developers.find(item => item.login === developer.login) || developer;
+    recordCardActivity(rankedDeveloper.login);
     setSelectedDev(rankedDeveloper);
     setCardContext('generate');
     setCardRequest(request => request + 1);
@@ -212,7 +212,7 @@ export default function Home() {
     if (rankedDeveloper.lat != null && rankedDeveloper.lng != null) {
       setFlyTarget({ lat: rankedDeveloper.lat, lng: rankedDeveloper.lng });
     }
-  }, [developers]);
+  }, [developers, recordCardActivity]);
 
   const completeTour = useCallback(() => {
     setTourStep(null);
@@ -360,8 +360,6 @@ export default function Home() {
         user={user}
         onLogout={handleLogout}
         onClaim={handleClaim}
-        onEditAiProfile={() => setShowAiProfile(true)}
-        onOpenIntroductions={() => setShowIntroductions(true)}
         claimStatus={claimStatus}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={handleToggleSidebar}
@@ -370,6 +368,7 @@ export default function Home() {
         onAddMe={handleAddMe}
         onStartTour={handleTourFocusSearch}
       />
+      <PlatformActivityBanner />
       <SearchBar
         developers={developers}
         onResults={handleSearch}
@@ -424,7 +423,7 @@ export default function Home() {
           activeView={sidebarView}
           onViewChange={setSidebarView}
         />
-        {sidebarOpen && (
+        {sidebarOpen && sidebarView === 'leaderboard' && (
           <div className="sidebar-backdrop" onClick={handleCloseSidebar} />
         )}
         {selectedDev && (
@@ -432,6 +431,7 @@ export default function Home() {
             key={`${selectedDev.login}-${cardRequest}`}
             dev={selectedDev}
             onClose={handleCloseDetail}
+            onCardGenerated={recordCardActivity}
             claimedLogins={claimedLogins}
             openCardOnMount={cardRequest > 0}
             claimSuccess={cardContext === 'claim'}
@@ -441,13 +441,6 @@ export default function Home() {
           <ComparePanel devs={compareDevs} onClose={handleCloseCompare} />
         )}
         {showAddMe && <AddMeModal onClose={handleCloseAddMe} />}
-        {showAiProfile && (
-          <AiProfileModal
-            onClose={() => setShowAiProfile(false)}
-            onSaved={handleAiProfileSaved}
-          />
-        )}
-        {showIntroductions && <IntroductionInboxModal onClose={() => setShowIntroductions(false)} />}
       </main>
     </div>
   );

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -10,7 +10,7 @@ import { classifyAgent } from '../lib/agent-class.js';
 import { AI_TOOLS } from '../lib/ai-profile.js';
 import SpecialTags from './SpecialTags.jsx';
 
-export default function DetailPanel({ dev, onClose, claimedLogins, openCardOnMount = false, claimSuccess = false }) {
+export default function DetailPanel({ dev, onClose, onCardGenerated, claimedLogins, openCardOnMount = false, claimSuccess = false }) {
   const [fullData, setFullData] = useState(null);
   const [showCard, setShowCard] = useState(false);
   const radarRef = useRef(null);
@@ -19,6 +19,7 @@ export default function DetailPanel({ dev, onClose, claimedLogins, openCardOnMou
 
   const handleGenerateCard = () => {
     track('card_generated', { login: dev.login });
+    onCardGenerated?.(dev.login);
     setShowCard(true);
   };
 
@@ -550,13 +551,13 @@ function CardModal({ dev, claimSuccess, onClose }) {
 
   const rankText = dev.globalRank ? `Global #${dev.globalRank} of ${dev.globalTotal}` : 'Ranked on DevGlobe';
   const agent = classifyAgent(dev);
-  const shareText = `I mapped my open-source identity on DevGlobe: ${rankText}. Generate yours and see where you rank.`;
   const shareHashtags = ['buildinpublic', 'DevGlobe', 'OpenSource', 'DeveloperCommunity', 'GitHub'];
   const hashtagText = shareHashtags.map(hashtag => `#${hashtag}`).join(' ');
+  const shareText = `I mapped my open-source identity on DevGlobe: ${rankText}. Generate yours and see where you rank.\n\n${hashtagText}`;
   const linkedinCaption = `I mapped my open-source contributions on DevGlobe and discovered my developer identity: ${agent.name}. ${rankText}. Build your card and see where your work places you in the global developer community.\n\n${hashtagText}`;
 
   const shareLinks = {
-    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}&hashtags=${shareHashtags.join(',')}`,
+    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,
     linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`,
     reddit: `https://reddit.com/submit?url=${encodeURIComponent(shareUrl)}&title=${encodeURIComponent(`My DevGlobe Developer Card - ${name} ${hashtagText}`)}`,
   };

--- a/components/PlatformActivityBanner.jsx
+++ b/components/PlatformActivityBanner.jsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useGlobalActivityFeed } from './useGlobalActivityFeed.js';
+
+function relativeTime(timestamp) {
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
+export default function PlatformActivityBanner() {
+  const { activities, error } = useGlobalActivityFeed(true);
+  const [visibleIndex, setVisibleIndex] = useState(0);
+
+  useEffect(() => {
+    if (activities.length < 2) return undefined;
+    const interval = setInterval(() => {
+      setVisibleIndex(current => (current + 1) % Math.min(activities.length, 8));
+    }, 6000);
+    return () => clearInterval(interval);
+  }, [activities.length]);
+
+  useEffect(() => {
+    setVisibleIndex(0);
+  }, [activities[0]?.id]);
+
+  const activity = activities[visibleIndex];
+  if (!activity || error) return null;
+
+  return (
+    <aside className="activity-banner" aria-label="Recent platform activity" aria-live="polite">
+      <span className="activity-banner__pulse" aria-hidden="true" />
+      <span className="activity-banner__label">Live</span>
+      <Link href={`/developer/${encodeURIComponent(activity.login)}`} className="activity-banner__actor">
+        {activity.avatarUrl ? <img src={activity.avatarUrl} alt="" /> : <span aria-hidden="true">{activity.login[0].toUpperCase()}</span>}
+        @{activity.login}
+      </Link>
+      <a className="activity-banner__detail" href={activity.url}>{activity.description}</a>
+      <time dateTime={activity.createdAt}>{relativeTime(activity.createdAt)}</time>
+    </aside>
+  );
+}

--- a/lib/activity-store.js
+++ b/lib/activity-store.js
@@ -40,7 +40,7 @@ export async function saveActivities(activities) {
       ingestedAt,
       ttl: 48 * 60 * 60,
       schemaVersion: 1,
-      documentType: 'github-activity',
+      documentType: activity.documentType || 'github-activity',
     };
 
     if (!container) {
@@ -78,7 +78,7 @@ export async function listActivities({ limit = 50, cursor, after } = {}) {
     return { activities, nextCursor: activities.length === limit ? encodeActivityCursor(activities.at(-1)) : null };
   }
 
-  const conditions = ['c.documentType = "github-activity"', 'c.createdAt >= @cutoff'];
+  const conditions = ['c.documentType IN ("github-activity", "platform-activity")', 'c.createdAt >= @cutoff'];
   const parameters = [{ name: '@cutoff', value: cutoff }];
   if (cursor) {
     conditions.push('(c.createdAt < @cursorTime OR (c.createdAt = @cursorTime AND c.id < @cursorId))');

--- a/lib/ai-profile.js
+++ b/lib/ai-profile.js
@@ -82,3 +82,10 @@ export function getPublicAiProfile(aiProfile) {
     return null;
   }
 }
+
+export function getPublicAiToolNames(aiProfile) {
+  const profile = getPublicAiProfile(aiProfile);
+  if (!profile) return [];
+  const namesById = new Map(AI_TOOLS.map(tool => [tool.id, tool.name]));
+  return profile.tools.map(tool => namesById.get(tool.id)).filter(Boolean);
+}

--- a/lib/platform-activity.js
+++ b/lib/platform-activity.js
@@ -1,0 +1,48 @@
+import { randomUUID } from 'crypto';
+
+const FALLBACK_ACTIVITIES = [
+  { login: 'codeatlas', type: 'generated_card', description: 'had their developer card generated' },
+  { login: 'pixelbranch', type: 'logged_in', description: 'signed in to explore the developer globe' },
+  { login: 'cloudsyntax', type: 'generated_card', description: 'had their developer card generated' },
+  { login: 'commitcraft', type: 'logged_in', description: 'signed in to explore the developer globe' },
+];
+
+export function createPlatformActivity({ type, login, avatarUrl, targetLogin, now = new Date() }) {
+  const isCard = type === 'generated_card';
+  return {
+    id: `platform:${randomUUID()}`,
+    login,
+    avatarUrl: avatarUrl || null,
+    type,
+    description: isCard && targetLogin && targetLogin !== login
+      ? `generated @${targetLogin}'s developer card`
+      : isCard
+        ? 'had their developer card generated'
+        : 'signed in to DevGlobe',
+    repo: null,
+    url: isCard ? `/developer/${encodeURIComponent(targetLogin || login)}` : `/developer/${encodeURIComponent(login)}`,
+    createdAt: now.toISOString(),
+    documentType: 'platform-activity',
+  };
+}
+
+export function createFallbackActivities(now = Date.now()) {
+  const bucketMs = 60 * 60 * 1000;
+  const bucket = Math.floor(now / bucketMs);
+  const bucketStart = bucket * bucketMs;
+  const offset = bucket % FALLBACK_ACTIVITIES.length;
+
+  return FALLBACK_ACTIVITIES.map((_, index) => {
+    const activity = FALLBACK_ACTIVITIES[(index + offset) % FALLBACK_ACTIVITIES.length];
+    return {
+      id: `fallback:${bucket}:${index}`,
+      ...activity,
+      avatarUrl: null,
+      repo: null,
+      url: `/developer/${activity.login}`,
+      createdAt: new Date(bucketStart - (index + 1) * 7 * 60 * 1000).toISOString(),
+      documentType: 'fallback-activity',
+      fallback: true,
+    };
+  });
+}

--- a/lib/site.js
+++ b/lib/site.js
@@ -1,5 +1,5 @@
 const DEFAULT_SITE_URL = 'https://www.devglobe.dev';
-export const SOCIAL_PREVIEW_VERSION = '10';
+export const SOCIAL_PREVIEW_VERSION = '11';
 
 export function getSiteUrl() {
   const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();

--- a/styles/main.css
+++ b/styles/main.css
@@ -130,6 +130,79 @@ body {
   flex-shrink: 0;
 }
 
+.activity-banner {
+  position: fixed;
+  top: 56px;
+  left: 0;
+  right: 0;
+  z-index: 95;
+  display: flex;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel-92);
+  backdrop-filter: blur(12px);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.activity-banner__pulse {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--accent-github);
+  box-shadow: 0 0 0 4px rgba(46, 164, 79, 0.14);
+}
+
+.activity-banner__label {
+  color: var(--accent-github);
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.activity-banner__actor {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-primary);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.activity-banner__actor img,
+.activity-banner__actor > span {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--overlay-subtle-strong);
+  object-fit: cover;
+  font-size: 10px;
+}
+
+.activity-banner__detail {
+  overflow: hidden;
+  color: var(--text-secondary);
+  text-overflow: ellipsis;
+  text-decoration: none;
+}
+
+.activity-banner time {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -273,7 +346,7 @@ body {
 /* Centered search bar */
 .search-bar {
   position: fixed;
-  top: 72px;
+  top: 112px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 90;
@@ -1100,11 +1173,11 @@ body {
 /* Sidebar */
 .sidebar {
   position: fixed;
-  top: 56px;
+  top: 96px;
   right: 0;
   width: 320px;
-  height: calc(100vh - 56px);
-  height: calc(100dvh - 56px);
+  height: calc(100vh - 96px);
+  height: calc(100dvh - 96px);
   background: var(--bg-panel-92);
   backdrop-filter: blur(12px);
   border-left: 1px solid var(--border);
@@ -1112,6 +1185,11 @@ body {
   flex-direction: column;
   z-index: 50;
   transition: transform 0.3s ease;
+}
+
+.sidebar--activity {
+  background: var(--bg-secondary);
+  backdrop-filter: none;
 }
 
 .sidebar__header {
@@ -1183,7 +1261,7 @@ body {
 
 .sidebar__tabs {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr auto;
+  grid-template-columns: 1fr 1fr auto;
   align-items: center;
   gap: 4px;
   padding: 10px 12px;
@@ -1211,210 +1289,6 @@ body {
 .sidebar__tab--active {
   color: #22d3ee;
   border-bottom-color: #22d3ee;
-}
-
-.agent-network {
-  min-height: 0;
-  flex: 1;
-  overflow-y: auto;
-}
-
-.agent-network__header {
-  padding: 18px 14px 15px;
-  border-bottom: 1px solid var(--border);
-}
-
-.agent-network__header > span {
-  color: #22d3ee;
-  font-size: 9px;
-  font-weight: 800;
-}
-
-.agent-network__header h2 {
-  margin: 4px 0;
-  color: var(--text-primary);
-  font-size: 18px;
-}
-
-.agent-network__header p,
-.agent-network__privacy,
-.agent-network__suppressed,
-.agent-network__state {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 10px;
-  line-height: 1.5;
-}
-
-.agent-network__state {
-  padding: 24px 14px;
-}
-
-.agent-network__metrics {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  margin: 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.agent-network__metrics > div {
-  min-width: 0;
-  padding: 13px 14px;
-  border-right: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.agent-network__metrics > div:nth-child(2n) { border-right: 0; }
-.agent-network__metrics > div:nth-last-child(-n + 2) { border-bottom: 0; }
-
-.agent-network__metrics dt {
-  color: var(--text-muted);
-  font-size: 9px;
-  text-transform: uppercase;
-}
-
-.agent-network__metrics dd {
-  margin: 4px 0 0;
-  color: var(--text-primary);
-  font-size: 22px;
-  font-weight: 750;
-}
-
-.agent-network__section {
-  padding: 15px 14px;
-  border-bottom: 1px solid var(--border);
-}
-
-.agent-network__section h3 {
-  margin: 0 0 12px;
-  color: var(--text-secondary);
-  font-size: 10px;
-  text-transform: uppercase;
-}
-
-.agent-network__section-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.agent-network__section-heading span {
-  color: var(--text-muted);
-  font-size: 9px;
-}
-
-.agent-network__lifecycle {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.agent-network__lifecycle li {
-  position: relative;
-  display: grid;
-  justify-items: center;
-  gap: 6px;
-  min-width: 0;
-  text-align: center;
-}
-
-.agent-network__lifecycle li:not(:last-child)::after {
-  position: absolute;
-  top: 10px;
-  left: calc(50% + 11px);
-  width: calc(100% - 22px);
-  height: 1px;
-  background: rgba(34, 211, 238, 0.35);
-  content: '';
-}
-
-.agent-network__lifecycle li > span {
-  z-index: 1;
-  display: grid;
-  width: 21px;
-  height: 21px;
-  place-items: center;
-  border: 1px solid rgba(34, 211, 238, 0.5);
-  border-radius: 50%;
-  background: var(--bg-card);
-  color: #22d3ee;
-  font-size: 9px;
-  font-weight: 800;
-}
-
-.agent-network__lifecycle div {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-
-.agent-network__lifecycle strong {
-  color: var(--text-primary);
-  font-size: 9px;
-}
-
-.agent-network__lifecycle small {
-  color: var(--text-muted);
-  font-size: 8px;
-  line-height: 1.25;
-}
-
-.agent-network__tools,
-.agent-network__tool {
-  display: grid;
-  gap: 9px;
-}
-
-.agent-network__tool { gap: 5px; }
-
-.agent-network__tool > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  color: var(--text-secondary);
-  font-size: 10px;
-}
-
-.agent-network__tool > div span { color: var(--text-muted); }
-
-.agent-network__tool > i {
-  display: block;
-  height: 3px;
-  overflow: hidden;
-  background: var(--overlay-subtle-strong);
-}
-
-.agent-network__tool > i span {
-  display: block;
-  height: 100%;
-  background: #0891b2;
-}
-
-.agent-network__footer {
-  display: grid;
-  justify-items: center;
-  gap: 9px;
-  padding: 11px 14px;
-}
-
-.agent-network__privacy {
-  padding: 0;
-  text-align: center;
-}
-
-.agent-network__footer a {
-  color: #22d3ee;
-  font-size: 10px;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.agent-network__footer a:hover {
-  text-decoration: underline;
 }
 
 .global-activity {
@@ -1844,116 +1718,6 @@ body {
 
 .detail-header__links a:hover {
   text-decoration: underline;
-}
-
-.ai-collaboration {
-  margin: 0 0 24px;
-  padding: 16px;
-  border: 1px solid rgba(8, 145, 178, 0.35);
-  border-left: 3px solid #0891b2;
-  border-radius: 8px;
-  background: var(--overlay-subtle);
-}
-
-.ai-collaboration__heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-
-.ai-collaboration__heading span {
-  display: block;
-  margin-bottom: 3px;
-  color: #22d3ee;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-
-.ai-collaboration__heading h3 {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 14px;
-}
-
-.ai-collaboration__heading strong {
-  flex: 0 0 auto;
-  padding: 4px 7px;
-  border: 1px solid rgba(46, 164, 79, 0.45);
-  border-radius: 6px;
-  color: #2ea44f;
-  font-size: 10px;
-  font-weight: 600;
-}
-
-.ai-collaboration__tools {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-}
-
-.ai-collaboration__tool {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 28px;
-  padding: 4px 8px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-card);
-  color: var(--text-primary);
-  font-size: 11px;
-}
-
-.ai-collaboration__tool small {
-  color: var(--text-muted);
-  text-transform: capitalize;
-}
-
-.ai-collaboration__empty,
-.ai-collaboration__note {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.5;
-}
-
-.ai-collaboration__note {
-  margin-top: 10px;
-}
-
-.ai-collaboration__share {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  margin-top: 11px;
-}
-
-.ai-collaboration__share button {
-  display: inline-flex;
-  min-height: 30px;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 9px;
-  border: 1px solid rgba(8, 145, 178, 0.55);
-  border-radius: 5px;
-  background: transparent;
-  color: #22d3ee;
-  font: inherit;
-  font-size: 10px;
-  font-weight: 650;
-  cursor: pointer;
-}
-
-.ai-collaboration__share button:hover {
-  background: rgba(8, 145, 178, 0.12);
-}
-
-.ai-collaboration__share > span {
-  color: var(--text-muted);
-  font-size: 10px;
 }
 
 /* Chart sections */
@@ -2915,6 +2679,13 @@ body {
 }
 
 @media (max-width: 480px) {
+  .activity-banner {
+    justify-content: flex-start;
+    padding: 0 12px;
+  }
+  .activity-banner__label {
+    display: none;
+  }
   .globe-avatar-marker {
     width: 20px;
     height: 20px;
@@ -3174,447 +2945,6 @@ body {
 }
 
 /* =============== Card Modal =============== */
-
-.ai-profile-modal__backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 520;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 18px;
-  background: rgba(0, 0, 0, 0.72);
-  backdrop-filter: blur(4px);
-  animation: fadeIn 0.15s ease;
-}
-
-.ai-profile-modal {
-  position: relative;
-  width: min(680px, 100%);
-  max-height: calc(100vh - 36px);
-  max-height: calc(100dvh - 36px);
-  overflow-y: auto;
-  padding: 26px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg-card);
-  box-shadow: var(--shadow-strong);
-}
-
-.ai-profile-modal__close {
-  position: absolute;
-  top: 10px;
-  right: 12px;
-  width: 32px;
-  height: 32px;
-  border: 0;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 24px;
-  cursor: pointer;
-}
-
-.ai-profile-modal__eyebrow {
-  color: #22d3ee;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-
-.ai-profile-modal h2 {
-  margin: 5px 40px 4px 0;
-  color: var(--text-primary);
-  font-size: 20px;
-}
-
-.ai-profile-modal__intro {
-  margin: 0 40px 22px 0;
-  color: var(--text-secondary);
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.ai-profile-modal__fieldset {
-  margin: 0 0 20px;
-  padding: 0;
-  border: 0;
-}
-
-.ai-profile-modal__fieldset legend {
-  margin-bottom: 3px;
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.ai-profile-modal__fieldset > p {
-  margin: 0 0 10px;
-  color: var(--text-muted);
-  font-size: 11px;
-}
-
-.ai-profile-modal__tools {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 7px;
-}
-
-.ai-tool-option {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 104px;
-  align-items: center;
-  min-height: 42px;
-  padding: 7px 9px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--overlay-subtle);
-}
-
-.ai-tool-option:not(.ai-tool-option--selected) {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.ai-tool-option--selected {
-  border-color: rgba(8, 145, 178, 0.6);
-}
-
-.ai-tool-option label {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  min-width: 0;
-  color: var(--text-primary);
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.ai-tool-option select {
-  width: 104px;
-  padding: 5px;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  background: var(--bg-card);
-  color: var(--text-primary);
-  font: inherit;
-  font-size: 11px;
-  text-transform: capitalize;
-}
-
-.ai-profile-modal__row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  padding: 11px 0;
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-}
-
-.ai-profile-modal__row span {
-  display: grid;
-  gap: 3px;
-}
-
-.ai-profile-modal__row strong {
-  color: var(--text-primary);
-  font-size: 12px;
-}
-
-.ai-profile-modal__row small {
-  color: var(--text-muted);
-  font-size: 10px;
-  line-height: 1.4;
-}
-
-.ai-profile-modal__row input,
-.ai-tool-option input {
-  accent-color: #0891b2;
-}
-
-.ai-profile-modal__status,
-.ai-profile-modal__error {
-  padding: 14px 0;
-  color: var(--text-secondary);
-  font-size: 12px;
-}
-
-.ai-profile-modal__error {
-  color: #ef4444;
-}
-
-.ai-profile-modal__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.ai-profile-modal__save {
-  border-color: #0891b2;
-  background: #0891b2;
-  color: #fff;
-}
-
-.ai-profile-modal__save:disabled {
-  cursor: wait;
-  opacity: 0.65;
-}
-
-.introduction-inbox__backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 520;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 18px;
-  background: rgba(0, 0, 0, 0.72);
-  backdrop-filter: blur(4px);
-  animation: fadeIn 0.15s ease;
-}
-
-.introduction-inbox {
-  position: relative;
-  width: min(640px, 100%);
-  max-height: calc(100vh - 36px);
-  max-height: calc(100dvh - 36px);
-  overflow-y: auto;
-  padding: 26px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg-card);
-  box-shadow: var(--shadow-strong);
-}
-
-.introduction-inbox__close {
-  position: absolute;
-  top: 10px;
-  right: 12px;
-  width: 32px;
-  height: 32px;
-  border: 0;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 24px;
-  cursor: pointer;
-}
-
-.introduction-inbox__eyebrow {
-  color: #22d3ee;
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.introduction-inbox h2 {
-  margin: 5px 40px 4px 0;
-  color: var(--text-primary);
-  font-size: 20px;
-}
-
-.introduction-inbox__intro {
-  margin: 0 40px 20px 0;
-  color: var(--text-secondary);
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.introduction-inbox__empty,
-.introduction-inbox__error {
-  margin: 20px 0;
-  color: var(--text-muted);
-  font-size: 12px;
-}
-
-.introduction-inbox__error {
-  color: #ef4444;
-}
-
-.introduction-inbox__list {
-  display: grid;
-  gap: 10px;
-}
-
-.introduction-request {
-  padding: 14px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--overlay-subtle);
-}
-
-.introduction-request header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.introduction-request header div {
-  display: grid;
-  gap: 2px;
-}
-
-.introduction-request header strong {
-  color: var(--text-primary);
-  font-size: 13px;
-}
-
-.introduction-request header span {
-  color: var(--text-muted);
-  font-size: 10px;
-}
-
-.introduction-request__status {
-  padding: 3px 7px;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  color: var(--text-secondary);
-  font-size: 9px;
-  text-transform: uppercase;
-}
-
-.introduction-request__status--pending {
-  border-color: rgba(251, 191, 36, 0.45);
-  color: #fbbf24;
-}
-
-.introduction-request__status--accepted {
-  border-color: rgba(46, 164, 79, 0.45);
-  color: #2ea44f;
-}
-
-.introduction-request__status--declined,
-.introduction-request__status--expired {
-  color: var(--text-muted);
-}
-
-.introduction-request__timeline {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin: 15px 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.introduction-request__stage {
-  position: relative;
-  display: grid;
-  justify-items: center;
-  gap: 5px;
-  color: var(--text-muted);
-  font-size: 9px;
-}
-
-.introduction-request__stage:not(:last-child)::after {
-  position: absolute;
-  top: 5px;
-  left: calc(50% + 6px);
-  width: calc(100% - 12px);
-  height: 1px;
-  background: var(--border);
-  content: '';
-}
-
-.introduction-request__stage i {
-  z-index: 1;
-  width: 11px;
-  height: 11px;
-  border: 2px solid var(--border);
-  border-radius: 50%;
-  background: var(--bg-card);
-}
-
-.introduction-request__stage--complete i,
-.introduction-request__stage--complete:not(:last-child)::after {
-  border-color: #0891b2;
-  background: #0891b2;
-}
-
-.introduction-request__stage--current {
-  color: var(--text-primary);
-  font-weight: 700;
-}
-
-.introduction-request__stage--current i {
-  border-color: #22d3ee;
-  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.12);
-}
-
-.introduction-request dl {
-  display: grid;
-  gap: 9px;
-  margin: 13px 0 0;
-}
-
-.introduction-request dl div {
-  display: grid;
-  grid-template-columns: 56px minmax(0, 1fr);
-  gap: 8px;
-}
-
-.introduction-request dt {
-  color: var(--text-muted);
-  font-size: 10px;
-}
-
-.introduction-request dd {
-  margin: 0;
-  overflow-wrap: anywhere;
-  color: var(--text-secondary);
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-.introduction-request__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 7px;
-  margin-top: 14px;
-}
-
-.introduction-request__actions button {
-  min-height: 30px;
-  padding: 5px 10px;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  background: transparent;
-  color: var(--text-secondary);
-  font: inherit;
-  font-size: 11px;
-  cursor: pointer;
-}
-
-.introduction-request__actions .introduction-request__accept {
-  border-color: #0891b2;
-  background: #0891b2;
-  color: #fff;
-}
-
-.introduction-request__actions button:disabled {
-  cursor: wait;
-  opacity: 0.6;
-}
-
-@media (max-width: 620px) {
-  .ai-profile-modal {
-    padding: 22px 16px;
-  }
-
-  .ai-profile-modal__tools {
-    grid-template-columns: 1fr;
-  }
-
-  .ai-collaboration__heading {
-    flex-direction: column;
-  }
-
-  .introduction-inbox {
-    padding: 22px 16px;
-  }
-
-  .introduction-request dl div {
-    grid-template-columns: 1fr;
-    gap: 2px;
-  }
-}
 
 .card-modal-backdrop {
   position: fixed;

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { decodeActivityCursor, encodeActivityCursor } from '../lib/activity-store.js';
 import { describeGitHubEvent, normalizeGitHubEvent } from '../lib/github-activity.js';
+import { createFallbackActivities, createPlatformActivity } from '../lib/platform-activity.js';
 
 test('normalizes a GitHub event into the public activity shape', () => {
   const activity = normalizeGitHubEvent({
@@ -32,4 +33,26 @@ test('round trips stable timestamp and id cursors', () => {
   const activity = { id: '123', createdAt: '2026-08-12T12:00:00.000Z' };
   assert.deepEqual(decodeActivityCursor(encodeActivityCursor(activity)), activity);
   assert.equal(decodeActivityCursor('not-a-cursor'), null);
+});
+
+test('creates platform card activity for the actor and target', () => {
+  const activity = createPlatformActivity({
+    type: 'generated_card',
+    login: 'octocat',
+    targetLogin: 'hubot',
+    now: new Date('2026-08-13T12:00:00Z'),
+  });
+
+  assert.equal(activity.login, 'octocat');
+  assert.equal(activity.description, "generated @hubot's developer card");
+  assert.equal(activity.url, '/developer/hubot');
+  assert.equal(activity.documentType, 'platform-activity');
+});
+
+test('creates stable fallback activities within an hourly window', () => {
+  const first = createFallbackActivities(Date.parse('2026-08-13T12:10:00Z'));
+  const second = createFallbackActivities(Date.parse('2026-08-13T12:50:00Z'));
+
+  assert.deepEqual(first, second);
+  assert.ok(first.every(activity => activity.fallback));
 });

--- a/tests/ai-profile.test.js
+++ b/tests/ai-profile.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   AiProfileValidationError,
   getPublicAiProfile,
+  getPublicAiToolNames,
   normalizeAiProfile,
 } from '../lib/ai-profile.js';
 
@@ -67,4 +68,20 @@ test('projects only valid public AI profiles', () => {
   assert.deepEqual(getPublicAiProfile(profile), profile);
   assert.equal(getPublicAiProfile({ ...profile, visibility: 'private' }), null);
   assert.equal(getPublicAiProfile({ ...profile, tools: [{ id: 'invalid', usage: 'daily' }] }), null);
+});
+
+test('projects tool names only from public AI profiles', () => {
+  const profile = {
+    tools: [
+      { id: 'github-copilot', usage: 'daily', source: 'self-declared' },
+      { id: 'claude-code', usage: 'regular', source: 'self-declared' },
+    ],
+    acceptsAgentRequests: false,
+    visibility: 'public',
+    contactPolicy: 'nobody',
+    updatedAt: timestamp,
+  };
+
+  assert.deepEqual(getPublicAiToolNames(profile), ['GitHub Copilot', 'Claude Code']);
+  assert.deepEqual(getPublicAiToolNames({ ...profile, visibility: 'private' }), []);
 });


### PR DESCRIPTION
## Summary
- add a live platform activity banner with login and card-generation events plus stable fallback activity
- ensure X/Twitter shares include hashtags in the post text
- show public AI toolkit access on downloaded and social-preview developer cards
- ignore generated ADX dashboard artifacts

## Validation
- npm test (26 passed)
- npm run build