### PR TITLE
feat: persist private developer contacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ COSMOS_KEY=your_cosmos_primary_or_secondary_key
 COSMOS_DATABASE=devglobe
 COSMOS_CONTAINER=developers
 COSMOS_ACTIVITY_CONTAINER=activities
+COSMOS_CONTACTS_CONTAINER=developer-contacts
 
 # Protects the server-to-server global activity collector endpoint.
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

--- a/README.md
+++ b/README.md
@@ -204,11 +204,18 @@ Required environment variables:
 | `COSMOS_DATABASE` | Database name |
 | `COSMOS_CONTAINER` | Container name |
 | `COSMOS_ACTIVITY_CONTAINER` | Rolling GitHub activity container (`activities`) |
+| `COSMOS_CONTACTS_CONTAINER` | Private lifecycle-email contact container (`developer-contacts`) |
 | `ACTIVITY_INGEST_SECRET` | Bearer secret for the activity collector endpoint |
 | `RESEND_API_KEY` | Optional Resend API key for claim and approval emails |
 | `EMAIL_FROM` | Sender on a domain verified by Resend |
 
-Lifecycle emails are transactional and best-effort. Claims use the verified primary email authorized through GitHub OAuth; nomination approvals can use only an email made public on the nominee's GitHub profile. Recipient addresses are not stored in Cosmos DB. See the [lifecycle email PRD](docs/prd/lifecycle-email-notifications.md).
+Lifecycle emails are transactional and best-effort. Claims use the verified primary email authorized through GitHub OAuth; self-nominations collect an explicitly consented notification address. Addresses are stored only in the private `developer-contacts` container and are never projected by public APIs or copied into developer documents. Create the container before deployment:
+
+```bash
+npm run setup-contacts-container
+```
+
+See the [lifecycle email PRD](docs/prd/lifecycle-email-notifications.md).
 
 ### Live developer activity
 

--- a/app/api/auth/claim/route.js
+++ b/app/api/auth/claim/route.js
@@ -4,6 +4,7 @@ import { getSession } from '../../../../lib/auth.js';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { buildClaimWelcomeEmail, sendLifecycleEmail } from '../../../../lib/lifecycle-email.js';
+import { saveDeveloperContact } from '../../../../lib/developer-contact-store.js';
 
 const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
 const COSMOS_KEY = process.env.COSMOS_KEY;
@@ -120,6 +121,20 @@ export async function POST() {
       }
 
       await container.items.upsert(dev);
