### PR TITLE
fix: use registered GitHub OAuth callback

### DIFF
--- a/app/api/auth/github/route.js
+++ b/app/api/auth/github/route.js
@@ -1,13 +1,7 @@
 import { NextResponse } from 'next/server';
-import { headers } from 'next/headers';
+import { buildGitHubAuthorizationUrl } from '../../../../lib/github-oauth.js';
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
-
-function getBaseUrl(hdrs) {
-  const host = hdrs.get('x-forwarded-host') || hdrs.get('host') || 'localhost:3000';
-  const proto = hdrs.get('x-forwarded-proto') || 'http';
-  return `${proto}://${host}`;
-}
 
 export async function GET() {
   if (!GITHUB_CLIENT_ID) {
@@ -17,16 +11,5 @@ export async function GET() {
     );
   }
 
-  const hdrs = await headers();
-  const baseUrl = getBaseUrl(hdrs);
-
-  const params = new URLSearchParams({
-    client_id: GITHUB_CLIENT_ID,
-    scope: 'read:user user:email',
-    redirect_uri: `${baseUrl}/api/auth/callback`,
-  });
-
-  return NextResponse.redirect(
-    `https://github.com/login/oauth/authorize?${params.toString()}`
-  );
+  return NextResponse.redirect(buildGitHubAuthorizationUrl(GITHUB_CLIENT_ID));
 }

--- a/lib/github-oauth.js
+++ b/lib/github-oauth.js
@@ -1,0 +1,6 @@
+export function buildGitHubAuthorizationUrl(clientId) {
+  const url = new URL('https://github.com/login/oauth/authorize');
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('scope', 'read:user user:email');
+  return url.toString();
+}

--- a/tests/github-oauth.test.js
+++ b/tests/github-oauth.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGitHubAuthorizationUrl } from '../lib/github-oauth.js';
+
+test('uses the callback registered on the GitHub OAuth application', () => {
+  const url = new URL(buildGitHubAuthorizationUrl('client-id'));
+
+  assert.equal(url.origin, 'https://github.com');
+  assert.equal(url.pathname, '/login/oauth/authorize');
+  assert.equal(url.searchParams.get('client_id'), 'client-id');
+  assert.equal(url.searchParams.get('scope'), 'read:user user:email');
+  assert.equal(url.searchParams.has('redirect_uri'), false);
+});


### PR DESCRIPTION
Follow/Sign in failed when a request-host-derived redirect_uri did not match the OAuth app callback; the fix omits redirect_uri so GitHub uses its registered callback. Validation: 97 tests passed and production build passed.