### PR TITLE
feat: add lifecycle email notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 SESSION_SECRET=your_random_session_secret
 
+# Transactional lifecycle emails (optional; Resend free tier)
+# EMAIL_FROM must use a sender/domain verified in Resend.
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+EMAIL_FROM=DevGlobe <hello@your-verified-domain.example>
+
 # Canonical public URL for metadata, cards, robots, sitemap, and share links.
 # Include the https:// protocol and do not wrap the value in quotes.
 NEXT_PUBLIC_SITE_URL=https://www.devglobe.dev

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Required environment variables:
 | `COSMOS_CONTAINER` | Container name |
 | `COSMOS_ACTIVITY_CONTAINER` | Rolling GitHub activity container (`activities`) |
 | `ACTIVITY_INGEST_SECRET` | Bearer secret for the activity collector endpoint |
+| `RESEND_API_KEY` | Optional Resend API key for claim and approval emails |
+| `EMAIL_FROM` | Sender on a domain verified by Resend |
+
+Lifecycle emails are transactional and best-effort. Claims use the verified primary email authorized through GitHub OAuth; nomination approvals can use only an email made public on the nominee's GitHub profile. Recipient addresses are not stored in Cosmos DB. See the [lifecycle email PRD](docs/prd/lifecycle-email-notifications.md).
 
 ### Live developer activity
 

--- a/app/api/auth/callback/route.js
+++ b/app/api/auth/callback/route.js
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 import { createSessionToken, buildSessionCookie } from '../../../../lib/auth.js';
 import { saveActivities } from '../../../../lib/activity-store.js';
 import { createPlatformActivity } from '../../../../lib/platform-activity.js';
+import { selectGitHubEmail } from '../../../../lib/github-email.js';
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
@@ -61,13 +62,25 @@ export async function GET(request) {
     }
 
     const ghUser = await userRes.json();
+    let githubEmails = [];
+    try {
+      const emailsRes = await fetch('https://api.github.com/user/emails', {
+        headers: {
+          Authorization: `Bearer ${tokenData.access_token}`,
+          Accept: 'application/vnd.github.v3+json',
+        },
+      });
+      if (emailsRes.ok) githubEmails = await emailsRes.json();
+    } catch (emailError) {
+      console.error('GitHub email lookup failed:', emailError.message);
+    }
 
     // Create session
     const session = {
       login: ghUser.login,
       name: ghUser.name || ghUser.login,
       avatarUrl: ghUser.avatar_url,
-      email: ghUser.email,
+      email: selectGitHubEmail(ghUser.email, githubEmails),
     };
 
     const token = await createSessionToken(session);

--- a/app/api/auth/claim/route.js
+++ b/app/api/auth/claim/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { getSession } from '../../../../lib/auth.js';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { buildClaimWelcomeEmail, sendLifecycleEmail } from '../../../../lib/lifecycle-email.js';
 
 const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
 const COSMOS_KEY = process.env.COSMOS_KEY;
@@ -99,6 +100,7 @@ export async function POST() {
       }).fetchAll();
 
       let dev;
