### PR TITLE
chore: remove obsolete Vercel references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,7 @@ SESSION_SECRET=your_random_session_secret
 # EMAIL_FROM must use a sender/domain verified in Resend.
 RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 EMAIL_FROM=DevGlobe <hello@your-verified-domain.example>
-# Protects scheduled endpoints; configure the same value in Vercel and Azure Functions.
+# Protects scheduled endpoints; configure the same value in Container Apps and Azure Functions.
 CRON_SECRET=your_random_cron_secret
 # Signs one-click unsubscribe links; SESSION_SECRET is used when omitted.
 EMAIL_PREFERENCE_SECRET=your_random_email_preference_secret

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The app runs with sample data out of the box — no API keys needed for developm
 │   ├── enrich-and-upload.js# SO enrichment + geocoding + Cosmos DB
 │   └── build-dataset.js    # Pipeline orchestrator
 ├── api/
-│   └── developers.js       # Vercel serverless endpoint
+│   └── developers.js       # Developer API endpoint
 └── data/
     └── developers-sample.json  # Sample data for local dev
 ```

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The command preserves existing tags and is idempotent. Other credentials require
 ```
 ├── index.html                  # Entry HTML
 ├── src/
-│   ├── main.jsx                # App bootstrap + Vercel Analytics
+│   ├── main.jsx                # Application bootstrap
 │   ├── App.jsx                 # Root component, data loading
 │   ├── components/
 │   │   ├── Globe.jsx           # 3D globe (react-globe.gl)

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -38,4 +38,4 @@ features:
 
 ## Two deployments, one product
 
