### PR TITLE
Fix live GitHub session persistence

### DIFF
--- a/app/api/auth/callback/route.js
+++ b/app/api/auth/callback/route.js
@@ -1,24 +1,22 @@
 import { NextResponse } from 'next/server';
-import { headers } from 'next/headers';
 import { createSessionToken, buildSessionCookie } from '../../../../lib/auth.js';
 import { saveActivities } from '../../../../lib/activity-store.js';
 import { createPlatformActivity } from '../../../../lib/platform-activity.js';
 import { selectGitHubEmail } from '../../../../lib/github-email.js';
+import { resolveGitHubCallbackBaseUrl } from '../../../../lib/github-oauth.js';
+import { getSiteUrl } from '../../../../lib/site.js';
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
 
-function getBaseUrl(hdrs) {
-  const host = hdrs.get('x-forwarded-host') || hdrs.get('host') || 'localhost:3000';
-  const proto = hdrs.get('x-forwarded-proto') || 'http';
-  return `${proto}://${host}`;
-}
-
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
-  const hdrs = await headers();
-  const baseUrl = getBaseUrl(hdrs);
+  const baseUrl = resolveGitHubCallbackBaseUrl(
+    request.url,
+    getSiteUrl(),
+    process.env.NODE_ENV === 'production'
+  );
 
   if (!code) {
     return NextResponse.redirect(`${baseUrl}?auth_error=no_code`);

--- a/lib/auth-config.js
+++ b/lib/auth-config.js
@@ -1,0 +1,10 @@
+export function resolveSessionCookieDomain(siteUrl, production = false) {
+  if (!production) return undefined;
+
+  try {
+    const hostname = new URL(siteUrl).hostname.toLowerCase();
+    return hostname.startsWith('www.') ? hostname.slice(4) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,10 +1,18 @@
 import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
+import { resolveSessionCookieDomain } from './auth-config.js';
 
 const SESSION_COOKIE = 'devglobe_session';
 const SECRET = new TextEncoder().encode(
   process.env.SESSION_SECRET || 'devglobe-dev-secret-change-in-production'
 );
+
+function sessionCookieDomain() {
+  return resolveSessionCookieDomain(
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.NODE_ENV === 'production'
+  );
+}
 
 /**
  * Create a signed JWT session token.
@@ -43,6 +51,7 @@ export async function getSession() {
  * Set session cookie with the given payload.
  */
 export function buildSessionCookie(token) {
+  const domain = sessionCookieDomain();
   return {
     name: SESSION_COOKIE,
     value: token,
@@ -51,6 +60,7 @@ export function buildSessionCookie(token) {
     sameSite: 'lax',
     path: '/',
     maxAge: 60 * 60 * 24 * 7, // 7 days
+    ...(domain ? { domain } : {}),
   };
 }
 
@@ -58,6 +68,7 @@ export function buildSessionCookie(token) {
  * Build a cookie config that clears the session.
  */
 export function buildLogoutCookie() {
+  const domain = sessionCookieDomain();
   return {
     name: SESSION_COOKIE,
     value: '',
@@ -66,5 +77,6 @@ export function buildLogoutCookie() {
     sameSite: 'lax',
     path: '/',
     maxAge: 0,
+    ...(domain ? { domain } : {}),
   };
 }

--- a/lib/github-oauth.js
+++ b/lib/github-oauth.js
@@ -1,5 +1,15 @@
 const GITHUB_LOGIN_RE = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
 
+export function resolveGitHubCallbackBaseUrl(requestUrl, siteUrl, production = false) {
+  if (!production) return new URL(requestUrl).origin;
+
+  try {
+    return new URL(siteUrl).origin;
+  } catch {
+    return new URL(requestUrl).origin;
+  }
+}
+
 export function buildGitHubAuthorizationUrl(clientId, login = '') {
   const url = new URL('https://github.com/login/oauth/authorize');
   url.searchParams.set('client_id', clientId);

--- a/tests/github-oauth.test.js
+++ b/tests/github-oauth.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildGitHubAuthorizationUrl } from '../lib/github-oauth.js';
+import { buildGitHubAuthorizationUrl, resolveGitHubCallbackBaseUrl } from '../lib/github-oauth.js';
+import { resolveSessionCookieDomain } from '../lib/auth-config.js';
 
 test('uses the callback registered on the GitHub OAuth application', () => {
   const url = new URL(buildGitHubAuthorizationUrl('client-id'));
@@ -18,4 +19,25 @@ test('suggests a valid nominated login without forwarding invalid input', () => 
 
   assert.equal(hintedUrl.searchParams.get('login'), 'octo-cat');
   assert.equal(invalidUrl.searchParams.has('login'), false);
+});
+
+test('uses the canonical site origin after a production OAuth callback', () => {
+  assert.equal(
+    resolveGitHubCallbackBaseUrl(
+      'https://devglobe.dev/api/auth/callback?code=redacted',
+      'https://www.devglobe.dev',
+      true
+    ),
+    'https://www.devglobe.dev'
+  );
+  assert.equal(
+    resolveGitHubCallbackBaseUrl('http://localhost:3000/api/auth/callback', 'https://www.devglobe.dev', false),
+    'http://localhost:3000'
+  );
+});
+
+test('shares production session cookies between the canonical www host and apex', () => {
+  assert.equal(resolveSessionCookieDomain('https://www.devglobe.dev', true), 'devglobe.dev');
+  assert.equal(resolveSessionCookieDomain('https://www.devglobe.dev', false), undefined);
+  assert.equal(resolveSessionCookieDomain('https://app.example.com', true), undefined);
 });


### PR DESCRIPTION
Root cause: The OAuth callback occurred on the apex domain, which set a host-only cookie. The subsequent canonical www redirect hid the session cookie from being read correctly because of host/canonical mismatch.

Fix: Handled domain consistency across callback and preserved the GitHub session relative to the canonical host.

Validation: 152 tests and build succeeded.