### PR TITLE
fix: restore Vercel deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,8 @@ jobs:
           node-version: 22
           cache: npm
 
-        - name: Use repository npm version
-          run: npm install --global npm@11.14.1
+      - name: Use repository npm version
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
the npm-version step was incorrectly nested under setup-node.with, the YAML now parses with separate ordered steps, and temp-query.js is excluded.