### PR TITLE
fix: scale impact history capture with Azure timer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Optional RU controls for the resumable impact snapshot job.
 IMPACT_HISTORY_CONCURRENCY=8
 IMPACT_HISTORY_BATCH_SIZE=500
+# Azure Timer Function setting; use your deployed application's URL.
+IMPACT_HISTORY_URL=https://www.devglobe.dev/api/cron/impact-history
 # GitHub API and nomination enrichment
 # Required for dataset scripts and complete self-nomination details.
 # Create at: https://github.com/settings/tokens
@@ -49,7 +51,7 @@ SESSION_SECRET=your_random_session_secret
 # EMAIL_FROM must use a sender/domain verified in Resend.
 RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 EMAIL_FROM=DevGlobe <hello@your-verified-domain.example>
-# Protects the weekly cron endpoint and is sent automatically by Vercel Cron.
+# Protects scheduled endpoints; configure the same value in Vercel and Azure Functions.
 CRON_SECRET=your_random_cron_secret
 # Signs one-click unsubscribe links; SESSION_SECRET is used when omitted.
 EMAIL_PREFERENCE_SECRET=your_random_email_preference_secret

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Optional RU controls for the resumable impact snapshot job.
+IMPACT_HISTORY_CONCURRENCY=8
+IMPACT_HISTORY_BATCH_SIZE=500
 # GitHub API and nomination enrichment
 # Required for dataset scripts and complete self-nomination details.
 # Create at: https://github.com/settings/tokens

--- a/README.md
+++ b/README.md
@@ -240,6 +240,17 @@ ACTIVITY_INGEST_SECRET=the-same-secret-configured-on-the-site
 
 The timer invokes the collector every minute, matching GitHub's advertised polling interval. GitHub's public Events API is best-effort and may delay or omit events; the 15-second browser refresh does not guarantee GitHub source delivery within that interval. A valid `GITHUB_TOKEN` is required for full three-page collection; anonymous fallback inspects one page only. The Cosmos activity container uses a 48-hour TTL while the API exposes only the latest 24 hours.
 
+### Impact history capture
+
+Deploy the `functions` directory to an Azure Function App and configure these application settings for the 15-minute impact-history timer:
+
+```env
+IMPACT_HISTORY_URL=https://www.devglobe.dev/api/cron/impact-history
+CRON_SECRET=the-same-secret-configured-in-vercel
+```
+
+The timer resumes the current UTC day's capture in RU-bounded batches. Keep `IMPACT_HISTORY_CONCURRENCY` and `IMPACT_HISTORY_BATCH_SIZE` on the Vercel application because the Next.js endpoint performs the Cosmos work.
+
 ## 🤝 Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and areas where help is needed.

--- a/docs/prd/developer-impact-history.md
+++ b/docs/prd/developer-impact-history.md
@@ -32,7 +32,7 @@ Snapshots contain only `login`, UTC day/time, score dimensions, aggregate stars/
 
 ## Capture
 
-Vercel invokes `/api/cron/impact-history` daily with `CRON_SECRET`. The job scores and ranks the complete public dataset once, adds rank within each primary language, writes snapshots, and publishes a deduplicated `rank_movement` feed event when global rank changes.
+Vercel invokes `/api/cron/impact-history` every 15 minutes with `CRON_SECRET`. The job scores and ranks the complete public dataset, then resumes an RU-bounded daily capture from persisted progress. Each invocation writes up to 500 idempotent snapshots and publishes a deduplicated `rank_movement` feed event when global rank changes. Repeated invocations complete the daily set without exceeding the function duration or overwhelming shared Cosmos throughput.
 
 ## History and deltas
 

--- a/docs/prd/developer-impact-history.md
+++ b/docs/prd/developer-impact-history.md
@@ -32,7 +32,7 @@ Snapshots contain only `login`, UTC day/time, score dimensions, aggregate stars/
 
 ## Capture
 
-Vercel invokes `/api/cron/impact-history` every 15 minutes with `CRON_SECRET`. The job scores and ranks the complete public dataset, then resumes an RU-bounded daily capture from persisted progress. Each invocation writes up to 500 idempotent snapshots and publishes a deduplicated `rank_movement` feed event when global rank changes. Repeated invocations complete the daily set without exceeding the function duration or overwhelming shared Cosmos throughput.
+An Azure Timer Function invokes `/api/cron/impact-history` every 15 minutes with `CRON_SECRET`. The job scores and ranks the complete public dataset, then resumes an RU-bounded daily capture from persisted progress. Each invocation writes up to 500 idempotent snapshots and publishes a deduplicated `rank_movement` feed event when global rank changes. Repeated invocations complete the daily set without exceeding the function duration or overwhelming shared Cosmos throughput.
 
 ## History and deltas
 

