### PR TITLE
ASCII terminal profile card

### DIFF
--- a/app/api/profile-card/[login]/route.js
+++ b/app/api/profile-card/[login]/route.js
@@ -1,0 +1,69 @@
+import { ImageResponse } from '@vercel/og';
+import { decodePng } from '../../../../lib/png-decode.js';
+import { imageToAscii, renderProfileCardSvg } from '../../../../lib/ascii-portrait.js';
+import { getProfileCardDeveloper, buildCardDetails } from '../../../../lib/profile-card-lookup.js';
+
+export const runtime = 'nodejs';
+
+const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+const PORTRAIT_COLS = 44;
+const PORTRAIT_ROWS = 22;
+const AVATAR_SIZE = 96;
+
+function svgResponse(svg, { cache = true } = {}) {
+  return new Response(svg, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/svg+xml; charset=utf-8',
+      'Cache-Control': cache
+        ? 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
+        : 'no-store',
+    },
+  });
+}
+
+async function fetchAsciiPortrait(login) {
+  try {
+    // GitHub avatars are often JPEG; rasterize to PNG via @vercel/og so the
+    // built-in PNG decoder can read the pixels without a JPEG dependency.
+    const png = new ImageResponse(
+      {
+        type: 'img',
+        props: {
+          src: `https://github.com/${encodeURIComponent(login)}.png?size=${AVATAR_SIZE}`,
+          width: AVATAR_SIZE,
+          height: AVATAR_SIZE,
+        },
+      },
+      { width: AVATAR_SIZE, height: AVATAR_SIZE },
+    );
+    const image = decodePng(Buffer.from(await png.arrayBuffer()));
+    return imageToAscii(image, PORTRAIT_COLS, PORTRAIT_ROWS);
+  } catch (error) {
+    console.error('Profile card portrait failed:', error.message);
+    return [];
+  }
+}
+
+export async function GET(request, { params }) {
+  const { login: rawLogin } = await params;
+  const login = rawLogin.replace(/\.svg$/i, '');
+
+  const theme = new URL(request.url).searchParams.get('theme') === 'light' ? 'light' : 'dark';
+
+  if (!LOGIN_PATTERN.test(login)) {
+    return svgResponse(renderProfileCardSvg({ login: 'invalid', details: [['Error', 'invalid login']], theme }), { cache: false });
+  }
+
+  try {
+    const [portrait, developer] = await Promise.all([
+      fetchAsciiPortrait(login),
+      getProfileCardDeveloper(login).catch(() => null),
+    ]);
+    const details = buildCardDetails(developer, login);
+    return svgResponse(renderProfileCardSvg({ login, portrait, details, theme }));
+  } catch (error) {
+    console.error('Profile card render failed:', error.message);
+    return svgResponse(renderProfileCardSvg({ login, details: [['GitHub', `@${login}`]], theme }), { cache: false });
+  }
+}

