### PR TITLE
Ensure every developer has a numeric score

### DIFF
--- a/app/api/developer/route.js
+++ b/app/api/developer/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { getPublicAiProfile } from '../../../lib/ai-profile.js';
+import { withNumericScore } from '../../../lib/developer-score.js';
 
 const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
 const COSMOS_KEY = process.env.COSMOS_KEY;
@@ -16,12 +17,13 @@ async function getSampleData() {
 }
 
 function withPublicAiProfile(developer) {
-  const aiProfile = getPublicAiProfile(developer.aiProfile);
+  const scoredDeveloper = withNumericScore(developer);
+  const aiProfile = getPublicAiProfile(scoredDeveloper.aiProfile);
   if (!aiProfile) {
-    const { aiProfile: omitted, ...publicDeveloper } = developer;
+    const { aiProfile: omitted, ...publicDeveloper } = scoredDeveloper;
     return publicDeveloper;
   }
-  return { ...developer, aiProfile };
+  return { ...scoredDeveloper, aiProfile };
 }
 
 export async function GET(request) {

--- a/app/api/developers/route.js
+++ b/app/api/developers/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { projectAgentReadiness } from '../../../lib/agent-network.js';
+import { withNumericScore } from '../../../lib/developer-score.js';
 import { parsePaginationParams } from '../../../lib/pagination.js';
 
 const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
@@ -17,7 +18,7 @@ async function getSampleData() {
 }
 
 function projectAgentReadinessList(developers) {
-  return developers.map(projectAgentReadiness);
+  return developers.map(withNumericScore).map(projectAgentReadiness);
 }
 
 // GET /api/developers            -> full array (legacy shape, unchanged for existing callers)

--- a/lib/developer-dataset.js
+++ b/lib/developer-dataset.js
@@ -1,12 +1,10 @@
 import { addDeveloperRanks } from './ranking.js';
 import { withOssWorth } from './oss-worth.js';
+import { withNumericScore } from './developer-score.js';
 
 export function prepareDeveloperDataset(developers = []) {
   const ranked = [...developers]
-    .map(developer => ({
-      ...developer,
-      score: Number.isFinite(developer.score) ? developer.score : 0,
-    }))
+    .map(withNumericScore)
     .sort((left, right) =>
       right.score - left.score || String(left.login || '').localeCompare(String(right.login || ''))
     );

--- a/lib/developer-score.js
+++ b/lib/developer-score.js
@@ -1,0 +1,6 @@
+export function withNumericScore(developer) {
+  return {
+    ...developer,
+    score: Number.isFinite(developer.score) ? developer.score : 0,
+  };
+}

--- a/lib/scoring.js
+++ b/lib/scoring.js
@@ -190,6 +190,12 @@ export function scoreAll(developers) {
     .sort((a, b) => b.score - a.score);
 }
 
+export function scoreDeveloperForDataset(developer, developers = []) {
+  const developerId = developer.id || developer.login;
+  const peers = developers.filter(candidate => (candidate.id || candidate.login) !== developerId);
+  return scoreAll([...peers, developer]).find(candidate => (candidate.id || candidate.login) === developerId);
+}
+
 export function getPlatformColor(dimensions) {
   const githubStrength = dimensions.stars + dimensions.commits + dimensions.repoReach;
   const soStrength = dimensions.soReputation + dimensions.soEngagement;

--- a/scripts/review-nominations.js
+++ b/scripts/review-nominations.js
@@ -26,6 +26,7 @@ import {
 } from '../lib/nominate.js';
 import { buildNominationApprovedEmail, sendLifecycleEmail } from '../lib/lifecycle-email.js';
 import { getDeveloperContact } from '../lib/developer-contact-store.js';
+import { scoreDeveloperForDataset } from '../lib/scoring.js';
 
 dotenv.config({ path: '.env.local' });
 dotenv.config();
@@ -106,24 +107,43 @@ async function approve(container, username, reviewer, refresh = false) {
   // itself (the partition key) is intentionally never changed here — only
   // lat/lng and other non-partition fields are updated.
   const coords = await geocodeLocation(dev.location);
+  const profileUpdate = {
+    name: enriched.name,
+    avatarUrl: enriched.avatarUrl,
+    bio: enriched.bio,
+    githubUrl: enriched.githubUrl,
+    followers: enriched.followers,
+    publicRepos: enriched.publicRepos,
+    totalStars: enriched.totalStars,
+    totalForks: enriched.totalForks,
+    totalWatchers: enriched.totalWatchers,
+    totalCommits: enriched.totalCommits,
+    topLanguage: enriched.topLanguage,
+    languages: enriched.languages,
+    topRepos: enriched.topRepos,
+    metricsUpdatedAt: new Date().toISOString(),
+    ...(coords ? { lat: coords.lat, lng: coords.lng } : {}),
+  };
+
+  const { resources: publicDevelopers } = await container.items.query({
+    query: `SELECT c.id, c.login, c.followers, c.totalStars, c.totalForks, c.totalWatchers,
+      c.totalCommits, c.soUserId, c.soReputation, c.soAnswers, c.soAcceptRate, c.soBadges
+      FROM c WHERE (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved') AND c.id != @id`,
+    parameters: [{ name: '@id', value: dev.id }],
+  }).fetchAll();
+  const scored = scoreDeveloperForDataset({ ...dev, ...profileUpdate }, publicDevelopers);
+  const scoreUpdate = {
+    score: scored.score,
+    scoreDimensions: scored.scoreDimensions,
+    scoreWeights: scored.scoreWeights,
+    scoreHasSO: scored.scoreHasSO,
+    scorePercentile: scored.scorePercentile,
+  };
 
   try {
     await patchDeveloperNomination(container, dev, {
-      name: enriched.name,
-      avatarUrl: enriched.avatarUrl,
-      bio: enriched.bio,
-      githubUrl: enriched.githubUrl,
-      followers: enriched.followers,
-      publicRepos: enriched.publicRepos,
-      totalStars: enriched.totalStars,
-      totalForks: enriched.totalForks,
-      totalWatchers: enriched.totalWatchers,
-      totalCommits: enriched.totalCommits,
-      topLanguage: enriched.topLanguage,
-      languages: enriched.languages,
-      topRepos: enriched.topRepos,
-      metricsUpdatedAt: new Date().toISOString(),
-      ...(coords ? { lat: coords.lat, lng: coords.lng } : {}),
+      ...profileUpdate,
+      ...scoreUpdate,
       ...(dev.nomination ? { nomination: {
         status: refresh ? dev.nomination.status : 'approved',
         reviewedAt: refresh ? dev.nomination.reviewedAt : new Date().toISOString(),

--- a/tests/developer-score.test.js
+++ b/tests/developer-score.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { withNumericScore } from '../lib/developer-score.js';
+
+test('preserves a numeric developer score', () => {
+  const developer = { login: 'scored', score: 72 };
+
+  assert.deepEqual(withNumericScore(developer), developer);
+  assert.notEqual(withNumericScore(developer), developer);
+});
+
+test('defaults absent or invalid developer scores to zero', () => {
+  for (const score of [undefined, null, '72', Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(withNumericScore({ login: 'unscored', score }).score, 0);
+  }
+});

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { scoreDeveloperForDataset } from '../lib/scoring.js';
+
+test('scores a sparse developer against the current dataset', () => {
+  const developer = { id: 'new', login: 'new', followers: 10 };
+  const peers = [
+    { id: 'top', login: 'top', followers: 1000, totalStars: 500 },
+    { id: 'new', login: 'new', followers: 1 },
+  ];
+
+  const scored = scoreDeveloperForDataset(developer, peers);
+
+  assert.equal(Number.isFinite(scored.score), true);
+  assert.equal(Number.isFinite(scored.scorePercentile), true);
+  assert.equal(scored.scoreHasSO, false);
+  assert.equal(scored.id, 'new');
+});


### PR DESCRIPTION
## Summary
- normalize absent or invalid stored scores to 0 across single-profile, list API, and dataset paths
- score nominations against current public peers before approval so new public profiles include all derived score fields
- add focused regression tests for sparse and stale profiles

## Validation
- npm test (193 passed)
- npm run build
- git diff --check

## Follow-up
Existing stale Cosmos documents still require a successful `npm run rescore-developers` dry run followed by `npm run rescore-developers -- --apply` to persist their recalculated relative scores.
Do not merge. Report PR URL and state. Do not edit files.