--- a/functions/impact-history/function.json
+++ b/functions/impact-history/function.json
@@ -1,0 +1,13 @@
+{
+  "bindings": [
+    {
+      "name": "timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */15 * * * *",
+      "runOnStartup": false,
+      "useMonitor": true
+    }
+  ],
+  "scriptFile": "index.js"
+}

--- a/functions/impact-history/index.js
+++ b/functions/impact-history/index.js
@@ -1,0 +1,20 @@
+module.exports = async function impactHistory(context) {
+  const endpoint = process.env.IMPACT_HISTORY_URL;
+  const secret = process.env.CRON_SECRET;
+  if (!endpoint || !secret) throw new Error('IMPACT_HISTORY_URL and CRON_SECRET are required');
+
+  const response = await fetch(endpoint, {
+    headers: { Authorization: `Bearer ${secret}` },
+  });
+  const result = await response.json();
+  context.log('DevGlobe impact history capture', {
+    status: response.status,
+    day: result.day,
+    snapshots: result.snapshots,
+    movements: result.movements,
+    processed: result.processed,
+    remaining: result.remaining,
+    complete: result.complete,
+  });
+  if (!response.ok) throw new Error(`Impact history capture returned ${response.status}`);
+};

--- a/lib/impact-history-capture.js
+++ b/lib/impact-history-capture.js
@@ -3,7 +3,42 @@ import { saveFeedEvents } from './feed-store.js';
 import { addDeveloperRanks } from './ranking.js';
 import { scoreAll } from './scoring.js';
 import { addLanguageRanks, createImpactSnapshot, createRankMovementEvent } from './impact-history.js';
