### PR TITLE
feat: replace Product Hunt badge with Spacerr

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -490,16 +490,16 @@ export default function Home() {
         onClose={completeTour}
       />
       <a
-        className="product-hunt-badge"
-        href="https://www.producthunt.com/products/devglobe-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-devglobe-2"
+        className="spacerr-badge"
+        href="https://spacerrapps.com/apps/devglobe?utm_source=badge&amp;utm_medium=referral&amp;utm_campaign=featured"
         target="_blank"
         rel="noopener noreferrer"
       >
         <img
-          alt="DevGlobe - Discover top open source devs on an interactive 3D globe | Product Hunt"
-          width="250"
+          alt="DevGlobe is featured on Spacerr"
+          width="192"
           height="54"
-          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1216204&amp;theme=light&amp;t=1785998968385"
+          src="https://spacerrapps.com/badge/devglobe.svg?theme=dark"
         />
       </a>
       <main className="main">

--- a/styles/main.css
+++ b/styles/main.css
@@ -712,7 +712,7 @@ body {
   background: var(--overlay-subtle-strong);
 }
 
-.tour-active .product-hunt-badge {
+.tour-active .spacerr-badge {
   visibility: hidden;
 }
 
@@ -764,17 +764,17 @@ body {
   object-fit: cover;
 }
 
-.product-hunt-badge {
+.spacerr-badge {
   position: fixed;
   bottom: 64px;
   left: 24px;
   z-index: 39;
   display: block;
-  width: 250px;
+  width: 192px;
   height: 54px;
 }
 
-.product-hunt-badge img {
+.spacerr-badge img {
   display: block;
   width: 100%;
   height: 100%;
@@ -3559,7 +3559,7 @@ body {
     min-width: 32px;
     padding: 0;
   }
-  .product-hunt-badge {
+  .spacerr-badge {
     display: none;
   }
 }


### PR DESCRIPTION
## Description
This PR replaces the Product Hunt badge with the Spacerr badge, preserving all tour/mobile behavior, size, and layout integration.

### Details:
- Spacerr URL: https://spacerrapps.com/apps/devglobe?utm_source=badge&utm_medium=referral&utm_campaign=featured
- Spacerr Image: https://spacerrapps.com/badge/devglobe.svg?theme=dark
- Dimensions: 192x54 px (stretching properties configured properly in CSS & JSX)
- Preserved Tour/Mobile Behavior: Tour hides badge (.tour-active .spacerr-badge { visibility: hidden; }) and is display: none; on screens <= 1199px (styles/main.css)

### Validation:
- 149 tests pass successfully
- Production build passes
- Diagnostics are clean
- SVG loads at 192x54 successfully
- Desktop placement verified at bottom: 64px, left: 24px, z-index: 39