+
+      if (session.email) {
+        try {
+          await saveDeveloperContact({
+            login: dev.login,
+            email: session.email,
+            source: 'github-oauth',
+            emailVerified: true,
+            transactionalEmailsEnabled: true,
+          });
+        } catch (contactError) {
+          console.error('Claim contact storage failed:', contactError.message);
+        }
+      }
 
       if (!wasClaimed) {
         try {

--- a/app/api/nominate/route.js
+++ b/app/api/nominate/route.js
@@ -2,7 +2,7 @@
  * Next.js API route — "Add me to DevGlobe" self-nomination
  *
  * Endpoint: POST /api/nominate
- * Body: { username: string, location?: string }
+ * Body: { username: string, location?: string, email: string, emailConsent: true }
  *
  * Validates the GitHub username via the GitHub API and stores the
  * nomination in the Cosmos DB 'nominations' container for admin review.
@@ -11,7 +11,7 @@ import { NextResponse } from 'next/server';
 import { submitNomination } from '../../../lib/nominate.js';
 
 export async function POST(request) {
-  const { username, location } = await request.json().catch(() => ({}));
-  const result = await submitNomination({ username, location });
+  const { username, location, email, emailConsent } = await request.json().catch(() => ({}));
+  const result = await submitNomination({ username, location, email, emailConsent });
   return NextResponse.json(result.body, { status: result.status });
 }

--- a/components/AddMeModal.jsx
+++ b/components/AddMeModal.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styles from './AddMeModal.module.css';
 
-const SUCCESS_MESSAGE = "Your profile is pending review. It will appear on the globe and in search after approval, usually within a week.";
+const SUCCESS_MESSAGE = "Your profile is pending review. We'll email you when it is approved and visible on the globe, usually within a week.";
 
 export default function AddMeModal({ onClose }) {
   const [username, setUsername] = useState('');
   const [location, setLocation] = useState('');
+  const [email, setEmail] = useState('');
+  const [emailConsent, setEmailConsent] = useState(false);
   const [status, setStatus] = useState('idle'); // idle | submitting | success | error
   const [error, setError] = useState('');
   const inputRef = useRef(null);
@@ -29,6 +31,11 @@ export default function AddMeModal({ onClose }) {
       setError('Please enter your GitHub username.');
       return;
     }
+    if (!email.trim() || !emailConsent) {
+      setStatus('error');
+      setError('Enter your email and agree to receive nomination updates.');
+      return;
+    }
 
     setStatus('submitting');
     setError('');
@@ -36,7 +43,12 @@ export default function AddMeModal({ onClose }) {
       const res = await fetch('/api/nominate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: clean, location: location.trim() }),
+        body: JSON.stringify({
+          username: clean,
+          location: location.trim(),
+          email: email.trim(),
+          emailConsent,
+        }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -97,6 +109,30 @@ export default function AddMeModal({ onClose }) {
                 onChange={(e) => setLocation(e.target.value)}
                 autoComplete="off"
               />
+
+              <label className={styles['modal__label']} htmlFor="nominate-email">
+                Email <span className={styles['modal__required']}>*</span>
+              </label>
+              <input
+                id="nominate-email"
+                className={styles['modal__input']}
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+              />
+
+              <label className={styles['modal__consent']}>
+                <input
+                  type="checkbox"
+                  checked={emailConsent}
+                  onChange={(e) => setEmailConsent(e.target.checked)}
+                  required
+                />
+                <span>Email me about this nomination and essential DevGlobe profile updates.</span>
+              </label>
 
               {status === 'error' && <div className={styles['modal__error']}>{error}</div>}
 

--- a/components/AddMeModal.module.css
+++ b/components/AddMeModal.module.css
@@ -104,6 +104,24 @@
   border-color: var(--accent-blue);
 }
 
+.modal__consent {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  align-items: start;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  cursor: pointer;
+}
+
+.modal__consent input {
+  width: 16px;
+  height: 16px;
+  margin: 1px 0 0;
+  accent-color: var(--accent-blue);
+}
+
 .modal__error {
   padding: 10px 12px;
   background: rgba(239, 68, 68, 0.12);

--- a/docs/prd/lifecycle-email-notifications.md
+++ b/docs/prd/lifecycle-email-notifications.md
@@ -20,13 +20,13 @@ Claimed and newly approved developers receive no follow-up after the lifecycle a
 - Confirm successful claims and nomination approvals outside the browser.
 - Link recipients directly to their public developer profile.
 - Introduce profile controls and AI collaboration features without a marketing sequence.
-- Use email addresses transiently and never add them to developer documents.
+- Store addresses only in a dedicated private contact container and never add them to developer documents.
 - Keep core lifecycle writes independent from provider availability.
 
 ## Non-goals
 
 - Marketing campaigns, newsletters, drip sequences, or bulk email.
-- Persisting email addresses in Cosmos DB.
+- Marketing use of lifecycle contact addresses without separate opt-in.
 - Discovering a nomination email that is private on GitHub.
 - Retrying failed delivery or building a durable email outbox in this phase.
 - Email preference management beyond these transactional lifecycle messages.
@@ -35,20 +35,21 @@ Claimed and newly approved developers receive no follow-up after the lifecycle a
 
 ### First profile claim
 
-After the developer document is successfully created or transitions from unclaimed to claimed, DevGlobe sends a welcome email to the verified primary address returned by the authenticated GitHub `user:email` scope. Repeated claims do not trigger another message.
+After the developer document is successfully created or transitions from unclaimed to claimed, DevGlobe stores and sends to the verified primary address returned by the authenticated GitHub `user:email` scope. Repeated claims do not trigger another message.
 
 The message confirms ownership and links to the profile, activity, rankings, and AI collaboration settings.
 
 ### First nomination approval
 
-After the review command completes fresh GitHub enrichment and atomically transitions a pending nomination to approved, DevGlobe sends an approval email when the GitHub profile exposes a public email address. Refreshing an already approved profile does not trigger another message.
+The self-nomination form requires a notification email and explicit consent for nomination and essential profile updates. The address is stored separately from the public nomination. After review completes fresh GitHub enrichment and atomically transitions a pending nomination to approved, DevGlobe sends the approval email to that private contact. Refreshing an already approved profile does not trigger another message.
 
-GitHub does not expose another user's private email to an administrative token. A nominee with no public profile email is therefore skipped until a future consent-based collection flow exists.
+Nomination addresses are not treated as identity-verified. A later authenticated claim replaces the stored address with the verified primary GitHub OAuth address while preserving separate product-update preferences.
 
 ## Functional Requirements
 
 - Use the Resend email API without adding an SDK dependency.
 - Configure delivery with `RESEND_API_KEY` and `EMAIL_FROM`.
+- Store lifecycle contacts in `COSMOS_CONTACTS_CONTAINER` with partition key `/id`.
 - Include both plain-text and escaped HTML bodies.
 - Display the hosted DevGlobe logo with fixed email-safe dimensions.
 - Use `/developer/{login}` as the primary call to action.
@@ -60,9 +61,11 @@ GitHub does not expose another user's private email to an administrative token. 
 
 ## Privacy And Security
 
-- Claim email is read from the signed GitHub OAuth session and used only for immediate delivery.
-- Nomination email is read from the freshly fetched public GitHub profile and used only for immediate delivery.
+- Claim email is read from the signed GitHub OAuth session and stored as verified OAuth contact data.
+- Nomination email requires explicit lifecycle consent and is stored as unverified self-nomination contact data.
+- Contact records default product-update consent to false.
 - Developer records, public APIs, activity records, and logs do not contain recipient addresses.
+- The private contact container supports point reads only and excludes document fields from indexing.
 - HTML interpolations are escaped and profile path segments are URL encoded.
 - The Resend API key remains server-side.
 
@@ -105,7 +108,8 @@ Provider logs supply initial delivery visibility. Product analytics and durable 
 ## Rollout
 
 1. Create a Resend account and verify the sending domain.
-2. Configure `RESEND_API_KEY` and a verified `EMAIL_FROM` value in Vercel and the review-script environment.
-3. Deploy and test with one controlled first claim and one controlled nomination approval.
-4. Monitor Resend delivery logs and application errors.
-5. Add durable notification events, retries, and preference controls only if delivery volume warrants them.
+2. Run `npm run setup-contacts-container` against the target Cosmos database.
+3. Configure `RESEND_API_KEY`, a verified `EMAIL_FROM`, and `COSMOS_CONTACTS_CONTAINER` in Vercel and the review-script environment.
+4. Deploy and test with one controlled first claim and one controlled nomination approval.
+5. Monitor Resend delivery logs and application errors.
+6. Add durable notification events, retries, verification, and preference controls only if delivery volume warrants them.

--- a/lib/developer-contact-store.js
+++ b/lib/developer-contact-store.js
@@ -1,0 +1,69 @@
+import { getCosmosContainer } from './cosmos.js';
+
+const CONTACT_SOURCES = new Set(['github-oauth', 'self-nomination']);
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export class DeveloperContactValidationError extends Error {}
+
+export function normalizeContactEmail(value) {
+  const email = String(value || '').trim().toLowerCase();
+  if (!email || email.length > 254 || !EMAIL_PATTERN.test(email)) {
+    throw new DeveloperContactValidationError('Please enter a valid email address.');
+  }
+  return email;
+}
+
+export function buildDeveloperContact(input, existing = null, now = new Date().toISOString()) {
+  const login = String(input.login || '').trim();
+  const id = login.toLowerCase();
+  if (!id) throw new DeveloperContactValidationError('GitHub login is required.');
+  if (!CONTACT_SOURCES.has(input.source)) {
+    throw new DeveloperContactValidationError('Unsupported email source.');
+  }
+
+  const email = normalizeContactEmail(input.email);
+  const sameVerifiedEmail = existing?.email === email && existing?.emailVerified === true;
+
+  return {
+    id,
+    login,
+    email,
+    emailVerified: input.emailVerified === true || sameVerifiedEmail,
+    source: input.source,
+    transactionalEmailsEnabled: input.transactionalEmailsEnabled === true,
+    productUpdatesEnabled: existing?.email === email && existing?.productUpdatesEnabled === true,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  };
+}
+
+function getContactContainer() {
+  return getCosmosContainer(process.env.COSMOS_CONTACTS_CONTAINER || 'developer-contacts');
+}
+
+async function readExistingContact(container, id) {
+  try {
+    const { resource } = await container.item(id, id).read();
+    return resource || null;
+  } catch (error) {
+    if (error.code === 404) return null;
+    throw error;
+  }
+}
+
+export async function saveDeveloperContact(input, options = {}) {
+  const container = options.container === undefined ? getContactContainer() : options.container;
+  if (!container) return { saved: false, reason: 'not_configured' };
+
+  const id = String(input.login || '').trim().toLowerCase();
+  const existing = id ? await readExistingContact(container, id) : null;
+  const document = buildDeveloperContact(input, existing, options.now);
+  const { resource } = await container.items.upsert(document);
+  return { saved: true, contact: resource || document };
+}
+
+export async function getDeveloperContact(login, options = {}) {
+  const container = options.container === undefined ? getContactContainer() : options.container;
+  if (!container || !login) return null;
+  return readExistingContact(container, String(login).trim().toLowerCase());
+}

--- a/lib/nominate.js
+++ b/lib/nominate.js
@@ -28,6 +28,11 @@
  *   6. Upsert one developer document with `nomination.status = 'pending'`.
  */
 import { CosmosClient } from '@azure/cosmos';
+import {
+  DeveloperContactValidationError,
+  normalizeContactEmail,
+  saveDeveloperContact,
+} from './developer-contact-store.js';
 
 const DATABASE = 'devglobe';
 const DEVELOPERS_CONTAINER = 'developers';
@@ -314,7 +319,7 @@ export async function patchDeveloperNomination(container, doc, updates) {
   return resource;
 }
 
-export async function submitNomination({ username, location }) {
+export async function submitNomination({ username, location, email, emailConsent }) {
   if (!process.env.COSMOS_ENDPOINT || !process.env.COSMOS_KEY) {
     return { status: 500, body: { error: 'Cosmos DB credentials not configured' } };
   }
@@ -325,6 +330,20 @@ export async function submitNomination({ username, location }) {
       status: 400,
       body: { error: 'Please enter a valid GitHub username (letters, numbers, hyphens).' },
     };
+  }
+
+  if (emailConsent !== true) {
+    return { status: 400, body: { error: 'Email consent is required for nomination updates.' } };
+  }
+
+  let contactEmail;
+  try {
+    contactEmail = normalizeContactEmail(email);
+  } catch (error) {
+    if (error instanceof DeveloperContactValidationError) {
+      return { status: 400, body: { error: error.message } };
+    }
+    throw error;
   }
 
   let ghUser;
@@ -362,6 +381,13 @@ export async function submitNomination({ username, location }) {
     }
 
     if (existing && existing.nomination?.status === 'pending') {
+      await saveDeveloperContact({
+        login: existing.login,
+        email: contactEmail,
+        source: 'self-nomination',
+        emailVerified: false,
+        transactionalEmailsEnabled: true,
+      });
       // Idempotent: repeating the same request shouldn't error or duplicate.
       return {
         status: 200,
@@ -413,6 +439,13 @@ export async function submitNomination({ username, location }) {
     };
 
     await container.items.upsert(doc);
+    await saveDeveloperContact({
+      login: enriched.login,
+      email: contactEmail,
+      source: 'self-nomination',
+      emailVerified: false,
+      transactionalEmailsEnabled: true,
+    });
 
     return {
       status: 201,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "populate-special-tags": "node scripts/populate-special-tags.js",
     "setup-activity-container": "node scripts/setup-activity-container.js",
     "setup-introductions-container": "node scripts/setup-introductions-container.js",
+    "setup-contacts-container": "node scripts/setup-contacts-container.js",
     "create-agent-key": "node scripts/create-agent-key.js",
     "review-nominations": "node scripts/review-nominations.js",
     "seed-emulator": "node scripts/seed-emulator.js"

--- a/scripts/review-nominations.js
+++ b/scripts/review-nominations.js
@@ -25,6 +25,7 @@ import {
   geocodeLocation,
 } from '../lib/nominate.js';
 import { buildNominationApprovedEmail, sendLifecycleEmail } from '../lib/lifecycle-email.js';
+import { getDeveloperContact } from '../lib/developer-contact-store.js';
 
 dotenv.config({ path: '.env.local' });
 dotenv.config();
@@ -141,9 +142,17 @@ async function approve(container, username, reviewer, refresh = false) {
   }
 
   if (!refresh) {
+    let recipient = ghUser.email;
+    try {
+      const contact = await getDeveloperContact(dev.login);
+      if (contact?.transactionalEmailsEnabled) recipient = contact.email;
+    } catch (contactError) {
+      console.error(`  Private contact lookup failed: ${contactError.message}`);
+    }
+
     try {
       await sendLifecycleEmail({
-        to: ghUser.email,
+        to: recipient,
         message: buildNominationApprovedEmail({ login: dev.login, name: enriched.name }),
         idempotencyKey: `nomination-approved-${dev.login.toLowerCase()}-${Date.parse(dev.nomination.submittedAt)}`,
       });

--- a/scripts/setup-contacts-container.js
+++ b/scripts/setup-contacts-container.js
@@ -1,0 +1,27 @@
+import 'dotenv/config';
+import { CosmosClient } from '@azure/cosmos';
+
+const endpoint = process.env.COSMOS_ENDPOINT?.trim();
+const key = process.env.COSMOS_KEY?.trim();
+const databaseId = process.env.COSMOS_DATABASE || 'devglobe';
+const containerId = process.env.COSMOS_CONTACTS_CONTAINER || 'developer-contacts';
+
+if (!endpoint || !key) {
+  console.error('COSMOS_ENDPOINT and COSMOS_KEY are required.');
+  process.exit(1);
+}
+
+const client = new CosmosClient({ endpoint, key });
+const database = client.database(databaseId);
+const { resource, statusCode } = await database.containers.createIfNotExists({
+  id: containerId,
+  partitionKey: { paths: ['/id'], kind: 'Hash' },
+  indexingPolicy: {
+    indexingMode: 'consistent',
+    automatic: true,
+    includedPaths: [],
+    excludedPaths: [{ path: '/*' }],
+  },
+});
+
+console.log(`${statusCode === 201 ? 'Created' : 'Verified'} private container ${databaseId}/${resource.id}.`);

--- a/tests/developer-contact-store.test.js
+++ b/tests/developer-contact-store.test.js
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DeveloperContactValidationError,
+  buildDeveloperContact,
+  getDeveloperContact,
+  normalizeContactEmail,
+  saveDeveloperContact,
+} from '../lib/developer-contact-store.js';
+
+const timestamp = '2026-08-14T12:00:00.000Z';
+
+function fakeContainer(existing = null) {
+  let saved;
+  return {
+    item: () => ({
+      read: async () => {
+        if (!existing) throw Object.assign(new Error('Not found'), { code: 404 });
+        return { resource: existing };
+      },
+    }),
+    items: {
+      upsert: async document => {
+        saved = document;
+        return { resource: document };
+      },
+    },
+    get saved() { return saved; },
+  };
+}
+
+test('normalizes and validates contact email', () => {
+  assert.equal(normalizeContactEmail(' Dev@Example.COM '), 'dev@example.com');
+  assert.throws(() => normalizeContactEmail('not-an-email'), DeveloperContactValidationError);
+});
+
+test('builds a private nomination contact without product marketing consent', () => {
+  assert.deepEqual(buildDeveloperContact({
+    login: 'OctoCat',
+    email: 'dev@example.com',
+    source: 'self-nomination',
+    emailVerified: false,
+    transactionalEmailsEnabled: true,
+  }, null, timestamp), {
+    id: 'octocat',
+    login: 'OctoCat',
+    email: 'dev@example.com',
+    emailVerified: false,
+    source: 'self-nomination',
+    transactionalEmailsEnabled: true,
+    productUpdatesEnabled: false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+});
+
+test('verified OAuth contact replaces nomination email and resets address-specific preferences', () => {
+  const existing = {
+    id: 'octocat',
+    login: 'OctoCat',
+    email: 'old@example.com',
+    emailVerified: false,
+    source: 'self-nomination',
+    transactionalEmailsEnabled: true,
+    productUpdatesEnabled: true,
+    createdAt: '2026-08-13T12:00:00.000Z',
+  };
+
+  const contact = buildDeveloperContact({
+    login: 'OctoCat',
+    email: 'verified@example.com',
+    source: 'github-oauth',
+    emailVerified: true,
+    transactionalEmailsEnabled: true,
+  }, existing, timestamp);
+
+  assert.equal(contact.email, 'verified@example.com');
+  assert.equal(contact.emailVerified, true);
+  assert.equal(contact.productUpdatesEnabled, false);
+  assert.equal(contact.createdAt, existing.createdAt);
+});
+
+test('saves and point-reads contacts by normalized login', async () => {
+  const container = fakeContainer();
+  const result = await saveDeveloperContact({
+    login: 'OctoCat',
+    email: 'dev@example.com',
+    source: 'github-oauth',
+    emailVerified: true,
+    transactionalEmailsEnabled: true,
+  }, { container, now: timestamp });
+
+  assert.equal(result.saved, true);
+  assert.equal(container.saved.id, 'octocat');
+
+  const storedContainer = fakeContainer(container.saved);
+  assert.deepEqual(await getDeveloperContact('OCTOCAT', { container: storedContainer }), container.saved);
+});
+
+test('skips persistence when Cosmos is not configured', async () => {
+  assert.deepEqual(await saveDeveloperContact({ login: 'octocat' }, { container: null }), {
+    saved: false,
+    reason: 'not_configured',
+  });
+});

--- a/tests/nomination-contact.test.js
+++ b/tests/nomination-contact.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { submitNomination } from '../lib/nominate.js';
+
+async function withCosmosEnvironment(run) {
+  const originalEndpoint = process.env.COSMOS_ENDPOINT;
+  const originalKey = process.env.COSMOS_KEY;
+  process.env.COSMOS_ENDPOINT = 'https://example.documents.azure.com';
+  process.env.COSMOS_KEY = 'test-key';
+
+  try {
+    await run();
+  } finally {
+    if (originalEndpoint === undefined) delete process.env.COSMOS_ENDPOINT;
+    else process.env.COSMOS_ENDPOINT = originalEndpoint;
+    if (originalKey === undefined) delete process.env.COSMOS_KEY;
+    else process.env.COSMOS_KEY = originalKey;
+  }
+}
+
+test('requires explicit email consent before nomination network calls', async () => {
+  await withCosmosEnvironment(async () => {
+    const result = await submitNomination({
+      username: 'octocat',
+      email: 'dev@example.com',
+      emailConsent: false,
+    });
+
+    assert.equal(result.status, 400);
+    assert.match(result.body.error, /consent/i);
+  });
+});
+
+test('rejects invalid nomination email before network calls', async () => {
+  await withCosmosEnvironment(async () => {
+    const result = await submitNomination({
+      username: 'octocat',
+      email: 'not-an-email',
+      emailConsent: true,
+    });
+
+    assert.equal(result.status, 400);
+    assert.match(result.body.error, /valid email/i);
+  });
+});


### PR DESCRIPTION
### Summary
- Established a private Cosmos contact container for developer contact details.
- Verified OAuth email persistence on claims during authentication.
- Implemented consented email collection on self-nominations.
- Configured approval email delivery from private contacts list.
- Prevented public developer-document email exposure by separating private contacts.
- Handled environmental setup and updated developer/admin documentation.

### Testing
- Ran unit and integration tests: `npm test` (56 passed).
- Ensured successful compilation and optimization: `npm run build`.
- Validated nomination modal behavior and fields on both desktop and mobile layouts.

### Notes
- Follow-up to #151.
- Please do not merge yet.