-import { getLatestImpactSnapshot, saveImpactSnapshot } from './impact-history-store.js';
+import {
+  getImpactCaptureProgress,
+  getImpactSnapshotForDay,
+  getLatestImpactDayBefore,
+  saveImpactCaptureProgress,
+  saveImpactSnapshot,
+} from './impact-history-store.js';
+
+const DEFAULT_CONCURRENCY = 8;
+const MAX_CONCURRENCY = 64;
+const DEFAULT_BATCH_SIZE = 500;
+const MAX_BATCH_SIZE = 5000;
+
+function resolveConcurrency(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_CONCURRENCY;
+  return Math.min(parsed, MAX_CONCURRENCY);
+}
+
+function resolveBatchSize(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_BATCH_SIZE;
+  return Math.min(parsed, MAX_BATCH_SIZE);
+}
+
+async function runWithConcurrency(items, concurrency, callback) {
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      await callback(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+}
 
 async function listPublicDevelopers() {
   const container = getCosmosContainer();
@@ -15,17 +50,32 @@ async function listPublicDevelopers() {
 
 export async function captureImpactHistory(options = {}) {
   const now = options.now || new Date();
-  const developers = options.developers || await listPublicDevelopers();
-  const getPrevious = options.getPrevious || getLatestImpactSnapshot;
+  const developers = options.developers || await (options.loadDevelopers || listPublicDevelopers)();
+  const day = now.toISOString().slice(0, 10);
+  const managedRun = !options.developers;
+  const getProgress = options.getProgress || getImpactCaptureProgress;
+  const saveProgress = options.saveProgress || saveImpactCaptureProgress;
+  const progress = managedRun ? await getProgress(day) : null;
+  const previousDay = progress?.previousDay
+    ?? await (options.getPreviousDay || getLatestImpactDayBefore)(day);
   const saveSnapshot = options.saveSnapshot || saveImpactSnapshot;
   const saveEvents = options.saveEvents || saveFeedEvents;
-  const ranked = addLanguageRanks(addDeveloperRanks(scoreAll(developers)));
+  const concurrency = resolveConcurrency(options.concurrency || process.env.IMPACT_HISTORY_CONCURRENCY);
+  const batchSize = resolveBatchSize(options.batchSize || process.env.IMPACT_HISTORY_BATCH_SIZE);
+  const scored = scoreAll(developers).sort((left, right) => (
+    right.score - left.score || left.login.localeCompare(right.login)
+  ));
+  const ranked = addLanguageRanks(addDeveloperRanks(scored));
+  const startIndex = managedRun ? progress?.nextIndex || 0 : 0;
+  const batch = managedRun ? ranked.slice(startIndex, startIndex + batchSize) : ranked;
   let snapshots = 0;
   let movements = 0;
 
-  for (const developer of ranked) {
+  await runWithConcurrency(batch, concurrency, async developer => {
     const snapshot = createImpactSnapshot(developer, now.toISOString());
-    const previous = await getPrevious(snapshot.login, snapshot.day);
+    const previous = options.getPrevious
+      ? await options.getPrevious(snapshot.login, snapshot.day)
+      : await (options.getPreviousForDay || getImpactSnapshotForDay)(snapshot.login, previousDay);
     await saveSnapshot(snapshot);
     snapshots += 1;
 
@@ -36,6 +86,26 @@ export async function captureImpactHistory(options = {}) {
       });
       movements += result.inserted;
     }
-  }
-  return { developers: ranked.length, snapshots, movements, day: now.toISOString().slice(0, 10) };
+  });
+
+  if (!managedRun) return { developers: ranked.length, snapshots, movements, day };
+
+  const nextIndex = startIndex + batch.length;
+  const complete = nextIndex >= ranked.length;
+  await saveProgress({
+    captureDay: day,
+    previousDay,
+    nextIndex,
+    total: ranked.length,
+    complete,
+  });
+  return {
+    developers: ranked.length,
+    snapshots,
+    movements,
+    day,
+    processed: nextIndex,
+    remaining: Math.max(ranked.length - nextIndex, 0),
+    complete,
+  };
 }

--- a/lib/impact-history-store.js
+++ b/lib/impact-history-store.js
@@ -28,6 +28,68 @@ export async function getLatestImpactSnapshot(login, beforeDay = null) {
   return resources[0] || null;
 }
 
+export async function getLatestImpactDayBefore(day) {
+  const container = getHistoryContainer();
+  if (!container) {
+    return [...memorySnapshots.values()]
+      .map(snapshot => snapshot.day)
+      .filter(snapshotDay => snapshotDay < day)
+      .sort()
+      .at(-1);
+  }
+
+  const { resources: days } = await container.items.query({
+    query: 'SELECT TOP 1 VALUE c.day FROM c WHERE c.day < @day ORDER BY c.day DESC',
+    parameters: [{ name: '@day', value: day }],
+  }).fetchAll();
+  return days[0] || null;
+}
+
+export async function getImpactSnapshotForDay(login, day) {
+  if (!day) return null;
+  const normalizedLogin = String(login || '').toLowerCase();
+  const id = `${normalizedLogin}:${day}`;
+  const container = getHistoryContainer();
+  if (!container) return memorySnapshots.get(id) || null;
+  try {
+    const { resource } = await container.item(id, normalizedLogin).read();
+    return resource || null;
+  } catch (error) {
+    if (error.code === 404) return null;
+    throw error;
+  }
+}
+
+export async function getImpactCaptureProgress(day) {
+  const id = `capture:${day}`;
+  const container = getHistoryContainer();
+  if (!container) return memorySnapshots.get(id) || null;
+  try {
+    const { resource } = await container.item(id, '__capture__').read();
+    return resource || null;
+  } catch (error) {
+    if (error.code === 404) return null;
+    throw error;
+  }
+}
+
+export async function saveImpactCaptureProgress(progress) {
+  const document = {
+    id: `capture:${progress.captureDay}`,
+    login: '__capture__',
+    documentType: 'impact-capture-progress',
+    ...progress,
+    updatedAt: new Date().toISOString(),
+  };
+  const container = getHistoryContainer();
+  if (!container) {
+    memorySnapshots.set(document.id, document);
+    return document;
+  }
+  const { resource } = await container.items.upsert(document);
+  return resource || document;
+}
+
 export async function listImpactSnapshots(login, days = 90, now = new Date()) {
   const normalizedLogin = String(login || '').toLowerCase();
   const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();

--- a/tests/impact-history-function.test.js
+++ b/tests/impact-history-function.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const impactHistory = require('../functions/impact-history/index.js');
+
+test('Azure timer invokes the protected impact-history endpoint and logs progress', async t => {
+  t.mock.method(globalThis, 'fetch', async (url, options) => {
+    assert.equal(url, 'https://example.test/api/cron/impact-history');
+    assert.equal(options.headers.Authorization, 'Bearer cron-secret');
+    return new Response(JSON.stringify({
+      day: '2026-08-16', snapshots: 500, movements: 2,
+      processed: 2000, remaining: 24675, complete: false,
+    }));
+  });
+  t.mock.method(console, 'error', () => {});
+  process.env.IMPACT_HISTORY_URL = 'https://example.test/api/cron/impact-history';
+  process.env.CRON_SECRET = 'cron-secret';
+  const entries = [];
+
+  await impactHistory({ log: (...args) => entries.push(args) });
+
+  assert.equal(entries[0][0], 'DevGlobe impact history capture');
+  assert.equal(entries[0][1].processed, 2000);
+});
+
+test('Azure timer rejects non-success responses', async t => {
+  t.mock.method(globalThis, 'fetch', async () => new Response(
+    JSON.stringify({ error: 'Impact history capture failed' }),
+    { status: 500 },
+  ));
+  process.env.IMPACT_HISTORY_URL = 'https://example.test/api/cron/impact-history';
+  process.env.CRON_SECRET = 'cron-secret';
+
+  await assert.rejects(
+    impactHistory({ log: () => {} }),
+    /Impact history capture returned 500/,
+  );
+});

--- a/tests/impact-history.test.js
+++ b/tests/impact-history.test.js
@@ -78,3 +78,69 @@ test('capture stores ranked snapshots and publishes privacy-aware movement event
   assert.equal(events[0].options.isPublicDeveloper, true);
   assert.equal(events[1].options.isPublicDeveloper, false);
 });
+
+test('capture bounds concurrent snapshot operations', async () => {
+  let active = 0;
+  let peak = 0;
+  const developers = Array.from({ length: 12 }, (_, index) => ({
+    login: `developer-${index}`,
+    totalStars: index,
+  }));
+
+  await captureImpactHistory({
+    developers,
+    concurrency: 3,
+    getPrevious: async () => null,
+    saveSnapshot: async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      active -= 1;
+    },
+  });
+
+  assert.equal(peak, 3);
+});
+
+test('capture uses the latest completed day for previous snapshots', async () => {
+  let previousDayLoads = 0;
+  const snapshots = [];
+
+  await captureImpactHistory({
+    now: new Date('2026-08-17T14:00:00.000Z'),
+    developers: [{ login: 'a' }, { login: 'b' }],
+    getPreviousDay: async day => {
+      previousDayLoads += 1;
+      assert.equal(day, '2026-08-17');
+      return '2026-08-16';
+    },
+    getPreviousForDay: async login => ({ login, globalRank: login === 'a' ? 2 : 1 }),
+    saveSnapshot: async snapshot => snapshots.push(snapshot),
+    saveEvents: async () => ({ inserted: 1 }),
+  });
+
+  assert.equal(previousDayLoads, 1);
+  assert.equal(snapshots.length, 2);
+});
+
+test('managed capture resumes from persisted progress', async () => {
+  const savedProgress = [];
+  const snapshots = [];
+  const developers = Array.from({ length: 5 }, (_, index) => ({ login: `dev-${index}` }));
+
+  const summary = await captureImpactHistory({
+    loadDevelopers: async () => developers,
+    batchSize: 2,
+    getProgress: async () => ({ nextIndex: 2, previousDay: null }),
+    saveProgress: async progress => savedProgress.push(progress),
+    getPreviousDay: async () => null,
+    getPreviousForDay: async () => null,
+    saveSnapshot: async snapshot => snapshots.push(snapshot),
+  });
+
+  assert.equal(summary.snapshots, 2);
+  assert.equal(summary.processed, 4);
+  assert.equal(summary.remaining, 1);
+  assert.equal(summary.complete, false);
+  assert.equal(savedProgress[0].nextIndex, 4);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -5,10 +5,6 @@
     {
       "path": "/api/cron/weekly-digest",
       "schedule": "0 13 * * 1"
-    },
-    {
-      "path": "/api/cron/impact-history",
-      "schedule": "*/15 * * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "/api/cron/impact-history",
-      "schedule": "0 14 * * *"
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
This pull request scales the impact history capture system.

Key features:
- Processes users in resumable 500-profile batches to avoid timeouts.
- Uses bounded concurrency for efficient API calls without hitting resource limits.
- Progress is saved using persisted progress.
- An Azure Timer every 15 minutes replacing Hobby-incompatible Vercel cron.
- External dependencies configured via Function App settings IMPACT_HISTORY_URL and CRON_SECRET.
- Validation: 102 tests/build passed successfully.