### PR TITLE
Return activity source from live API

### DIFF
--- a/functions/public-api/index.js
+++ b/functions/public-api/index.js
@@ -141,7 +141,7 @@ async function liveActivities(request) {
     parameters.push({ name: '@afterTime', value: after.createdAt }, { name: '@afterId', value: after.id });
   }
   const { resources } = await container.items.query({
-    query: `SELECT TOP ${limit} c.id, c.login, c.avatarUrl, c.type, c.description, c.repo, c.url, c.createdAt, c.ingestedAt FROM c WHERE ${conditions.join(' AND ')} ORDER BY c.createdAt DESC, c.id DESC`,
+    query: `SELECT TOP ${limit} c.id, c.login, c.avatarUrl, c.type, c.description, c.repo, c.url, c.createdAt, c.ingestedAt, c.documentType FROM c WHERE ${conditions.join(' AND ')} ORDER BY c.createdAt DESC, c.id DESC`,
     parameters,
   }).fetchAll();
   return json(request, {

--- a/lib/activity-store.js
+++ b/lib/activity-store.js
@@ -90,7 +90,7 @@ export async function listActivities({ limit = 50, cursor, after } = {}) {
   }
 
   const query = {
-    query: `SELECT TOP ${limit} c.id, c.login, c.avatarUrl, c.type, c.description, c.repo, c.url, c.createdAt, c.ingestedAt FROM c WHERE ${conditions.join(' AND ')} ORDER BY c.createdAt DESC, c.id DESC`,
+    query: `SELECT TOP ${limit} c.id, c.login, c.avatarUrl, c.type, c.description, c.repo, c.url, c.createdAt, c.ingestedAt, c.documentType FROM c WHERE ${conditions.join(' AND ')} ORDER BY c.createdAt DESC, c.id DESC`,
     parameters,
   };
   const { resources } = await container.items.query(query).fetchAll();


### PR DESCRIPTION
Cosmos filtered by documentType but omitted it from projections, causing DevGlobe login/card events to appear under GitHub. Both activity tests and build pass.