--- a/lib/ascii-portrait.js
+++ b/lib/ascii-portrait.js
@@ -1,0 +1,138 @@
+const CHARSET = '@%#*+=-:. ';
+
+export const CARD_THEMES = {
+  dark: {
+    background: '#0d1117',
+    border: '#30363d',
+    text: '#c9d1d9',
+    muted: '#8b949e',
+    accent: '#58a6ff',
+    highlight: '#7ee787',
+    palette: ['#ff7b72', '#ffa657', '#f2cc60', '#7ee787', '#79c0ff', '#d2a8ff'],
+  },
+  light: {
+    background: '#ffffff',
+    border: '#d0d7de',
+    text: '#24292f',
+    muted: '#57606a',
+    accent: '#0969da',
+    highlight: '#1a7f37',
+    palette: ['#cf222e', '#9a6700', '#4d7c0f', '#1a7f37', '#0969da', '#8250df'],
+  },
+};
+
+export function luminance(r, g, b) {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Convert decoded RGBA pixels into an array of ASCII rows.
+ * Background-colored / transparent cells become spaces so the portrait is cut out.
+ */
+export function imageToAscii(image, cols, rows) {
+  const { data, width, height } = image;
+  const at = (x, y) => {
+    const i = (y * width + x) * 4;
+    return [data[i], data[i + 1], data[i + 2], data[i + 3]];
+  };
+
+  const corners = [at(0, 0), at(width - 1, 0), at(0, height - 1), at(width - 1, height - 1)];
+  const bg = [0, 1, 2].map(c => corners.reduce((sum, p) => sum + p[c], 0) / corners.length);
+
+  const lines = [];
+  for (let ry = 0; ry < rows; ry += 1) {
+    let line = '';
+    for (let rx = 0; rx < cols; rx += 1) {
+      const x0 = Math.floor((rx * width) / cols);
+      const x1 = Math.max(x0 + 1, Math.floor(((rx + 1) * width) / cols));
+      const y0 = Math.floor((ry * height) / rows);
+      const y1 = Math.max(y0 + 1, Math.floor(((ry + 1) * height) / rows));
+
+      let r = 0; let g = 0; let b = 0; let a = 0; let n = 0;
+      for (let y = y0; y < y1; y += 1) {
+        for (let x = x0; x < x1; x += 1) {
+          const p = at(x, y);
+          r += p[0]; g += p[1]; b += p[2]; a += p[3]; n += 1;
+        }
+      }
+      r /= n; g /= n; b /= n; a /= n;
+
+      const distance = Math.sqrt((r - bg[0]) ** 2 + (g - bg[1]) ** 2 + (b - bg[2]) ** 2);
+      if (a < 32 || distance < 20) {
+        line += ' ';
+        continue;
+      }
+      const index = Math.min(CHARSET.length - 1, Math.max(0, Math.round((luminance(r, g, b) / 255) * (CHARSET.length - 1))));
+      line += CHARSET[index];
+    }
+    lines.push(line.replace(/\s+$/, ''));
+  }
+  return lines;
+}
+
+function infoLine(label, value, y, colors) {
+  const labelText = `${label}:`;
+  const dots = '.'.repeat(Math.max(2, 20 - labelText.length));
+  return `<text x="470" y="${y}" class="line">`
+    + `<tspan class="label">${escapeXml(labelText)}</tspan>`
+    + `<tspan class="muted"> ${dots} </tspan>`
+    + `<tspan class="value">${escapeXml(value)}</tspan>`
+    + '</text>';
+}
+
+/**
+ * Render a terminal-window profile card SVG with an ASCII portrait and info lines.
+ * `details` is an array of [label, value]. Pure string output for easy testing.
+ */
+export function renderProfileCardSvg({ login, portrait = [], details = [], theme = 'dark' } = {}) {
+  const colors = CARD_THEMES[theme] || CARD_THEMES.dark;
+  const rowCount = Math.max(portrait.length, details.length + 4, 20);
+  const height = 70 + rowCount * 18;
+  const width = 900;
+
+  const portraitLines = portrait
+    .map((line, index) => {
+      const color = colors.palette[Math.floor((index / Math.max(portrait.length, 1)) * colors.palette.length)] || colors.text;
+      return `<text x="30" y="${70 + index * 15}" class="portrait" fill="${color}" xml:space="preserve">${escapeXml(line)}</text>`;
+    })
+    .join('\n  ');
+
+  let y = 66;
+  const infoLines = [];
+  infoLines.push(`<text x="470" y="${y}" class="section">${escapeXml(`@${login}`)}</text>`);
+  y += 26;
+  for (const [label, value] of details) {
+    infoLines.push(infoLine(label, value, y, colors));
+    y += 22;
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="Terminal profile card for ${escapeXml(login)}">
+  <style>
+    .line, .portrait, .section { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+    .portrait { font-size: 12px; }
+    .label { fill: ${colors.accent}; }
+    .muted { fill: ${colors.muted}; }
+    .value { fill: ${colors.text}; }
+    .section { fill: ${colors.highlight}; font-weight: 700; }
+  </style>
+  <rect x="1" y="1" width="${width - 2}" height="${height - 2}" rx="8" fill="${colors.background}" stroke="${colors.border}" stroke-width="2"/>
+  <circle cx="24" cy="24" r="6" fill="#ff5f56"/>
+  <circle cx="46" cy="24" r="6" fill="#ffbd2e"/>
+  <circle cx="68" cy="24" r="6" fill="#27c93f"/>
+  <text x="450" y="29" text-anchor="middle" class="line muted">${escapeXml(login)}@github: ~</text>
+  <line x1="440" y1="44" x2="440" y2="${height - 30}" stroke="${colors.border}"/>
+  ${portraitLines}
+  ${infoLines.join('\n  ')}
+  <text x="30" y="${height - 18}" class="line"><tspan class="section" fill="${colors.highlight}">$</tspan><tspan class="value"> building in the open</tspan><tspan class="label">_</tspan></text>
+</svg>
+`;
+}

--- a/lib/png-decode.js
+++ b/lib/png-decode.js
@@ -1,0 +1,97 @@
+import zlib from 'node:zlib';
+
+const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function paeth(a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  return pb <= pc ? b : c;
+}
+
+/**
+ * Decode a non-interlaced, 8-bit PNG (color type 2 RGB or 6 RGBA) into RGBA pixels.
+ * Uses only Node's built-in zlib so no third-party dependency is required.
+ */
+export function decodePng(input) {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  for (let i = 0; i < 8; i += 1) {
+    if (buf[i] !== SIGNATURE[i]) throw new Error('Not a PNG image');
+  }
+
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  const idatChunks = [];
+
+  let pos = 8;
+  while (pos < buf.length) {
+    const length = buf.readUInt32BE(pos);
+    const type = buf.toString('ascii', pos + 4, pos + 8);
+    const dataStart = pos + 8;
+
+    if (type === 'IHDR') {
+      width = buf.readUInt32BE(dataStart);
+      height = buf.readUInt32BE(dataStart + 4);
+      bitDepth = buf[dataStart + 8];
+      colorType = buf[dataStart + 9];
+      interlace = buf[dataStart + 12];
+    } else if (type === 'IDAT') {
+      idatChunks.push(buf.subarray(dataStart, dataStart + length));
+    } else if (type === 'IEND') {
+      break;
+    }
+
+    pos = dataStart + length + 4; // skip chunk data and its CRC
+  }
+
+  if (bitDepth !== 8) throw new Error(`Unsupported PNG bit depth: ${bitDepth}`);
+  if (interlace !== 0) throw new Error('Interlaced PNG is not supported');
+  const channels = colorType === 6 ? 4 : colorType === 2 ? 3 : 0;
+  if (!channels) throw new Error(`Unsupported PNG color type: ${colorType}`);
+
+  const raw = zlib.inflateSync(Buffer.concat(idatChunks));
+  const stride = width * channels;
+  const out = new Uint8Array(width * height * 4);
+  let prev = new Uint8Array(stride);
+  let rp = 0;
+
+  for (let y = 0; y < height; y += 1) {
+    const filter = raw[rp];
+    rp += 1;
+    const cur = new Uint8Array(stride);
+    for (let i = 0; i < stride; i += 1) {
+      const x = raw[rp + i];
+      const a = i >= channels ? cur[i - channels] : 0;
+      const b = prev[i];
+      const c = i >= channels ? prev[i - channels] : 0;
+      let value;
+      switch (filter) {
+        case 0: value = x; break;
+        case 1: value = x + a; break;
+        case 2: value = x + b; break;
+        case 3: value = x + ((a + b) >> 1); break;
+        case 4: value = x + paeth(a, b, c); break;
+        default: throw new Error(`Unsupported PNG filter: ${filter}`);
+      }
+      cur[i] = value & 0xff;
+    }
+    rp += stride;
+
+    for (let x = 0; x < width; x += 1) {
+      const src = x * channels;
+      const dst = (y * width + x) * 4;
+      out[dst] = cur[src];
+      out[dst + 1] = cur[src + 1];
+      out[dst + 2] = cur[src + 2];
+      out[dst + 3] = channels === 4 ? cur[src + 3] : 255;
+    }
+    prev = cur;
+  }
+
+  return { width, height, data: out };
+}

--- a/lib/profile-card-lookup.js
+++ b/lib/profile-card-lookup.js
@@ -1,0 +1,57 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getCosmosContainer } from './cosmos.js';
+import { addDeveloperRanks } from './ranking.js';
+import { scoreAll } from './scoring.js';
+
+const CARD_FIELDS = 'c.login, c.name, c.location, c.topLanguage, c.score, c.globalRank, c.globalTotal, c.country, c.countryRank, c.totalStars, c.totalCommits, c.followers';
+
+async function getFromCosmos(login) {
+  const container = getCosmosContainer();
+  if (!container) return null;
+  try {
+    const { resources } = await container.items.query({
+      query: `SELECT TOP 1 ${CARD_FIELDS}
+        FROM c
+        WHERE (c.login = @login OR c.id = @login)
+          AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')`,
+      parameters: [{ name: '@login', value: login }],
+    }).fetchAll();
+    return resources[0] || null;
+  } catch (error) {
+    console.error('Profile card: Cosmos error', error.message);
+    return null;
+  }
+}
+
+async function getFromSampleData(login) {
+  const filePath = path.join(process.cwd(), 'data', 'developers-sample.json');
+  const raw = await fs.readFile(filePath, 'utf-8');
+  const developers = addDeveloperRanks(scoreAll(JSON.parse(raw)));
+  return developers.find(d => d.login.toLowerCase() === login.toLowerCase()) || null;
+}
+
+export async function getProfileCardDeveloper(login) {
+  const fromCosmos = await getFromCosmos(login);
+  if (fromCosmos) return fromCosmos;
+  return getFromSampleData(login);
+}
+
+/** Build the ordered [label, value] detail rows shown on the card. */
+export function buildCardDetails(developer, login) {
+  const rows = [];
+  const number = value => (Number.isFinite(Number(value)) ? Number(value).toLocaleString('en-US') : null);
+
+  if (developer?.name) rows.push(['Name', developer.name]);
+  if (developer?.location) rows.push(['Location', developer.location]);
+  if (developer?.topLanguage) rows.push(['Language', developer.topLanguage]);
+  if (number(developer?.score) !== null) rows.push(['Score', `${number(developer.score)}/100`]);
+  if (developer?.globalRank) rows.push(['Global rank', `#${number(developer.globalRank)}`]);
+  if (developer?.countryRank && developer?.country) rows.push([developer.country, `#${number(developer.countryRank)}`]);
+  if (number(developer?.totalStars) !== null) rows.push(['Stars', number(developer.totalStars)]);
+  if (number(developer?.totalCommits) !== null) rows.push(['Commits', number(developer.totalCommits)]);
+  if (number(developer?.followers) !== null) rows.push(['Followers', number(developer.followers)]);
+
+  if (!rows.length) rows.push(['GitHub', `@${login}`]);
+  return rows;
+}

