### PR TITLE
Add README generator to home menu

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -22,6 +22,7 @@ import dynamic from 'next/dynamic';
 const Globe = dynamic(() => import('../components/Globe.jsx'), { ssr: false });
 const PENDING_CLAIM_KEY = 'devglobe-pending-claim';
 const PENDING_README_KEY = 'devglobe-pending-readme';
+const PENDING_HOME_README_KEY = 'devglobe-pending-home-readme';
 let cachedDeveloperDataset = null;
 
 export default function Home() {
@@ -313,6 +314,39 @@ export default function Home() {
     requestAnimationFrame(() => document.querySelector('#search-bar input')?.focus());
   }, [developers, handleGenerateCard, selectedDev, user]);
 
+  const handleOpenReadmeFeature = useCallback(() => {
+    if (!user) {
+      try { localStorage.setItem(PENDING_HOME_README_KEY, '1'); } catch { /* OAuth can continue without persistence. */ }
+      track('github_auth_started', { source: 'home_readme' });
+      window.location.assign('/api/auth/github');
+      return;
+    }
+    const developer = resolveIdentityCardDeveloper(null, user, developers);
+    const claimed = Boolean(
+      developer?.claimed || claimedLogins.has(user.login) || claimedLogins.has(user.login.toLowerCase())
+    );
+    if (!developer || !claimed) {
+      void handleClaim({ openCard: false, openReadme: true });
+      return;
+    }
+    track('profile_readme_opened', { login: developer.login, source: 'home' });
+    setCardRequest(0);
+    setCardContext(null);
+    setSelectedDev(developer);
+    setSidebarOpen(false);
+    setReadmeRequest(request => request + 1);
+  }, [claimedLogins, developers, handleClaim, user]);
+
+  // Resume a "Generate README" request started from the home menu before sign-in.
+  useEffect(() => {
+    if (!user || developers.length === 0) return;
+    let pending = false;
+    try { pending = localStorage.getItem(PENDING_HOME_README_KEY) === '1'; } catch { return; }
+    if (!pending) return;
+    try { localStorage.removeItem(PENDING_HOME_README_KEY); } catch { /* best-effort cleanup */ }
+    handleOpenReadmeFeature();
+  }, [user, developers, handleOpenReadmeFeature]);
+
   const handleOpenCompareFeature = useCallback(() => {
     setCardRequest(0);
     setCardContext(null);
@@ -488,6 +522,14 @@ export default function Home() {
         onGenerateCard={handleGenerateCard}
         onSearchState={handleTourSearchState}
         onOpenCardFeature={handleOpenCardFeature}
+        onOpenReadmeFeature={handleOpenReadmeFeature}
+        readmeTooltip={
+          !user
+            ? 'Sign in with GitHub to generate a README for your profile'
+            : claimStatus === 'claimed'
+              ? 'Generate a README for your GitHub profile'
+              : 'Claim your profile to generate your GitHub README'
+        }
         onOpenCompareFeature={handleOpenCompareFeature}
         compareCount={compareDevs.length}
       />

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -26,7 +26,7 @@ const SAMPLES_BY_MODE = {
   ],
 };
 
-export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenCompareFeature, compareCount = 0 }) {
+export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0 }) {
   const [query, setQuery] = useState('');
   const [mode, setMode] = useState('text');
   const [topN, setTopN] = useState(50);
@@ -195,13 +195,27 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
             type="button"
             className="feature-action feature-action--card"
             onClick={onOpenCardFeature}
-            aria-label="Generate identity card"
-            title="Generate identity card"
+            aria-label="Generate your developer identity card"
+            title="Generate your developer identity card"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <rect x="3" y="3" width="18" height="18" rx="2" />
               <circle cx="8.5" cy="8.5" r="1.5" />
               <path d="M21 15l-5-5L5 21" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            className="feature-action feature-action--readme"
+            onClick={onOpenReadmeFeature}
+            aria-label={readmeTooltip}
+            title={readmeTooltip}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M4 3h11l5 5v13H4z" />
+              <path d="M14 3v6h6" />
+              <path d="M8 13h8" />
+              <path d="M8 17h6" />
             </svg>
           </button>
           <button

--- a/styles/main.css
+++ b/styles/main.css
@@ -522,6 +522,14 @@ body {
   background: rgba(8, 145, 178, 0.18);
 }
 
+.feature-action--readme {
+  color: #a78bfa;
+}
+
+.feature-action--readme:hover {
+  background: rgba(139, 92, 246, 0.16);
+}
+
 .feature-action--compare {
   color: #fbbf24;
 }


### PR DESCRIPTION
Makes the profile README generator reachable from the main home page, next to Generate identity card.

- New toolbar button in the search bar with a state-aware tooltip (sign in / claim / generate).
- handleOpenReadmeFeature resolves the signed-in user's own profile and opens the generator; mirrors existing gating (sign-in then claim then generate) and auto-resumes after GitHub sign-in.
- Clarified the identity-card button tooltip.

Build passes; 174 tests pass.