### PR TITLE
fix: extend Azure Function timeout for impact capture

### DIFF
--- a/functions/host.json
+++ b/functions/host.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "functionTimeout": "00:00:15",
+  "functionTimeout": "00:05:00",
   "logging": {
     "applicationInsights": {
       "samplingSettings": {


### PR DESCRIPTION
explain shared host timeout increases from 15 seconds to 5 minutes so the Azure timer can await one resumable impact-history batch; validation JSON parse, 2 timer tests, diff check. Do not merge.