--- a/lib/profile-readme.js
+++ b/lib/profile-readme.js
@@ -124,7 +124,12 @@ export function generateProfileReadme(developer, options = {}) {
   const lines = [
     '<div align="center">',
     '',
-    `<img src="https://github.com/${encodedLogin}.png" width="120" height="120" style="border-radius:50%" alt="${escapeHtml(developer.name || login)}" />`,
+    `<a href="https://github.com/${encodedLogin}">`,
+    '  <picture>',
+    `    <source media="(prefers-color-scheme: dark)" srcset="${siteUrl}/api/profile-card/${encodedLogin}.svg?theme=dark" />`,
+    `    <img src="${siteUrl}/api/profile-card/${encodedLogin}.svg?theme=light" alt="${escapeHtml(developer.name || login)} terminal profile card" width="900" />`,
+    '  </picture>',
+    '</a>',
     '',
     `# Hey, I'm ${name} 👋`,
     '',

--- a/tests/ascii-portrait.test.js
+++ b/tests/ascii-portrait.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { luminance, imageToAscii, renderProfileCardSvg } from '../lib/ascii-portrait.js';
+import { buildCardDetails } from '../lib/profile-card-lookup.js';
+
+function solidImage(width, height, rgba) {
+  const data = new Uint8Array(width * height * 4);
+  for (let i = 0; i < width * height; i += 1) data.set(rgba, i * 4);
+  return { width, height, data };
+}
+
+test('luminance weights green most heavily', () => {
+  assert.ok(luminance(0, 255, 0) > luminance(255, 0, 0));
+  assert.ok(luminance(255, 0, 0) > luminance(0, 0, 255));
+});
+
+test('imageToAscii cuts out the background and keeps foreground', () => {
+  // 4x2: left half dark foreground, right half matches the (white) corners => background.
+  const width = 4; const height = 2;
+  const data = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const i = (y * width + x) * 4;
+      const dark = x < 2;
+      data[i] = dark ? 20 : 255;
+      data[i + 1] = dark ? 20 : 255;
+      data[i + 2] = dark ? 20 : 255;
+      data[i + 3] = 255;
+    }
+  }
+  const rows = imageToAscii({ width, height, data }, 4, 2);
+  assert.equal(rows.length, 2);
+  // Foreground (dark) becomes a dense glyph; background (white corners) is trimmed to empty.
+  assert.match(rows[0], /^[@%#]/);
+  assert.equal(rows[0].replace(/\s+$/, '').length <= 2, true);
+});
+
+test('renderProfileCardSvg produces a terminal card with escaped details', () => {
+  const svg = renderProfileCardSvg({
+    login: 'octo-dev',
+    portrait: ['@@  ', ' ## '],
+    details: [['Name', 'A & B <x>'], ['Stars', '1,234']],
+    theme: 'dark',
+  });
+  assert.match(svg, /^<\?xml/);
+  assert.match(svg, /<svg/);
+  assert.match(svg, /octo-dev@github/);
+  assert.match(svg, /A &amp; B &lt;x&gt;/);
+  assert.doesNotMatch(svg, /<x>/);
+  assert.match(svg, /1,234/);
+  assert.match(svg, /<\/svg>/);
+});
+
+test('renderProfileCardSvg honors the light theme background', () => {
+  const light = renderProfileCardSvg({ login: 'octo-dev', theme: 'light' });
+  assert.match(light, /#ffffff/);
+});
+
+test('buildCardDetails includes present fields and falls back when empty', () => {
+  const details = buildCardDetails({
+    name: 'Octo Dev', location: 'Colombo', topLanguage: 'TypeScript',
+    score: 88, globalRank: 12, totalStars: 1234, followers: 90,
+  }, 'octo-dev');
+  const labels = details.map(([label]) => label);
+  assert.deepEqual(labels.slice(0, 3), ['Name', 'Location', 'Language']);
+  assert.ok(details.some(([, value]) => value === '88/100'));
+
+  const fallback = buildCardDetails(null, 'octo-dev');
+  assert.deepEqual(fallback, [['GitHub', '@octo-dev']]);
+});

--- a/tests/png-decode.test.js
+++ b/tests/png-decode.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import zlib from 'node:zlib';
+import { decodePng } from '../lib/png-decode.js';
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i += 1) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type, data) {
+  const typeBuf = Buffer.from(type, 'ascii');
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+  return Buffer.concat([length, typeBuf, data, crc]);
+}
+
+// Encode a tiny 8-bit RGBA PNG so we can validate the decoder via round-trip.
+function encodePng(width, height, rgba) {
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type RGBA
+  const stride = width * 4;
+  const raw = Buffer.alloc(height * (stride + 1));
+  for (let y = 0; y < height; y += 1) {
+    raw[y * (stride + 1)] = 0; // filter: none
+    rgba.subarray(y * stride, (y + 1) * stride).copy(raw, y * (stride + 1) + 1);
+  }
+  return Buffer.concat([
+    signature,
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+test('decodePng round-trips an 8-bit RGBA image', () => {
+  const pixels = Buffer.from([
+    255, 0, 0, 255, 0, 255, 0, 255,
+    0, 0, 255, 255, 255, 255, 255, 128,
+  ]);
+  const png = encodePng(2, 2, pixels);
+  const decoded = decodePng(png);
+
+  assert.equal(decoded.width, 2);
+  assert.equal(decoded.height, 2);
+  assert.deepEqual(Array.from(decoded.data), Array.from(pixels));
+});
+
+test('decodePng rejects non-PNG input', () => {
+  assert.throws(() => decodePng(Buffer.from('not a png')), /Not a PNG/);
+});

--- a/tests/profile-readme.test.js
+++ b/tests/profile-readme.test.js
@@ -27,6 +27,8 @@ test('generateProfileReadme builds a profile-styled README', () => {
   const markdown = generateProfileReadme(developer(), { siteUrl: 'https://devglobe.test/' });
 
   assert.match(markdown, /# Hey, I'm Octo Dev 👋/);
+  assert.match(markdown, /api\/profile-card\/octo-dev\.svg\?theme=dark/);
+  assert.match(markdown, /<picture>/);
   assert.match(markdown, /komarev\.com\/ghpvc\/\?username=octo-dev/);
   assert.match(markdown, /## 🚀 About Me/);
   assert.match(markdown, /## 🏆 Community Impact/);


### PR DESCRIPTION
adds /api/profile-card/{login}.svg that rasterizes the GitHub avatar via @vercel/og, decodes PNG with a zero-dependency decoder, renders a colored ASCII terminal card with profile details; the generated README embeds it via a theme-aware <picture>; 165 tests + build pass