### PR TITLE
Fix LinkedIn card previews and README activity

### DIFF
--- a/app/api/activities/live/route.js
+++ b/app/api/activities/live/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { decodeActivityCursor, encodeActivityCursor, listActivities } from '../../../../lib/activity-store.js';
-import { createFallbackActivities } from '../../../../lib/platform-activity.js';
+import { createFallbackActivities, normalizePlatformActivity } from '../../../../lib/platform-activity.js';
 
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
@@ -17,9 +17,9 @@ export async function GET(request) {
 
   try {
     const result = await listActivities({ limit, cursor, after });
-    const activities = !cursor && !after && result.activities.length === 0
+    const activities = (!cursor && !after && result.activities.length === 0
       ? createFallbackActivities().slice(0, limit)
-      : result.activities;
+      : result.activities).map(normalizePlatformActivity);
     return NextResponse.json({
       ...result,
       activities,

--- a/app/api/activities/platform/route.js
+++ b/app/api/activities/platform/route.js
@@ -4,11 +4,12 @@ import { saveActivities } from '../../../../lib/activity-store.js';
 import { createPlatformActivity } from '../../../../lib/platform-activity.js';
 
 const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+const ACTIVITY_TYPES = new Set(['generated_card', 'generated_readme']);
 
 export async function POST(request) {
   try {
     const body = await request.json();
-    if (body.type !== 'generated_card' || !LOGIN_PATTERN.test(body.targetLogin || '')) {
+    if (!ACTIVITY_TYPES.has(body.type) || !LOGIN_PATTERN.test(body.targetLogin || '')) {
       return NextResponse.json({ error: 'Invalid platform activity' }, { status: 400 });
     }
 

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -320,17 +320,17 @@ export default function Home() {
     setFiltered(rankedResults);
   }, [developers]);
 
-  const recordCardActivity = useCallback((targetLogin) => {
+  const recordPlatformActivity = useCallback((type, targetLogin) => {
     fetch('/api/activities/platform', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type: 'generated_card', targetLogin }),
+      body: JSON.stringify({ type, targetLogin }),
     }).catch(() => {});
   }, []);
 
   const handleGenerateCard = useCallback((developer) => {
     const rankedDeveloper = developers.find(item => item.login === developer.login) || developer;
-    recordCardActivity(rankedDeveloper.login);
+    recordPlatformActivity('generated_card', rankedDeveloper.login);
     setSelectedDev(rankedDeveloper);
     setCardContext('generate');
     setCardRequest(request => request + 1);
@@ -338,7 +338,7 @@ export default function Home() {
     if (rankedDeveloper.lat != null && rankedDeveloper.lng != null) {
       setFlyTarget({ lat: rankedDeveloper.lat, lng: rankedDeveloper.lng });
     }
-  }, [developers, recordCardActivity]);
+  }, [developers, recordPlatformActivity]);
 
   const handleOpenCardFeature = useCallback(() => {
     const developer = resolveIdentityCardDeveloper(selectedDev, user, developers);
@@ -350,7 +350,7 @@ export default function Home() {
     requestAnimationFrame(() => document.querySelector('#search-bar input')?.focus());
   }, [developers, handleGenerateCard, selectedDev, user]);
 
-  const handleOpenReadmeFeature = useCallback((requestedDeveloper) => {
+  const handleOpenReadmeFeature = useCallback((requestedDeveloper, { recordActivity = true } = {}) => {
     const developer = requestedDeveloper || selectedDev || resolveIdentityCardDeveloper(null, user, developers);
     if (!developer) {
       setTourStep('search');
@@ -358,12 +358,13 @@ export default function Home() {
       return;
     }
     track('profile_readme_opened', { login: developer.login, source: 'home' });
+    if (recordActivity) recordPlatformActivity('generated_readme', developer.login);
     setCardRequest(0);
     setCardContext(null);
     setSelectedDev(developer);
     setSidebarOpen(false);
     setReadmeRequest(request => request + 1);
-  }, [developers, selectedDev, user]);
+  }, [developers, recordPlatformActivity, selectedDev, user]);
 
   // Resume a "Generate README" request started from the home menu before sign-in.
   useEffect(() => {
@@ -373,7 +374,7 @@ export default function Home() {
     if (!pendingLogin) return;
     try { localStorage.removeItem(PENDING_HOME_README_KEY); } catch { /* best-effort cleanup */ }
     const developer = developers.find(candidate => candidate.login.toLowerCase() === pendingLogin.toLowerCase());
-    if (developer) handleOpenReadmeFeature(developer);
+    if (developer) handleOpenReadmeFeature(developer, { recordActivity: false });
   }, [user, developers, handleOpenReadmeFeature]);
 
   const handleOpenCompareFeature = useCallback(() => {
@@ -617,7 +618,8 @@ export default function Home() {
             key={`${selectedDev.login}-${cardRequest}`}
             dev={selectedDev}
             onClose={handleCloseDetail}
-            onCardGenerated={recordCardActivity}
+            onCardGenerated={targetLogin => recordPlatformActivity('generated_card', targetLogin)}
+            onReadmeGenerated={targetLogin => recordPlatformActivity('generated_readme', targetLogin)}
             claimedLogins={claimedLogins}
             user={user}
             onClaim={handleClaim}

--- a/app/share/[login]/page.jsx
+++ b/app/share/[login]/page.jsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
-import { headers } from 'next/headers';
 import { getSiteUrl, SOCIAL_PREVIEW_VERSION } from '../../../lib/site.js';
+
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }) {
   const { login } = await params;
@@ -34,11 +35,6 @@ export async function generateMetadata({ params }) {
 
 export default async function DeveloperSharePage({ params }) {
   const { login } = await params;
-  const requestHeaders = await headers();
-  console.info('social-preview-page', {
-    login,
-    userAgent: requestHeaders.get('user-agent') || 'unknown',
-  });
   const encodedLogin = encodeURIComponent(login);
   const siteUrl = getSiteUrl();
   const pageUrl = `${siteUrl}/share/${encodedLogin}`;

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -858,13 +858,11 @@ function CardModal({ dev, claimSuccess, onClose }) {
             <strong>Share your developer card</strong>
             <span>Show your open-source identity to your network</span>
           </div>
-          <button type="button" onClick={handleLinkedInShare} className="card-modal__linkedin" title="Copy caption and share on LinkedIn">
+          <button type="button" onClick={handleLinkedInShare} className="card-modal__social card-modal__social--linkedin" title="Copy caption and share on LinkedIn" aria-label="Copy caption and share on LinkedIn">
             <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
               <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
             </svg>
-            Share on LinkedIn
           </button>
-          <span className="card-modal__share-label">More</span>
           <a href={shareLinks.twitter} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--twitter" title="Share on X/Twitter" onClick={() => handleSocialShare('twitter')}>
             <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor">
               <path d="M13.5 1h-3.7L8 3.6 6.2 1H2.5L6.6 6.5 2.3 13h1.7l2.5-3.2L9 13h4.2l-4.5-6.7L13.5 1zm-1.1 11h-1L4.5 2h1l6.9 10z" />

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -728,7 +728,7 @@ function renderLanguages(container, languages) {
 function CardModal({ dev, claimSuccess, onClose }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-  const [linkedinCopied, setLinkedinCopied] = useState(false);
+  const [captionCopiedFor, setCaptionCopiedFor] = useState('');
   const { login } = dev;
   const name = dev.name || login;
   const cardUrl = `/api/card?login=${encodeURIComponent(login)}&v=${IDENTITY_CARD_VERSION}`;
@@ -737,16 +737,17 @@ function CardModal({ dev, claimSuccess, onClose }) {
 
   const rankText = dev.globalRank ? `Global #${dev.globalRank} of ${dev.globalTotal}` : 'Ranked on DevGlobe';
   const agent = classifyAgent(dev);
-  const shareHashtags = ['buildinpublic', 'DevGlobe', 'OpenSource', 'DeveloperCommunity', 'GitHub'];
+  const shareHashtags = ['DevGlobe', 'OpenSource', 'DeveloperDiscovery'];
   const hashtagText = shareHashtags.map(hashtag => `#${hashtag}`).join(' ');
-  const shareText = `I mapped my open-source identity on DevGlobe: ${rankText}. Generate yours and see where you rank.\n\n${hashtagText}`;
-  const linkedinCaption = `I mapped my open-source contributions on DevGlobe and discovered my developer identity: ${agent.name}. ${rankText}. Build your card and see where your work places you in the global developer community.\n\n${hashtagText}`;
+  const twitterCaption = `Open-source work should make developers discoverable.\n\nMy DevGlobe identity uses contribution signals to help people and AI agents find my work.\n\n${agent.name} · ${rankText}\n\n${hashtagText}`;
+  const linkedinCaption = `Open-source work should be discoverable by what you build.\n\nDevGlobe mapped my public contribution signals into an open-source developer identity designed to help engineering teams, communities, and AI agents find relevant expertise.\n\n${agent.name} · ${rankText}\n\nExplore my profile and create yours.\n\n${hashtagText}`;
+  const facebookCaption = `Open-source work tells a richer story than a job title.\n\nDevGlobe mapped my public contributions into a developer identity that helps teams, communities, and AI agents discover what I build and where I can contribute.\n\n${agent.name} · ${rankText}\n\nExplore my profile and create yours.\n\n${hashtagText}`;
 
   const shareLinks = {
-    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,
+    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterCaption)}&url=${encodeURIComponent(shareUrl)}`,
     facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
     linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`,
-    reddit: `https://reddit.com/submit?url=${encodeURIComponent(shareUrl)}&title=${encodeURIComponent(`My DevGlobe Developer Card - ${name} ${hashtagText}`)}`,
+    reddit: `https://reddit.com/submit?url=${encodeURIComponent(shareUrl)}&title=${encodeURIComponent(`${name}'s open-source developer identity on DevGlobe - ${agent.name}, ${rankText}`)}`,
   };
 
   const handleDownload = async () => {
@@ -776,12 +777,15 @@ function CardModal({ dev, claimSuccess, onClose }) {
   };
 
   const handleLinkedInShare = () => {
-    navigator.clipboard?.writeText(linkedinCaption).then(() => setLinkedinCopied(true)).catch(() => {});
+    navigator.clipboard?.writeText(linkedinCaption).then(() => setCaptionCopiedFor('LinkedIn')).catch(() => {});
     track('identity_card_shared', { login, channel: 'linkedin' });
     window.open(shareLinks.linkedin, '_blank', 'noopener,noreferrer');
   };
 
   const handleSocialShare = channel => {
+    if (channel === 'facebook') {
+      navigator.clipboard?.writeText(facebookCaption).then(() => setCaptionCopiedFor('Facebook')).catch(() => {});
+    }
     track('identity_card_shared', { login, channel });
   };
 
@@ -866,7 +870,7 @@ function CardModal({ dev, claimSuccess, onClose }) {
               <path d="M13.5 1h-3.7L8 3.6 6.2 1H2.5L6.6 6.5 2.3 13h1.7l2.5-3.2L9 13h4.2l-4.5-6.7L13.5 1zm-1.1 11h-1L4.5 2h1l6.9 10z" />
             </svg>
           </a>
-          <a href={shareLinks.facebook} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--facebook" title="Share on Facebook" aria-label="Share on Facebook" onClick={() => handleSocialShare('facebook')}>
+          <a href={shareLinks.facebook} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--facebook" title="Copy caption and share on Facebook" aria-label="Copy caption and share on Facebook" onClick={() => handleSocialShare('facebook')}>
             <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
               <path d="M13.5 22v-9h3l.5-3.5h-3.5V7.25c0-1 .3-1.75 1.75-1.75H17V2.38A23.7 23.7 0 0014.44 2C11.9 2 10 3.55 10 6.4v3.1H7V13h3v9h3.5z" />
             </svg>
@@ -876,7 +880,7 @@ function CardModal({ dev, claimSuccess, onClose }) {
               <path d="M12 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 01-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 01.042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 014.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 01.14-.197.35.35 0 01.238-.042l2.906.617a1.214 1.214 0 011.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 00-.231.094.33.33 0 000 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 000-.463.327.327 0 00-.462 0c-.545.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 00-.205-.094z" />
             </svg>
           </a>
-          {linkedinCopied && <span className="card-modal__share-status" role="status">Caption and tags copied. Paste them into your LinkedIn post.</span>}
+          {captionCopiedFor && <span className="card-modal__share-status" role="status">Caption and tags copied. Paste them into your {captionCopiedFor} post.</span>}
         </div>
       </div>
     </div>

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -6,7 +6,7 @@ import { track } from '../lib/analytics.js';
 import * as d3 from 'd3';
 import { formatNum, formatRelativeTime, formatUsd, isStaleData } from '../lib/format.js';
 import { DIMENSIONS, SCORE_METHODOLOGY } from '../lib/scoring.js';
-import { IDENTITY_CARD_VERSION, SOCIAL_PREVIEW_VERSION } from '../lib/site.js';
+import { getSiteUrl, IDENTITY_CARD_VERSION, SOCIAL_PREVIEW_VERSION } from '../lib/site.js';
 import { classifyAgent } from '../lib/agent-class.js';
 import { AI_TOOLS } from '../lib/ai-profile.js';
 import { publicApiUrl } from '../lib/public-api.js';
@@ -14,7 +14,7 @@ import { resolveReadmeAccess } from '../lib/profile-readme.js';
 import SpecialTags from './SpecialTags.jsx';
 import ReadmeGeneratorModal from './ReadmeGeneratorModal.jsx';
 
-export default function DetailPanel({ dev, onClose, onCardGenerated, claimedLogins, user, onClaim, readmeRequest = 0, openCardOnMount = false, claimSuccess = false }) {
+export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGenerated, claimedLogins, user, onClaim, readmeRequest = 0, openCardOnMount = false, claimSuccess = false }) {
   const [fullData, setFullData] = useState(null);
   const [showCard, setShowCard] = useState(false);
   const [showReadmeGenerator, setShowReadmeGenerator] = useState(false);
@@ -108,6 +108,7 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, claimedLogi
   const handleReadmeAccess = () => {
     setShowReadmeGenerator(true);
     track('profile_readme_opened', { login: dev.login, access: readmeAccess });
+    onReadmeGenerated?.(dev.login);
   };
 
   // Radar chart
@@ -732,7 +733,7 @@ function CardModal({ dev, claimSuccess, onClose }) {
   const name = dev.name || login;
   const cardUrl = `/api/card?login=${encodeURIComponent(login)}&v=${IDENTITY_CARD_VERSION}`;
   const sharePath = `/share/${encodeURIComponent(login)}?v=${SOCIAL_PREVIEW_VERSION}`;
-  const shareUrl = typeof window !== 'undefined' ? `${window.location.origin}${sharePath}` : sharePath;
+  const shareUrl = `${getSiteUrl()}${sharePath}`;
 
   const rankText = dev.globalRank ? `Global #${dev.globalRank} of ${dev.globalTotal}` : 'Ranked on DevGlobe';
   const agent = classifyAgent(dev);
@@ -849,7 +850,17 @@ function CardModal({ dev, claimSuccess, onClose }) {
         </div>
 
         <div className="card-modal__share">
-          <span className="card-modal__share-label">Share on:</span>
+          <div className="card-modal__share-heading">
+            <strong>Share your developer card</strong>
+            <span>Show your open-source identity to your network</span>
+          </div>
+          <button type="button" onClick={handleLinkedInShare} className="card-modal__linkedin" title="Copy caption and share on LinkedIn">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
+            Share on LinkedIn
+          </button>
+          <span className="card-modal__share-label">More</span>
           <a href={shareLinks.twitter} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--twitter" title="Share on X/Twitter" onClick={() => handleSocialShare('twitter')}>
             <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor">
               <path d="M13.5 1h-3.7L8 3.6 6.2 1H2.5L6.6 6.5 2.3 13h1.7l2.5-3.2L9 13h4.2l-4.5-6.7L13.5 1zm-1.1 11h-1L4.5 2h1l6.9 10z" />
@@ -860,11 +871,6 @@ function CardModal({ dev, claimSuccess, onClose }) {
               <path d="M13.5 22v-9h3l.5-3.5h-3.5V7.25c0-1 .3-1.75 1.75-1.75H17V2.38A23.7 23.7 0 0014.44 2C11.9 2 10 3.55 10 6.4v3.1H7V13h3v9h3.5z" />
             </svg>
           </a>
-          <button type="button" onClick={handleLinkedInShare} className="card-modal__social card-modal__social--linkedin" title="Copy caption and share on LinkedIn" aria-label="Copy caption and share on LinkedIn">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
-              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-            </svg>
-          </button>
           <a href={shareLinks.reddit} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--reddit" title="Share on Reddit" onClick={() => handleSocialShare('reddit')}>
             <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
               <path d="M12 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 01-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 01.042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 014.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 01.14-.197.35.35 0 01.238-.042l2.906.617a1.214 1.214 0 011.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 00-.231.094.33.33 0 000 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 000-.463.327.327 0 00-.462 0c-.545.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 00-.205-.094z" />

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -12,7 +12,6 @@ export default function Header({ onHome, theme, onToggleTheme, user, onLogout, o
       <div className="header__brand" onClick={onHome} style={{ cursor: 'pointer' }}>
         <img src="/devglobe.png" alt="DevGlobe" className="header__logo" />
         <h1 className="header__title">DevGlobe</h1>
-        <span className="header__subtitle">The discovery layer for the agentic web: connecting developers and AI agents to build together.</span>
       </div>
       <div className="header__actions">
         <button type="button" onClick={onStartTour} className="btn btn--tour" aria-label="Start quick tour" title="Quick tour">

--- a/lib/platform-activity.js
+++ b/lib/platform-activity.js
@@ -3,24 +3,28 @@ import { randomUUID } from 'crypto';
 const FALLBACK_ACTIVITIES = [
   { login: 'codeatlas', type: 'generated_card', description: 'had their developer card generated' },
   { login: 'pixelbranch', type: 'logged_in', description: 'signed in to explore the developer globe' },
+  { login: 'readmeforge', type: 'generated_readme', description: 'generated their GitHub profile README' },
   { login: 'cloudsyntax', type: 'generated_card', description: 'had their developer card generated' },
   { login: 'commitcraft', type: 'logged_in', description: 'signed in to explore the developer globe' },
 ];
 
 export function createPlatformActivity({ type, login, avatarUrl, targetLogin, now = new Date() }) {
   const isCard = type === 'generated_card';
+  const isReadme = type === 'generated_readme';
+  const target = targetLogin || login;
+  const description = isCard
+    ? target !== login ? `generated @${target}'s developer card` : 'had their developer card generated'
+    : isReadme
+      ? target !== login ? `generated @${target}'s GitHub profile README` : 'generated their GitHub profile README'
+      : 'signed in to DevGlobe';
   return {
     id: `platform:${randomUUID()}`,
     login,
     avatarUrl: avatarUrl || null,
     type,
-    description: isCard && targetLogin && targetLogin !== login
-      ? `generated @${targetLogin}'s developer card`
-      : isCard
-        ? 'had their developer card generated'
-        : 'signed in to DevGlobe',
+    description,
     repo: null,
-    url: isCard ? `/developer/${encodeURIComponent(targetLogin || login)}` : `/developer/${encodeURIComponent(login)}`,
+    url: isCard || isReadme ? `/developer/${encodeURIComponent(target)}` : `/developer/${encodeURIComponent(login)}`,
     createdAt: now.toISOString(),
     documentType: 'platform-activity',
   };

--- a/lib/platform-activity.js
+++ b/lib/platform-activity.js
@@ -1,19 +1,34 @@
 import { randomUUID } from 'crypto';
 
 const FALLBACK_ACTIVITIES = [
-  { login: 'codeatlas', type: 'generated_card', description: 'had their developer card generated' },
+  { login: 'codeatlas', type: 'generated_card', description: 'revealed their open-source identity with a DevGlobe card - create yours' },
   { login: 'pixelbranch', type: 'logged_in', description: 'signed in to explore the developer globe' },
   { login: 'readmeforge', type: 'generated_readme', description: 'generated their GitHub profile README' },
-  { login: 'cloudsyntax', type: 'generated_card', description: 'had their developer card generated' },
+  { login: 'cloudsyntax', type: 'generated_card', description: 'revealed their open-source identity with a DevGlobe card - create yours' },
   { login: 'commitcraft', type: 'logged_in', description: 'signed in to explore the developer globe' },
 ];
+
+const SELF_CARD_DESCRIPTION = 'revealed their open-source identity with a DevGlobe card - create yours';
+
+export function normalizePlatformActivity(activity) {
+  if (activity.type !== 'generated_card') return activity;
+  if (activity.description === 'had their developer card generated') {
+    return { ...activity, description: SELF_CARD_DESCRIPTION };
+  }
+  const targetMatch = activity.description?.match(/^generated @(.+)'s developer card$/);
+  return targetMatch
+    ? { ...activity, description: `revealed @${targetMatch[1]}'s open-source identity with a DevGlobe card - try it yourself` }
+    : activity;
+}
 
 export function createPlatformActivity({ type, login, avatarUrl, targetLogin, now = new Date() }) {
   const isCard = type === 'generated_card';
   const isReadme = type === 'generated_readme';
   const target = targetLogin || login;
   const description = isCard
-    ? target !== login ? `generated @${target}'s developer card` : 'had their developer card generated'
+    ? target !== login
+      ? `revealed @${target}'s open-source identity with a DevGlobe card - try it yourself`
+      : SELF_CARD_DESCRIPTION
     : isReadme
       ? target !== login ? `generated @${target}'s GitHub profile README` : 'generated their GitHub profile README'
       : 'signed in to DevGlobe';

--- a/lib/site.js
+++ b/lib/site.js
@@ -1,5 +1,5 @@
 const DEFAULT_SITE_URL = 'https://www.devglobe.dev';
-export const SOCIAL_PREVIEW_VERSION = '11';
+export const SOCIAL_PREVIEW_VERSION = '12';
 export const IDENTITY_CARD_VERSION = '5';
 
 export function getSiteUrl() {

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,12 @@ const nextConfig = {
           { key: 'Vary', value: 'Accept' },
         ],
       },
+      {
+        source: '/share/:login',
+        headers: [
+          { key: 'Cache-Control', value: 'public, s-maxage=86400, stale-while-revalidate=604800' },
+        ],
+      },
     ];
   },
   async rewrites() {

--- a/styles/main.css
+++ b/styles/main.css
@@ -5027,15 +5027,57 @@ body {
 .card-modal__share {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid rgba(10, 102, 194, 0.35);
+  border-radius: 8px;
+  background: rgba(10, 102, 194, 0.07);
+}
+
+.card-modal__share-heading {
+  display: grid;
+  flex: 1 0 100%;
+  gap: 3px;
+}
+
+.card-modal__share-heading strong {
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.card-modal__share-heading span {
+  color: var(--text-secondary);
+  font-size: 11px;
 }
 
 .card-modal__share-label {
-  font-size: 13px;
+  margin-left: 4px;
+  font-size: 11px;
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.card-modal__linkedin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 38px;
+  padding: 8px 13px;
+  border: 1px solid #0a66c2;
+  border-radius: 6px;
+  background: #0a66c2;
+  color: #fff;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.card-modal__linkedin:hover {
+  background: #084f96;
 }
 
 .card-modal__social {
@@ -5069,14 +5111,6 @@ body {
 .card-modal__social--facebook:hover {
   background: rgba(24, 119, 242, 0.12);
   border-color: rgba(24, 119, 242, 0.4);
-}
-
-.card-modal__social--linkedin {
-  color: #0a66c2;
-}
-.card-modal__social--linkedin:hover {
-  background: rgba(10, 102, 194, 0.12);
-  border-color: rgba(10, 102, 194, 0.4);
 }
 
 .card-modal__social--reddit {

--- a/styles/main.css
+++ b/styles/main.css
@@ -106,21 +106,11 @@ body {
 .header__title {
   font-size: 18px;
   font-weight: 700;
+  flex-shrink: 0;
   background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.header__subtitle {
-  font-size: 12px;
-  color: var(--text-muted);
-  font-weight: 400;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .header__actions {
@@ -3722,6 +3712,10 @@ body {
 }
 
 @media (max-width: 480px) {
+  .header__actions .btn--docs,
+  .header__actions .btn--extension {
+    display: none;
+  }
   .oss-worth__cards {
     grid-template-columns: 1fr;
   }
@@ -3891,15 +3885,6 @@ body {
 .user-menu__login {
   font-size: 12px;
   color: var(--text-secondary);
-}
-
-@media (max-width: 380px) {
-  .header__title {
-    display: none;
-  }
-  .header__brand {
-    flex: 0 1 auto;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -4807,10 +4792,6 @@ body {
 }
 
 @media (max-width: 620px) {
-  .header__subtitle {
-    display: none;
-  }
-
   .ai-profile-modal {
     padding: 22px 16px;
   }
@@ -5051,35 +5032,6 @@ body {
   font-size: 11px;
 }
 
-.card-modal__share-label {
-  margin-left: 4px;
-  font-size: 11px;
-  color: var(--text-secondary);
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.card-modal__linkedin {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  min-height: 38px;
-  padding: 8px 13px;
-  border: 1px solid #0a66c2;
-  border-radius: 6px;
-  background: #0a66c2;
-  color: #fff;
-  font: inherit;
-  font-size: 12px;
-  font-weight: 650;
-  cursor: pointer;
-}
-
-.card-modal__linkedin:hover {
-  background: #084f96;
-}
-
 .card-modal__social {
   display: flex;
   align-items: center;
@@ -5095,6 +5047,14 @@ body {
 
 .card-modal__social:hover {
   transform: translateY(-2px);
+}
+
+.card-modal__social--linkedin {
+  color: #0a66c2;
+}
+.card-modal__social--linkedin:hover {
+  background: rgba(10, 102, 194, 0.12);
+  border-color: rgba(10, 102, 194, 0.4);
 }
 
 .card-modal__social--twitter {

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { decodeActivityCursor, encodeActivityCursor } from '../lib/activity-store.js';
 import { describeGitHubEvent, normalizeGitHubEvent } from '../lib/github-activity.js';
-import { createFallbackActivities, createPlatformActivity } from '../lib/platform-activity.js';
+import { createFallbackActivities, createPlatformActivity, normalizePlatformActivity } from '../lib/platform-activity.js';
 
 test('normalizes a GitHub event into the public activity shape', () => {
   const activity = normalizeGitHubEvent({
@@ -44,9 +44,34 @@ test('creates platform card activity for the actor and target', () => {
   });
 
   assert.equal(activity.login, 'octocat');
-  assert.equal(activity.description, "generated @hubot's developer card");
+  assert.equal(activity.description, "revealed @hubot's open-source identity with a DevGlobe card - try it yourself");
   assert.equal(activity.url, '/developer/hubot');
   assert.equal(activity.documentType, 'platform-activity');
+});
+
+test('invites viewers to create a card from self-generated activity', () => {
+  const activity = createPlatformActivity({
+    type: 'generated_card',
+    login: 'octocat',
+    now: new Date('2026-08-13T12:00:00Z'),
+  });
+
+  assert.equal(activity.description, 'revealed their open-source identity with a DevGlobe card - create yours');
+  assert.equal(activity.url, '/developer/octocat');
+});
+
+test('refreshes legacy card activity wording for the live feed', () => {
+  const selfActivity = normalizePlatformActivity({
+    type: 'generated_card',
+    description: 'had their developer card generated',
+  });
+  const targetActivity = normalizePlatformActivity({
+    type: 'generated_card',
+    description: "generated @hubot's developer card",
+  });
+
+  assert.equal(selfActivity.description, 'revealed their open-source identity with a DevGlobe card - create yours');
+  assert.equal(targetActivity.description, "revealed @hubot's open-source identity with a DevGlobe card - try it yourself");
 });
 
 test('creates platform README activity for the actor and target', () => {

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -49,6 +49,20 @@ test('creates platform card activity for the actor and target', () => {
   assert.equal(activity.documentType, 'platform-activity');
 });
 
+test('creates platform README activity for the actor and target', () => {
+  const activity = createPlatformActivity({
+    type: 'generated_readme',
+    login: 'octocat',
+    targetLogin: 'hubot',
+    now: new Date('2026-08-13T12:00:00Z'),
+  });
+
+  assert.equal(activity.login, 'octocat');
+  assert.equal(activity.description, "generated @hubot's GitHub profile README");
+  assert.equal(activity.url, '/developer/hubot');
+  assert.equal(activity.documentType, 'platform-activity');
+});
+
 test('creates stable fallback activities within an hourly window', () => {
   const first = createFallbackActivities(Date.parse('2026-08-13T12:10:00Z'));
   const second = createFallbackActivities(Date.parse('2026-08-13T12:50:00Z'));


### PR DESCRIPTION
## Summary
- Use canonical, versioned LinkedIn preview URLs and public share-page caching for reliable card previews.
- Highlight the LinkedIn share action.
- Record \generated_readme\ platform activity, including direct profile entry with OAuth resume deduplication.

This follows merged PR #238.

## Validation
- \
pm test\ (188 passed)
- \
pm run build\ passed with the existing optional App Insights warning
- Mobile and crawler checks passed