### PR TITLE
Recognize legacy session cookie for existing logins

### DIFF
--- a/lib/auth-config.js
+++ b/lib/auth-config.js
@@ -1,5 +1,17 @@
 export const SESSION_COOKIE_NAME = 'devglobe_session_v2';
 
+// Older deployments issued this cookie name; still honor it so existing logins
+// are recognized without forcing a re-login.
+export const LEGACY_SESSION_COOKIE_NAMES = ['devglobe_session'];
+
+export function selectSessionToken(getCookieValue) {
+  for (const name of [SESSION_COOKIE_NAME, ...LEGACY_SESSION_COOKIE_NAMES]) {
+    const value = getCookieValue(name);
+    if (value) return value;
+  }
+  return null;
+}
+
 export function resolveSessionCookieDomain(siteUrl, production = false) {
   if (!production) return undefined;
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,6 @@
 import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
-import { resolveSessionCookieDomain, SESSION_COOKIE_NAME } from './auth-config.js';
+import { resolveSessionCookieDomain, selectSessionToken, SESSION_COOKIE_NAME } from './auth-config.js';
 
 const SECRET = new TextEncoder().encode(
   process.env.SESSION_SECRET || 'devglobe-dev-secret-change-in-production'
@@ -41,7 +41,7 @@ export async function verifySessionToken(token) {
  */
 export async function getSession() {
   const cookieStore = await cookies();
-  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+  const token = selectSessionToken(name => cookieStore.get(name)?.value);
   if (!token) return null;
   return verifySessionToken(token);
 }

--- a/tests/github-oauth.test.js
+++ b/tests/github-oauth.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { buildGitHubAuthorizationUrl, resolveGitHubCallbackBaseUrl } from '../lib/github-oauth.js';
-import { resolveSessionCookieDomain, SESSION_COOKIE_NAME } from '../lib/auth-config.js';
+import { resolveSessionCookieDomain, selectSessionToken, SESSION_COOKIE_NAME } from '../lib/auth-config.js';
 
 test('uses the callback registered on the GitHub OAuth application', () => {
   const url = new URL(buildGitHubAuthorizationUrl('client-id'));
@@ -41,4 +41,14 @@ test('shares production session cookies between the canonical www host and apex'
   assert.equal(resolveSessionCookieDomain('https://www.devglobe.dev', true), 'devglobe.dev');
   assert.equal(resolveSessionCookieDomain('https://www.devglobe.dev', false), undefined);
   assert.equal(resolveSessionCookieDomain('https://app.example.com', true), undefined);
+});
+
+test('selectSessionToken prefers the current cookie and falls back to the legacy one', () => {
+  const both = { devglobe_session_v2: 'new', devglobe_session: 'old' };
+  assert.equal(selectSessionToken(name => both[name]), 'new');
+
+  const legacyOnly = { devglobe_session: 'old' };
+  assert.equal(selectSessionToken(name => legacyOnly[name]), 'old');
+
+  assert.equal(selectSessionToken(() => undefined), null);
 });


### PR DESCRIPTION
root cause: cookie renamed to devglobe_session_v2 in #226 orphaned existing devglobe_session logins so the header/menu showed signed-out; fix: getSession falls back to the legacy cookie while still issuing v2; validation: 156 tests + build