-The interactive Next.js application runs at [www.devglobe.dev](https://www.devglobe.dev) on Vercel. This static documentation site is published independently through GitHub Pages so reference material remains fast, indexable, and available without application credentials.
+The interactive Next.js application runs at [www.devglobe.dev](https://www.devglobe.dev) on Azure Container Apps. This static documentation site is published independently through GitHub Pages so reference material remains fast, indexable, and available without application credentials.

--- a/docs-site/reference/architecture.md
+++ b/docs-site/reference/architecture.md
@@ -13,14 +13,14 @@ flowchart LR
   SO[Stack Overflow API] --> P
   P --> C[(Azure Cosmos DB)]
   C --> N[Next.js API and MCP]
-  N --> V[Vercel application]
-  V --> H[Human users]
+  N --> CA[Azure Container Apps]
+  CA --> H[Human users]
   N --> A[AI agents]
   R[Repository Markdown] --> VP[VitePress build]
   VP --> GP[GitHub Pages docs]
 ```
 
-The React 19 and Next.js 15 application runs on Vercel. Azure Cosmos DB stores indexed profiles, vector embeddings, activity, private user-scoped features, and consent records in separate containers. Azure Functions invoke scheduled ingestion and snapshot endpoints. Documentation is a static VitePress artifact deployed independently to GitHub Pages.
+The React 19 and Next.js 15 application runs on Azure Container Apps. Azure Cosmos DB stores indexed profiles, vector embeddings, activity, private user-scoped features, and consent records in separate containers. Azure Functions serve high-volume public reads and run scheduled ingestion, snapshot, and lifecycle tasks. Documentation is a static VitePress artifact deployed independently to GitHub Pages.
 
 ## Data sources
 

--- a/docs-site/reference/development.md
+++ b/docs-site/reference/development.md
@@ -1,6 +1,6 @@
 ---
 title: Development and deployment
-description: Run DevGlobe locally, build the documentation, and understand Vercel and GitHub Pages deployments.
+description: Run DevGlobe locally, build the documentation, and understand Azure and GitHub Pages deployments.
 ---
 
 # Development and deployment
@@ -32,7 +32,8 @@ Set `DOCS_BASE=/` for a future custom documentation domain. Set `DOCS_SITE_URL` 
 
 | Surface | Host | Workflow |
 |---|---|---|
-| Dynamic application and APIs | Vercel | `.github/workflows/deploy.yml` |
+| Dynamic application and private APIs | Azure Container Apps | `.github/workflows/deploy.yml` |
+| Public read APIs and scheduled tasks | Azure Functions | `.github/workflows/deploy-azure-functions.yml` |
 | Static documentation | GitHub Pages | `.github/workflows/docs-pages.yml` |
 
 The Pages workflow builds on pull requests and deploys only pushes to `main`. It does not export or replace the dynamic application.

--- a/docs/azure-backend.md
+++ b/docs/azure-backend.md
@@ -1,6 +1,6 @@
 # Azure Backend
 
-DevGlobe uses Vercel for the Next.js frontend and Azure for high-volume public reads and scheduled ingestion.
+DevGlobe runs the Next.js application on Azure Container Apps, with Azure Functions handling high-volume public reads and scheduled work.
 
 ## Traffic split
 
@@ -15,36 +15,41 @@ Azure Functions serves:
 - GitHub activity ingestion every five minutes
 - Hourly generation of the compressed developer snapshot
 
-Azure Blob Storage serves `developers.json` directly to browsers. Vercel remains responsible for OAuth, private account mutations, nominations, cards, share metadata, and the frontend.
+Azure Blob Storage serves `developers.json` directly to browsers. Azure Container Apps serves the frontend, OAuth, private account mutations, nominations, cards, share metadata, and MCP endpoint.
 
 ## Azure resources
 
-The current deployment reuses these Consumption resources in `devglobe-rg`:
+The deployment uses these resources in `devglobe-rg`:
 
+- Container App: `devglobe-web`
+- Container Apps environment: `devglobe-env`
+- Container registry: `devglobewebacr`
 - Function App: `devglobe-public-api`
 - Storage account: `devglobeactivityfn`
 - Static website endpoint: `https://devglobeactivityfn.z13.web.core.windows.net/`
 
-The Function App requires the existing Cosmos, GitHub, and Azure OpenAI application settings. Never place those values in public frontend variables.
+The Container App and Function App require their existing Cosmos, GitHub, and Azure OpenAI application settings. Never place secrets in public frontend variables or image build arguments.
 
 ## Frontend configuration
 
-Configure Production and Preview environments in Vercel:
+The Container Apps deployment workflow supplies these public values while building the Next.js image:
 
 ```env
 NEXT_PUBLIC_API_URL=https://devglobe-public-api.azurewebsites.net
 NEXT_PUBLIC_DEVELOPER_SNAPSHOT_URL=https://devglobeactivityfn.z13.web.core.windows.net/developers.json
 ```
 
-The browser calls Azure directly. Do not configure a Vercel rewrite or proxy because proxied responses still consume Vercel transfer and invocation allowances.
+The browser calls Azure Functions and Blob Storage directly. Their CORS rules must allow the production application origin.
 
 ## Custom domain
 
-After adding DNS at the current `devglobe.dev` DNS provider, bind `api.devglobe.dev` to the Function App and update `NEXT_PUBLIC_API_URL`. Azure does not currently host the `devglobe.dev` DNS zone, so this step is external to the resource group.
+The `www.devglobe.dev` CNAME targets the Container App ingress hostname. The `asuid.www` TXT record proves ownership to Azure, and the Container Apps environment manages the TLS certificate. Azure does not host the `devglobe.dev` DNS zone, so DNS changes remain external to the resource group.
 
 ## Deployment
 
-Install production dependencies and deploy the contents of `functions/` to the Function App. The ZIP root must contain `host.json`, not a wrapping `functions` directory.
+Pushes to `main` build the standalone Next.js image in Azure Container Registry and update the Container App through `.github/workflows/deploy.yml`. GitHub Actions authenticates with Azure through OIDC.
+
+Changes under `functions/` deploy separately through `.github/workflows/deploy-azure-functions.yml`. For manual Function deployment, install production dependencies and deploy the contents of `functions/`; the ZIP root must contain `host.json`, not a wrapping `functions` directory.
 
 ```powershell
 Set-Location functions
@@ -56,10 +61,10 @@ For a CLI-only deployment, create a ZIP containing the contents of `functions/`,
 
 ## Validation
 
-Confirm all of the following before setting the Vercel frontend variables:
+Confirm all of the following after deployment:
 
 - `/api/developers/count` returns the production count and the expected CORS origin.
 - `/api/developer?id=sajeetharan` returns the public profile.
 - `/api/search?q=typescript&mode=text` returns bounded results.
 - Blob `developers.json` returns `Content-Encoding: gzip` and a long-lived cache header.
-- The activity timer writes directly to the activity container without calling Vercel.
+- The activity timer writes directly to the activity container.

--- a/docs/prd/lifecycle-email-notifications.md
+++ b/docs/prd/lifecycle-email-notifications.md
@@ -109,7 +109,7 @@ Provider logs supply initial delivery visibility. Product analytics and durable 
 
 1. Create a Resend account and verify the sending domain.
 2. Run `npm run setup-contacts-container` against the target Cosmos database.
-3. Configure `RESEND_API_KEY`, a verified `EMAIL_FROM`, and `COSMOS_CONTACTS_CONTAINER` in Vercel and the review-script environment.
+3. Configure `RESEND_API_KEY`, a verified `EMAIL_FROM`, and `COSMOS_CONTACTS_CONTAINER` in Azure Container Apps and the review-script environment.
 4. Deploy and test with one controlled first claim and one controlled nomination approval.
 5. Monitor Resend delivery logs and application errors.
 6. Add durable notification events, retries, verification, and preference controls only if delivery volume warrants them.

--- a/next.config.js
+++ b/next.config.js
@@ -19,16 +19,6 @@ const nextConfig = {
       },
     ];
   },
-  async redirects() {
-    return [
-      {
-        source: '/:path*',
-        has: [{ type: 'host', value: 'dev-globe-viz.vercel.app' }],
-        destination: 'https://www.devglobe.dev/:path*',
-        permanent: true,
-      },
-    ];
-  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
This PR finalizes public cloud infrastructure and local dev simplification by removing obsolete Vercel references.

### Summary of Changes
- Removed obsolete runtime redirect configuration from 
ext.config.js.
- Updated Azure and general system documentation to standardise deployment guides (e.g. docs/azure-backend.md, architecture/development guides, README, etc.).
- Intentionally retained @vercel/og package and related imports for social card generation.
- Validated via 145 tests, docs build, and production build successfully passed.