+      const wasClaimed = resources[0]?.claimed === true;
 
       if (resources.length > 0) {
         // Existing profile — mark as claimed
@@ -118,6 +120,18 @@ export async function POST() {
       }
 
       await container.items.upsert(dev);
+
+      if (!wasClaimed) {
+        try {
+          await sendLifecycleEmail({
+            to: session.email,
+            message: buildClaimWelcomeEmail({ login: dev.login, name: dev.name }),
+            idempotencyKey: `profile-claimed-${dev.login.toLowerCase()}`,
+          });
+        } catch (emailError) {
+          console.error('Claim email delivery failed:', emailError.message);
+        }
+      }
 
       return NextResponse.json({
         ok: true,

--- a/docs/prd/lifecycle-email-notifications.md
+++ b/docs/prd/lifecycle-email-notifications.md
@@ -1,0 +1,111 @@
+# PRD: Lifecycle Email Notifications
+
+**Status:** Implemented
+**Issue:** [#151](https://github.com/sajeetharan/devglobe/issues/151)
+**Owner:** DevGlobe
+**Last updated:** 2026-08-14
+
+## Summary
+
+DevGlobe sends a single onboarding email when a developer first claims a profile and a single approval email when a self-nomination becomes public. Each email links directly to the developer profile and introduces the next useful product actions.
+
+Resend provides delivery through its free tier and HTTP API. Email delivery is best-effort: claiming and approval remain successful when the recipient has no usable email, the provider is not configured, or the provider request fails.
+
+## Problem
+
+Claimed and newly approved developers receive no follow-up after the lifecycle action completes. They can miss profile controls, AI collaboration settings, rankings, activity, and the public URL they can share.
+
+## Goals
+
+- Confirm successful claims and nomination approvals outside the browser.
+- Link recipients directly to their public developer profile.
+- Introduce profile controls and AI collaboration features without a marketing sequence.
+- Use email addresses transiently and never add them to developer documents.
+- Keep core lifecycle writes independent from provider availability.
+
+## Non-goals
+
+- Marketing campaigns, newsletters, drip sequences, or bulk email.
+- Persisting email addresses in Cosmos DB.
+- Discovering a nomination email that is private on GitHub.
+- Retrying failed delivery or building a durable email outbox in this phase.
+- Email preference management beyond these transactional lifecycle messages.
+
+## Users And Triggers
+
+### First profile claim
+
+After the developer document is successfully created or transitions from unclaimed to claimed, DevGlobe sends a welcome email to the verified primary address returned by the authenticated GitHub `user:email` scope. Repeated claims do not trigger another message.
+
+The message confirms ownership and links to the profile, activity, rankings, and AI collaboration settings.
+
+### First nomination approval
+
+After the review command completes fresh GitHub enrichment and atomically transitions a pending nomination to approved, DevGlobe sends an approval email when the GitHub profile exposes a public email address. Refreshing an already approved profile does not trigger another message.
+
+GitHub does not expose another user's private email to an administrative token. A nominee with no public profile email is therefore skipped until a future consent-based collection flow exists.
+
+## Functional Requirements
+
+- Use the Resend email API without adding an SDK dependency.
+- Configure delivery with `RESEND_API_KEY` and `EMAIL_FROM`.
+- Include both plain-text and escaped HTML bodies.
+- Display the hosted DevGlobe logo with fixed email-safe dimensions.
+- Use `/developer/{login}` as the primary call to action.
+- Invite developer recipients to contribute code, ideas, or documentation on GitHub.
+- Apply a deterministic provider idempotency key to each lifecycle event.
+- Skip safely when the recipient or provider configuration is absent.
+- Log delivery failures without logging addresses, API keys, or response bodies.
+- Do not roll back or fail a successful claim or approval because email delivery failed.
+
+## Privacy And Security
+
+- Claim email is read from the signed GitHub OAuth session and used only for immediate delivery.
+- Nomination email is read from the freshly fetched public GitHub profile and used only for immediate delivery.
+- Developer records, public APIs, activity records, and logs do not contain recipient addresses.
+- HTML interpolations are escaped and profile path segments are URL encoded.
+- The Resend API key remains server-side.
+
+## Templates
+
+### Claim welcome
+
+- Subject: `Your DevGlobe profile is claimed`
+- Confirms that the profile is under the developer's control.
+- Prompts exploration of activity, rankings, and AI collaboration preferences.
+- CTA: `Explore your profile`
+
+### Nomination approved
+
+- Subject: `Your DevGlobe nomination was approved`
+- Confirms that the profile is public.
+- Prompts review, sharing, and claiming the profile for additional controls.
+- CTA: `View your profile`
+
+## Success Metrics
+
+- Delivery attempts and provider success rate by lifecycle type.
+- Profile visits from lifecycle email links.
+- AI collaboration profile completion after a claim email.
+- Claim conversion after a nomination approval email.
+
+Provider logs supply initial delivery visibility. Product analytics and durable event telemetry are follow-up work.
+
+## Acceptance Criteria
+
+- A first successful claim attempts one welcome email when a verified OAuth email exists.
+- Repeating a claim does not attempt another welcome email.
+- A first successful nomination approval attempts one approval email when GitHub exposes a public email.
+- Refresh and already-approved paths do not send approval emails.
+- Missing recipient or provider settings skip delivery without failing the lifecycle action.
+- Provider errors are sanitized and do not fail the lifecycle action.
+- Templates include plain text, escaped HTML, and an encoded profile URL.
+- Unit tests, the full test suite, and the production build pass.
+
+## Rollout
+
+1. Create a Resend account and verify the sending domain.
+2. Configure `RESEND_API_KEY` and a verified `EMAIL_FROM` value in Vercel and the review-script environment.
+3. Deploy and test with one controlled first claim and one controlled nomination approval.
+4. Monitor Resend delivery logs and application errors.
+5. Add durable notification events, retries, and preference controls only if delivery volume warrants them.

--- a/lib/github-email.js
+++ b/lib/github-email.js
@@ -1,0 +1,7 @@
+export function selectGitHubEmail(profileEmail, emails = []) {
+  const verifiedEmails = Array.isArray(emails)
+    ? emails.filter(email => email?.verified && typeof email.email === 'string' && email.email.trim())
+    : [];
+  const primary = verifiedEmails.find(email => email.primary);
+  return primary?.email.trim() || String(profileEmail || '').trim() || verifiedEmails[0]?.email.trim() || null;
+}

--- a/lib/lifecycle-email.js
+++ b/lib/lifecycle-email.js
@@ -1,0 +1,115 @@
+import { getSiteUrl } from './site.js';
+
+const RESEND_API_URL = 'https://api.resend.com/emails';
+const REPOSITORY_URL = 'https://github.com/sajeetharan/devglobe';
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function profileUrl(login) {
+  return `${getSiteUrl()}/developer/${encodeURIComponent(login)}`;
+}
+
+function emailLayout({ preview, heading, greeting, body, login, action }) {
+  const url = profileUrl(login);
+  const logoUrl = `${getSiteUrl()}/devglobe.png`;
+  return `<!doctype html>
+<html lang="en">
+  <body style="margin:0;background:#f3f6f4;color:#17211b;font-family:Arial,sans-serif">
+    <div style="display:none;max-height:0;overflow:hidden">${escapeHtml(preview)}</div>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f3f6f4;padding:32px 16px">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:600px;background:#ffffff;border:1px solid #dce5df">
+          <tr><td style="padding:24px 32px 12px">
+            <img src="${escapeHtml(logoUrl)}" width="48" height="48" alt="DevGlobe" style="display:block;width:48px;height:48px;object-fit:contain;border:0">
+          </td></tr>
+          <tr><td style="padding:0 32px 8px;font-size:28px;font-weight:700;line-height:1.2">${escapeHtml(heading)}</td></tr>
+          <tr><td style="padding:12px 32px 0;font-size:16px;line-height:1.6">Hi ${escapeHtml(greeting)},</td></tr>
+          <tr><td style="padding:8px 32px 24px;font-size:16px;line-height:1.6">${escapeHtml(body)}</td></tr>
+          <tr><td style="padding:0 32px 28px">
+            <a href="${escapeHtml(url)}" style="display:inline-block;background:#117a4b;color:#ffffff;padding:12px 18px;text-decoration:none;font-weight:700">${escapeHtml(action)}</a>
+          </td></tr>
+          <tr><td style="padding:20px 32px;border-top:1px solid #e7ece9;font-size:15px;line-height:1.6">
+            <strong>Built by developers, with developers.</strong><br>
+            DevGlobe is open source. Help improve developer discovery, profiles, and agent collaboration by contributing code, ideas, or documentation.<br>
+            <a href="${REPOSITORY_URL}" style="color:#117a4b;font-weight:700">Contribute on GitHub</a>
+          </td></tr>
+          <tr><td style="padding:20px 32px;border-top:1px solid #e7ece9;color:#5c6b62;font-size:13px;line-height:1.5">Explore your developer profile, AI collaboration settings, rankings, and activity on DevGlobe.</td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+}
+
+export function buildClaimWelcomeEmail({ login, name }) {
+  const greeting = name || login;
+  const url = profileUrl(login);
+  return {
+    subject: 'Your DevGlobe profile is claimed',
+    text: `Hi ${greeting},\n\nYour DevGlobe profile is now claimed and under your control. Explore your profile, add your AI collaboration preferences, and see your activity and rankings.\n\nOpen your profile: ${url}\n\nDevGlobe is open source. Contribute code, ideas, or documentation: ${REPOSITORY_URL}\n\nDevGlobe`,
+    html: emailLayout({
+      preview: 'Your DevGlobe profile is now under your control.',
+      heading: 'Your profile is claimed',
+      greeting,
+      body: 'Your DevGlobe profile is now under your control. Explore your activity and rankings, then add your AI collaboration preferences so agents and developers know how you like to work.',
+      login,
+      action: 'Explore your profile',
+    }),
+  };
+}
+
+export function buildNominationApprovedEmail({ login, name }) {
+  const greeting = name || login;
+  const url = profileUrl(login);
+  return {
+    subject: 'Your DevGlobe nomination was approved',
+    text: `Hi ${greeting},\n\nYour nomination was approved and your DevGlobe profile is now public. Explore your profile, review your developer metrics, and claim it to unlock profile controls and AI collaboration preferences.\n\nView your profile: ${url}\n\nDevGlobe is open source. Contribute code, ideas, or documentation: ${REPOSITORY_URL}\n\nDevGlobe`,
+    html: emailLayout({
+      preview: 'Your nomination was approved and your profile is live.',
+      heading: 'You are live on DevGlobe',
+      greeting,
+      body: 'Your nomination was approved and your profile is now public. Review your developer metrics, share your profile, and claim it to unlock profile controls and AI collaboration preferences.',
+      login,
+      action: 'View your profile',
+    }),
+  };
+}
+
+export async function sendLifecycleEmail({ to, message, idempotencyKey, fetchImpl = fetch }) {
+  const recipient = String(to || '').trim();
+  if (!recipient) return { sent: false, reason: 'missing_recipient' };
+
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const from = process.env.EMAIL_FROM?.trim();
+  if (!apiKey || !from) return { sent: false, reason: 'not_configured' };
+
+  const response = await fetchImpl(RESEND_API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
+    },
+    body: JSON.stringify({
+      from,
+      to: [recipient],
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Email provider returned status ${response.status}`);
+  }
+
+  const result = await response.json();
+  return { sent: true, id: result.id || null };
+}

--- a/scripts/review-nominations.js
+++ b/scripts/review-nominations.js
@@ -24,6 +24,7 @@ import {
   enrichFromGitHub,
   geocodeLocation,
 } from '../lib/nominate.js';
+import { buildNominationApprovedEmail, sendLifecycleEmail } from '../lib/lifecycle-email.js';
 
 dotenv.config({ path: '.env.local' });
 dotenv.config();
@@ -137,6 +138,18 @@ async function approve(container, username, reviewer, refresh = false) {
       process.exit(1);
     }
     throw err;
+  }
+
+  if (!refresh) {
+    try {
+      await sendLifecycleEmail({
+        to: ghUser.email,
+        message: buildNominationApprovedEmail({ login: dev.login, name: enriched.name }),
+        idempotencyKey: `nomination-approved-${dev.login.toLowerCase()}-${Date.parse(dev.nomination.submittedAt)}`,
+      });
+    } catch (emailError) {
+      console.error(`  Approval email delivery failed: ${emailError.message}`);
+    }
   }
 
   console.log(`  ✓ "${username}" ${refresh ? 'details refreshed' : 'approved and now public'}.`);

--- a/tests/github-email.test.js
+++ b/tests/github-email.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { selectGitHubEmail } from '../lib/github-email.js';
+
+test('selects the verified primary GitHub email', () => {
+  assert.equal(selectGitHubEmail('public@example.com', [
+    { email: 'other@example.com', verified: true, primary: false },
+    { email: 'primary@example.com', verified: true, primary: true },
+  ]), 'primary@example.com');
+});
+
+test('falls back to public profile email and ignores unverified addresses', () => {
+  assert.equal(selectGitHubEmail('public@example.com', [
+    { email: 'unverified@example.com', verified: false, primary: true },
+  ]), 'public@example.com');
+  assert.equal(selectGitHubEmail(null, [
+    { email: 'unverified@example.com', verified: false, primary: true },
+  ]), null);
+});

--- a/tests/lifecycle-email.test.js
+++ b/tests/lifecycle-email.test.js
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildClaimWelcomeEmail,
+  buildNominationApprovedEmail,
+  sendLifecycleEmail,
+} from '../lib/lifecycle-email.js';
+
+test('builds claim email with an encoded profile link and escaped HTML', () => {
+  const message = buildClaimWelcomeEmail({ login: 'dev user', name: '<Dev & Co>' });
+
+  assert.match(message.subject, /claimed/i);
+  assert.match(message.text, /developer\/dev%20user/);
+  assert.match(message.html, /&lt;Dev &amp; Co&gt;/);
+  assert.doesNotMatch(message.html, /<Dev & Co>/);
+  assert.match(message.html, /src="https:\/\/www\.devglobe\.dev\/devglobe\.png"/);
+  assert.match(message.html, /Contribute on GitHub/);
+  assert.match(message.text, /github\.com\/sajeetharan\/devglobe/);
+});
+
+test('builds nomination approval email with claim follow-up', () => {
+  const message = buildNominationApprovedEmail({ login: 'octocat', name: 'Octocat' });
+
+  assert.match(message.subject, /approved/i);
+  assert.match(message.text, /claim it/i);
+  assert.match(message.html, /View your profile/);
+  assert.match(message.html, /github\.com\/sajeetharan\/devglobe/);
+});
+
+test('skips delivery when recipient or provider configuration is missing', async () => {
+  const originalApiKey = process.env.RESEND_API_KEY;
+  const originalFrom = process.env.EMAIL_FROM;
+  delete process.env.RESEND_API_KEY;
+  delete process.env.EMAIL_FROM;
+
+  try {
+    assert.deepEqual(await sendLifecycleEmail({ to: '', message: {} }), {
+      sent: false,
+      reason: 'missing_recipient',
+    });
+    assert.deepEqual(await sendLifecycleEmail({ to: 'dev@example.com', message: {} }), {
+      sent: false,
+      reason: 'not_configured',
+    });
+  } finally {
+    if (originalApiKey === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = originalApiKey;
+    if (originalFrom === undefined) delete process.env.EMAIL_FROM;
+    else process.env.EMAIL_FROM = originalFrom;
+  }
+});
+
+test('sends through Resend with an idempotency key', async () => {
+  const originalApiKey = process.env.RESEND_API_KEY;
+  const originalFrom = process.env.EMAIL_FROM;
+  process.env.RESEND_API_KEY = 'test-key';
+  process.env.EMAIL_FROM = 'DevGlobe <hello@example.com>';
+  let request;
+
+  try {
+    const result = await sendLifecycleEmail({
+      to: 'dev@example.com',
+      message: { subject: 'Subject', text: 'Text', html: '<p>HTML</p>' },
+      idempotencyKey: 'profile-claimed-octocat',
+      fetchImpl: async (url, options) => {
+        request = { url, options };
+        return { ok: true, json: async () => ({ id: 'email-123' }) };
+      },
+    });
+
+    assert.deepEqual(result, { sent: true, id: 'email-123' });
+    assert.equal(request.url, 'https://api.resend.com/emails');
+    assert.equal(request.options.headers['Idempotency-Key'], 'profile-claimed-octocat');
+    assert.deepEqual(JSON.parse(request.options.body).to, ['dev@example.com']);
+  } finally {
+    if (originalApiKey === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = originalApiKey;
+    if (originalFrom === undefined) delete process.env.EMAIL_FROM;
+    else process.env.EMAIL_FROM = originalFrom;
+  }
+});
+
+test('throws a sanitized provider error', async () => {
+  const originalApiKey = process.env.RESEND_API_KEY;
+  const originalFrom = process.env.EMAIL_FROM;
+  process.env.RESEND_API_KEY = 'test-key';
+  process.env.EMAIL_FROM = 'hello@example.com';
+
+  try {
+    await assert.rejects(sendLifecycleEmail({
+      to: 'dev@example.com',
+      message: { subject: 'Subject', text: 'Text', html: '<p>HTML</p>' },
+      fetchImpl: async () => ({ ok: false, status: 422 }),
+    }), /status 422/);
+  } finally {
+    if (originalApiKey === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = originalApiKey;
+    if (originalFrom === undefined) delete process.env.EMAIL_FROM;
+    else process.env.EMAIL_FROM = originalFrom;
+  }
+});


### PR DESCRIPTION
### Summary
- Resend claim/approval transactional emails
- Verified/transient GitHub email handling
- Logo/contribution templates
- PRD/config docs

### Testing
- \
pm test\ (49 passed)
- \
pm run build\

Closes #151