### PR TITLE
fix: link landing page to impact history

### DIFF
--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -192,6 +192,7 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, claimedLogi
               {merged.soUserId && (
                 <a href={`https://stackoverflow.com/users/${merged.soUserId}`} target="_blank" rel="noreferrer">StackOverflow ↗</a>
               )}
+                <a href={`/developer/${encodeURIComponent(dev.login)}`}>Impact History</a>
                 <a href={`/share/${encodeURIComponent(dev.login)}#get-your-badge`} target="_blank" rel="noopener noreferrer">Get Badge ↗</a>
                 <button
                 className="btn btn--share"


### PR DESCRIPTION
Selecting a developer from the globe or leaderboard now exposes an Impact History link to the developer detail route. Validation: production build passed and git diff check passed.