### PR TITLE
feat: add claimed profile visibility insights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ COSMOS_DATABASE=devglobe
 COSMOS_CONTAINER=developers
 COSMOS_ACTIVITY_CONTAINER=activities
 COSMOS_CONTACTS_CONTAINER=developer-contacts
+COSMOS_ENGAGEMENT_CONTAINER=engagement-events
+# HMACs browser session IDs before storage; SESSION_SECRET is used when omitted.
+ENGAGEMENT_HASH_SECRET=your_random_engagement_hash_secret
+# Logs allow-listed events in the browser during local analytics verification.
+NEXT_PUBLIC_ANALYTICS_DEBUG=false
 
 # Protects the server-to-server global activity collector endpoint.
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Required environment variables:
 | `COSMOS_CONTAINER` | Container name |
 | `COSMOS_ACTIVITY_CONTAINER` | Rolling GitHub activity container (`activities`) |
 | `COSMOS_CONTACTS_CONTAINER` | Private lifecycle-email contact container (`developer-contacts`) |
+| `COSMOS_ENGAGEMENT_CONTAINER` | Privacy-filtered engagement events (default: `engagement-events`) |
+| `ENGAGEMENT_HASH_SECRET` | HMAC secret for session-window deduplication; defaults to `SESSION_SECRET` |
 | `ACTIVITY_INGEST_SECRET` | Bearer secret for the activity collector endpoint |
 | `RESEND_API_KEY` | Optional Resend API key for claim and approval emails |
 | `EMAIL_FROM` | Sender on a domain verified by Resend |
@@ -230,6 +232,8 @@ npm run setup-contacts-container
 ```
 
 See the [lifecycle email PRD](docs/prd/lifecycle-email-notifications.md).
+
+Claimed-profile visibility insights use allow-listed engagement events with hashed session IDs. Create the TTL-enabled container before deployment with `node scripts/setup-engagement-container.js`. See the [engagement analytics contract](docs/prd/engagement-analytics.md) for event semantics, privacy thresholds, and deletion behavior.
 
 Verified users can explicitly opt in to a Monday weekly digest from the user menu. The digest includes current global and country rankings, rank movement since the previous digest, current DevGlobe features, and an Explore DevGlobe link. The Azure Functions app invokes `/api/cron/weekly-digest` at 13:00 UTC each Monday; only verified contacts with `productUpdatesEnabled: true` are eligible. Each message uses a per-user, per-week idempotency key and includes one-click unsubscribe headers and a signed unsubscribe link.
 

--- a/app/api/engagement/route.js
+++ b/app/api/engagement/route.js
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { createEngagementEvent, EngagementValidationError, isAutomatedUserAgent, resolveEngagementSession } from '../../../lib/engagement.js';
+import { getEngagementContainer, saveEngagementEvent } from '../../../lib/engagement-store.js';
+
+const MAX_BATCH_SIZE = 50;
+const SESSION_COOKIE = 'devglobe-engagement-session';
+
+export async function POST(request) {
+  try {
+    const userAgent = request.headers.get('user-agent');
+    const destination = request.headers.get('sec-fetch-dest');
+    if (isAutomatedUserAgent(userAgent) || destination === 'image') {
+      return NextResponse.json({ accepted: 0, automated: true }, { status: 202 });
+    }
+
+    const container = getEngagementContainer();
+    if (!container) return NextResponse.json({ error: 'Engagement tracking is unavailable' }, { status: 503 });
+    const body = await request.json();
+    const inputs = Array.isArray(body.events) ? body.events : [body];
+    if (inputs.length === 0 || inputs.length > MAX_BATCH_SIZE) {
+      return NextResponse.json({ error: 'Events must contain between 1 and 50 items' }, { status: 400 });
+    }
+    const secret = process.env.ENGAGEMENT_HASH_SECRET || process.env.SESSION_SECRET;
+    if (!secret) return NextResponse.json({ error: 'Engagement tracking is unavailable' }, { status: 503 });
+    const session = resolveEngagementSession(request.cookies.get(SESSION_COOKIE)?.value, secret, randomUUID);
+    const privacyKey = request.headers.get('x-azure-clientip')
+      || request.headers.get('cf-connecting-ip')
+      || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      || 'unknown';
+
+    const events = inputs.map(input => createEngagementEvent(input, { session: session.id, secret, privacyKey }));
+    const results = await Promise.all(events.map(event => saveEngagementEvent(container, event)));
+    const response = NextResponse.json({ accepted: results.filter(Boolean).length, duplicates: results.filter(result => !result).length }, { status: 202 });
+    if (session.cookieValue) {
+      response.cookies.set(SESSION_COOKIE, session.cookieValue, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+      });
+    }
+    return response;
+  } catch (error) {
+    if (error instanceof EngagementValidationError || error instanceof SyntaxError) {
+      return NextResponse.json({ error: error.message || 'Invalid event payload' }, { status: 400 });
+    }
+    console.error('Engagement ingestion failed:', error.message);
+    return NextResponse.json({ error: 'Unable to record engagement' }, { status: 500 });
+  }
+}

--- a/app/api/profile-insights/route.js
+++ b/app/api/profile-insights/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../lib/auth.js';
+import { getCosmosContainer } from '../../../lib/cosmos.js';
+import { aggregateProfileInsights, ENGAGEMENT_RETENTION_DAYS, isVerifiedProfileOwner } from '../../../lib/engagement.js';
+import { getEngagementContainer, loadProfileEngagementEvents } from '../../../lib/engagement-store.js';
+
+async function getDeveloper(container, login) {
+  const { resources } = await container.items.query({
+    query: 'SELECT TOP 1 c.id, c.login, c.claimed FROM c WHERE LOWER(c.login) = @login',
+    parameters: [{ name: '@login', value: login.toLowerCase() }],
+  }).fetchAll();
+  return resources[0] || null;
+}
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.login) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    const developerContainer = getCosmosContainer();
+    const engagementContainer = getEngagementContainer();
+    if (!developerContainer || !engagementContainer) {
+      return NextResponse.json({ error: 'Profile insights are unavailable' }, { status: 503 });
+    }
+    const developer = await getDeveloper(developerContainer, session.login);
+    if (!isVerifiedProfileOwner(session, developer)) {
+      return NextResponse.json({ error: 'Claim your profile first' }, { status: 403 });
+    }
+    const now = new Date();
+    const since = new Date(now.getTime() - ENGAGEMENT_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+    const events = await loadProfileEngagementEvents(engagementContainer, developer.login, since);
+    return NextResponse.json(aggregateProfileInsights(events, { now }), { headers: { 'Cache-Control': 'private, no-store' } });
+  } catch (error) {
+    console.error('Profile insights read failed:', error.message);
+    return NextResponse.json({ error: 'Unable to load profile insights' }, { status: 500 });
+  }
+}

--- a/components/AppInsights.jsx
+++ b/components/AppInsights.jsx
@@ -30,13 +30,17 @@ export default function AppInsights({ connectionString: connectionStringProp }) 
           },
         });
         appInsights.loadAppInsights();
+        window.__DEVGLOBE_APP_INSIGHTS__ = appInsights;
         appInsights.trackPageView();
       } catch {
         // Analytics is best-effort; never block the app if it fails to load.
       }
     })();
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      delete window.__DEVGLOBE_APP_INSIGHTS__;
+    };
   }, [connectionStringProp]);
 
   return null;

--- a/components/ComparePanel.jsx
+++ b/components/ComparePanel.jsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { track } from '../lib/analytics.js';
 import { formatNum } from '../lib/format.js';
 
 const METRICS = [
@@ -12,6 +13,10 @@ const METRICS = [
 
 export default function ComparePanel({ devs, onClose }) {
   const [devA, devB] = devs;
+
+  useEffect(() => {
+    track('comparison_started', { source: 'compare_panel' });
+  }, []);
 
   return (
     <div className="compare-panel-backdrop" onClick={onClose}>

--- a/components/ProfileInsights.jsx
+++ b/components/ProfileInsights.jsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import { formatNum } from '../lib/format.js';
+
+const LABELS = {
+  profileViews: 'Profile views',
+  searchAppearances: 'Search appearances',
+  cardGenerations: 'Cards generated',
+  shareActions: 'Share actions',
+};
+
+function Trend({ metric }) {
+  if (metric.value == null) return <span className="profile-insights__private">Private until 3 sessions</span>;
+  if (metric.change == null) return <span className="profile-insights__trend">No prior comparison</span>;
+  const direction = metric.change > 0 ? 'up' : metric.change < 0 ? 'down' : '';
+  return <span className={`profile-insights__trend${direction ? ` profile-insights__trend--${direction}` : ''}`}>{metric.change > 0 ? '+' : ''}{formatNum(metric.change)} vs prior</span>;
+}
+
+export default function ProfileInsights() {
+  const [open, setOpen] = useState(false);
+  const [result, setResult] = useState(null);
+  const [period, setPeriod] = useState(7);
+  const [status, setStatus] = useState('idle');
+
+  async function toggle() {
+    const nextOpen = !open;
+    setOpen(nextOpen);
+    if (!nextOpen || result || status === 'loading') return;
+    setStatus('loading');
+    try {
+      const response = await fetch('/api/profile-insights', { cache: 'no-store' });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error);
+      setResult(data);
+      setStatus('ready');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  const selected = result?.periods.find(item => item.days === period);
+  return (
+    <div className="profile-insights">
+      <button type="button" className="user-menu__item" onClick={toggle} aria-expanded={open}>
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <path d="M3 3v18h18" /><path d="m7 15 4-4 3 3 5-6" />
+        </svg>
+        Visibility insights
+        <span className="profile-insights__chevron">{open ? '−' : '+'}</span>
+      </button>
+      {open && (
+        <section className="profile-insights__panel" aria-label="Private profile visibility insights">
+          {status === 'loading' && <p>Loading insights...</p>}
+          {status === 'error' && <p>Insights are unavailable right now.</p>}
+          {selected && (
+            <>
+              <div className="profile-insights__periods" aria-label="Insights period">
+                {result.periods.map(item => (
+                  <button type="button" key={item.days} className={period === item.days ? 'active' : ''} onClick={() => setPeriod(item.days)}>{item.days}d</button>
+                ))}
+              </div>
+              <div className="profile-insights__metrics">
+                {Object.entries(selected.metrics).map(([name, metric]) => (
+                  <div key={name}>
+                    <span>{LABELS[name]}</span>
+                    <strong>{metric.value == null ? '—' : formatNum(metric.value)}</strong>
+                    <Trend metric={metric} />
+                  </div>
+                ))}
+              </div>
+              <p className="profile-insights__note">Search terms and visitor identities are never shown. Low-volume metrics stay private.</p>
+            </>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useCallback } from 'react';
 import SpecialTags from './SpecialTags.jsx';
+import { trackSearchAppearances } from '../lib/analytics.js';
 import { countryKey } from '../lib/country.js';
 import { publicApiUrl } from '../lib/public-api.js';
 
@@ -78,6 +79,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
       onResults(results);
       setResultCount(results.length);
       setSingleResult(results.length === 1 ? results[0] : null);
+      trackSearchAppearances(results.map(result => result.login), m);
       onSearchState?.({ query: q.trim(), results });
       return;
     }
@@ -101,6 +103,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
           ? developers.find(developer => developer.login === results[0].login) || results[0]
           : null;
         setSingleResult(matchedDeveloper);
+        trackSearchAppearances(results.map(result => result.login), m);
         onSearchState?.({ query: q.trim(), results });
       }
     } catch (e) {

--- a/components/UserMenu.jsx
+++ b/components/UserMenu.jsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { track } from '../lib/analytics.js';
 import ProfileCompletionChecklist from './ProfileCompletionChecklist.jsx';
+import ProfileInsights from './ProfileInsights.jsx';
 
 export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenProfile, onGenerateCard, completionVersion, claimStatus }) {
   const [open, setOpen] = useState(false);
@@ -162,6 +163,7 @@ export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onO
                 onGenerateCard={onGenerateCard}
                 onCloseMenu={() => setOpen(false)}
               />
+              <ProfileInsights />
               <button className="user-menu__item" onClick={() => { onEditAiProfile(); setOpen(false); }}>
                 <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M12 8V4H8" />

--- a/docs/prd/engagement-analytics.md
+++ b/docs/prd/engagement-analytics.md
@@ -1,0 +1,21 @@
+# Engagement analytics and profile visibility
+
+## Event contract
+
+DevGlobe records intentional browser actions only. `profile_viewed`, `card_generated`, `profile_shared`, and `search_appearance` include the public target login needed to build owner insights. `comparison_started`, `recommendation_opened`, `next_action_selected`, and `session_restored` measure the broader engagement funnel. Optional properties are limited to `action`, `channel`, `journey`, and `source`, each capped at 40 characters.
+
+Search text, email addresses, OAuth data, IP addresses, and raw browser session IDs are never stored. Search appearance events contain only the public logins displayed in the result set and the search mode.
+
+## Counting and privacy
+
+The server rejects missing and known automated user agents, social preview crawlers, and direct image requests. It issues a signed, HTTP-only browser-session cookie and rejects forged session identities; raw session IDs are HMACed before storage. Repeated events for the same session, event name, target profile, action qualifier, and 30-minute window produce the same Cosmos item ID and are idempotent. The minimum-volume threshold counts separately HMACed network cohorts, so deleting or rotating a browser cookie cannot reveal a low-volume metric.
+
+Profile insights show 7, 30, and 90-day event counts with the immediately preceding period. A metric is suppressed unless at least three distinct hashed sessions contributed during that period. Only an authenticated GitHub owner whose matching profile is claimed can read the private panel.
+
+An engaged session contains at least two distinct meaningful event types or a card generation followed by another meaningful action. Returning-user reporting compares a claimed user's first session in a 7 or 30-day period with an earlier session. Funnel reporting uses `card_generated` followed by a different meaningful event in the same hashed session.
+
+## Retention and deletion
+
+Raw allow-listed events have item-level Cosmos TTL and expire after 180 days, which supports current and prior 90-day comparisons. Aggregate responses are computed on demand and are not persisted. Session hashes cannot be reversed without the server secret and rotate when that secret changes.
+
+When a profile is removed, its event partition should be deleted as part of the same administrative removal workflow. Until that workflow runs, TTL remains the deletion backstop. Rotating `ENGAGEMENT_HASH_SECRET` prevents future sessions from being linked to earlier hashes.

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,1 +1,58 @@
-export function track() {}
+const ENGAGEMENT_EVENT_MAP = {
+	agent_profile_shared: 'profile_shared',
+	card_generated: 'card_generated',
+	comparison_started: 'comparison_started',
+	identity_card_shared: 'profile_shared',
+	next_action_selected: 'next_action_selected',
+	profile_viewed: 'profile_viewed',
+	recommendation_opened: 'recommendation_opened',
+	session_restored: 'session_restored',
+};
+const ALLOWED_PROPERTIES = new Set(['action', 'channel', 'journey', 'source']);
+
+function safeProperties(properties) {
+	return Object.fromEntries(Object.entries(properties || {})
+		.filter(([key, value]) => ALLOWED_PROPERTIES.has(key) && typeof value === 'string'));
+}
+
+function send(events) {
+	if (typeof window === 'undefined' || events.length === 0) return;
+	try {
+		fetch('/api/engagement', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ events }),
+			keepalive: true,
+		}).catch(() => {});
+		if (process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === 'true') console.debug('[analytics]', events);
+	} catch {
+		// Analytics must never block the product action being measured.
+	}
+}
+
+export function track(name, properties = {}) {
+	if (typeof window === 'undefined') return;
+	try {
+		window.__DEVGLOBE_APP_INSIGHTS__?.trackEvent({ name }, safeProperties(properties));
+	} catch {
+		// Continue with durable ingestion when the optional RUM client fails.
+	}
+	const eventName = ENGAGEMENT_EVENT_MAP[name];
+	if (!eventName) return;
+	send([{
+		eventName,
+		targetLogin: properties.login,
+		properties: safeProperties(properties),
+	}]);
+}
+
+export function trackSearchAppearances(logins, source) {
+	const events = [...new Set(logins.map(login => String(login || '').trim()).filter(Boolean))]
+		.slice(0, 50)
+		.map(targetLogin => ({
+			eventName: 'search_appearance',
+			targetLogin,
+			properties: { source },
+		}));
+	send(events);
+}

--- a/lib/engagement-store.js
+++ b/lib/engagement-store.js
@@ -1,0 +1,30 @@
+import { getCosmosContainer } from './cosmos.js';
+
+export function getEngagementContainer() {
+  return getCosmosContainer(process.env.COSMOS_ENGAGEMENT_CONTAINER || 'engagement-events');
+}
+
+export async function saveEngagementEvent(container, event) {
+  try {
+    await container.items.create(event);
+    return true;
+  } catch (error) {
+    if (error.code === 409 || error.statusCode === 409) return false;
+    throw error;
+  }
+}
+
+export async function loadProfileEngagementEvents(container, login, since) {
+  const { resources } = await container.items.query({
+    query: `SELECT c.eventName, c.createdAt, c.sessionHash, c.privacyHash
+      FROM c
+      WHERE c.targetLogin = @login
+        AND c.documentType = "engagement-event"
+        AND c.createdAt >= @since`,
+    parameters: [
+      { name: '@login', value: login.toLowerCase() },
+      { name: '@since', value: since.toISOString() },
+    ],
+  }, { partitionKey: login.toLowerCase() }).fetchAll();
+  return resources;
+}

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -1,0 +1,158 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const ENGAGEMENT_EVENTS = new Set([
+  'card_generated',
+  'comparison_started',
+  'next_action_selected',
+  'profile_shared',
+  'profile_viewed',
+  'recommendation_opened',
+  'search_appearance',
+  'session_restored',
+]);
+
+export const ENGAGEMENT_RETENTION_DAYS = 180;
+export const ENGAGEMENT_DEDUPLICATION_MS = 30 * 60 * 1000;
+export const INSIGHTS_PRIVACY_THRESHOLD = 3;
+const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+const BOT_PATTERN = /bot|crawler|spider|preview|slurp|facebookexternalhit|linkedinbot|twitterbot|whatsapp|discordbot/i;
+const ALLOWED_PROPERTIES = new Set(['action', 'channel', 'journey', 'source']);
+
+export class EngagementValidationError extends Error {}
+
+export function isAutomatedUserAgent(userAgent) {
+  return !userAgent || BOT_PATTERN.test(String(userAgent));
+}
+
+function normalizeTargetLogin(value) {
+  const login = String(value || '').trim().toLowerCase();
+  if (!login) return null;
+  if (!LOGIN_PATTERN.test(login)) throw new EngagementValidationError('Invalid target login');
+  return login;
+}
+
+function normalizeProperties(value) {
+  if (value == null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new EngagementValidationError('Invalid event properties');
+  }
+  const properties = {};
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (!ALLOWED_PROPERTIES.has(key)) continue;
+    if (typeof rawValue !== 'string') throw new EngagementValidationError(`Invalid ${key}`);
+    const normalized = rawValue.trim().slice(0, 40);
+    if (normalized) properties[key] = normalized;
+  }
+  return properties;
+}
+
+export function normalizeEngagementEvent(input) {
+  const eventName = String(input?.eventName || '').trim();
+  if (!ENGAGEMENT_EVENTS.has(eventName)) throw new EngagementValidationError('Unsupported engagement event');
+  const targetLogin = normalizeTargetLogin(input.targetLogin);
+  if (['card_generated', 'profile_shared', 'profile_viewed', 'search_appearance'].includes(eventName) && !targetLogin) {
+    throw new EngagementValidationError('Target login is required');
+  }
+  return { eventName, targetLogin, properties: normalizeProperties(input.properties) };
+}
+
+export function createEngagementEvent(input, options = {}) {
+  const normalized = normalizeEngagementEvent(input);
+  const now = options.now ? new Date(options.now) : new Date();
+  const secret = String(options.secret || 'development-engagement-secret');
+  const session = String(options.session || '');
+  if (!session) throw new EngagementValidationError('Session is required');
+  const sessionHash = createHmac('sha256', secret).update(session).digest('base64url');
+  const privacyHash = createHmac('sha256', secret).update(`privacy:${options.privacyKey || 'unknown'}`).digest('base64url');
+  const window = Math.floor(now.getTime() / ENGAGEMENT_DEDUPLICATION_MS);
+  const qualifier = normalized.eventName === 'profile_shared'
+    ? normalized.properties.channel || ''
+    : normalized.eventName === 'next_action_selected'
+      ? normalized.properties.action || ''
+      : normalized.eventName === 'recommendation_opened'
+        ? normalized.properties.journey || ''
+        : '';
+  const eventKey = [sessionHash, normalized.eventName, normalized.targetLogin || '', qualifier, window].join(':');
+  const id = createHmac('sha256', secret).update(eventKey).digest('base64url');
+  const day = now.toISOString().slice(0, 10);
+
+  return {
+    id,
+    documentType: 'engagement-event',
+    day,
+    createdAt: now.toISOString(),
+    eventName: normalized.eventName,
+    targetLogin: normalized.targetLogin,
+    partitionKey: normalized.targetLogin || `day:${day}`,
+    sessionHash,
+    privacyHash,
+    properties: normalized.properties,
+    actorType: 'human',
+    ttl: ENGAGEMENT_RETENTION_DAYS * 24 * 60 * 60,
+    schemaVersion: 1,
+  };
+}
+
+export function resolveEngagementSession(cookieValue, secret, createId) {
+  const [id, signature] = String(cookieValue || '').split('.');
+  if (id && signature) {
+    const expected = createHmac('sha256', secret).update(id).digest('base64url');
+    const actualBuffer = Buffer.from(signature);
+    const expectedBuffer = Buffer.from(expected);
+    if (actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)) {
+      return { id, cookieValue: null };
+    }
+  }
+  const newId = createId();
+  const newSignature = createHmac('sha256', secret).update(newId).digest('base64url');
+  return { id: newId, cookieValue: `${newId}.${newSignature}` };
+}
+
+function metric(events, eventNames, start, end, threshold) {
+  const matching = events.filter(event => eventNames.includes(event.eventName)
+    && Date.parse(event.createdAt) >= start.getTime()
+    && Date.parse(event.createdAt) < end.getTime());
+  const uniqueSessions = new Set(matching.map(event => event.privacyHash || event.sessionHash)).size;
+  return {
+    value: uniqueSessions >= threshold ? matching.length : null,
+    uniqueSessions: uniqueSessions >= threshold ? uniqueSessions : null,
+    suppressed: uniqueSessions < threshold,
+  };
+}
+
+export function aggregateProfileInsights(events, options = {}) {
+  const now = options.now ? new Date(options.now) : new Date();
+  const threshold = options.threshold ?? INSIGHTS_PRIVACY_THRESHOLD;
+  const definitions = {
+    profileViews: ['profile_viewed'],
+    searchAppearances: ['search_appearance'],
+    cardGenerations: ['card_generated'],
+    shareActions: ['profile_shared'],
+  };
+
+  return {
+    privacyThreshold: threshold,
+    retentionDays: ENGAGEMENT_RETENTION_DAYS,
+    periods: [7, 30, 90].map(days => {
+      const currentStart = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+      const previousStart = new Date(currentStart.getTime() - days * 24 * 60 * 60 * 1000);
+      const metrics = {};
+      for (const [name, eventNames] of Object.entries(definitions)) {
+        const current = metric(events, eventNames, currentStart, now, threshold);
+        const previous = metric(events, eventNames, previousStart, currentStart, threshold);
+        metrics[name] = {
+          ...current,
+          previousValue: previous.value,
+          change: current.value != null && previous.value != null ? current.value - previous.value : null,
+        };
+      }
+      return { days, metrics };
+    }),
+  };
+}
+
+export function isVerifiedProfileOwner(session, developer) {
+  return Boolean(session?.login
+    && developer?.claimed === true
+    && String(session.login).toLowerCase() === String(developer.login || '').toLowerCase());
+}

--- a/scripts/setup-engagement-container.js
+++ b/scripts/setup-engagement-container.js
@@ -1,0 +1,45 @@
+import 'dotenv/config';
+import { CosmosClient } from '@azure/cosmos';
+
+const endpoint = process.env.COSMOS_ENDPOINT?.trim();
+const key = process.env.COSMOS_KEY?.trim();
+const databaseId = process.env.COSMOS_DATABASE || 'devglobe';
+const containerId = process.env.COSMOS_ENGAGEMENT_CONTAINER || 'engagement-events';
+const includedPaths = [
+  { path: '/documentType/?' },
+  { path: '/eventName/?' },
+  { path: '/createdAt/?' },
+];
+
+if (!endpoint || !key) {
+  console.error('COSMOS_ENDPOINT and COSMOS_KEY are required.');
+  process.exit(1);
+}
+
+const client = new CosmosClient({ endpoint, key });
+const database = client.database(databaseId);
+const { resource, statusCode } = await database.containers.createIfNotExists({
+  id: containerId,
+  partitionKey: { paths: ['/partitionKey'], kind: 'Hash' },
+  defaultTtl: -1,
+  indexingPolicy: {
+    indexingMode: 'consistent',
+    automatic: true,
+    includedPaths,
+    excludedPaths: [{ path: '/*' }],
+  },
+});
+
+if (statusCode !== 201) {
+  const partitionPaths = resource.partitionKey?.paths || [];
+  const indexedPaths = new Set(resource.indexingPolicy?.includedPaths?.map(item => item.path));
+  const compatible = partitionPaths.length === 1
+    && partitionPaths[0] === '/partitionKey'
+    && resource.defaultTtl === -1
+    && includedPaths.every(item => indexedPaths.has(item.path));
+  if (!compatible) {
+    throw new Error(`${databaseId}/${containerId} exists with incompatible partition key, TTL, or indexes. Use a new COSMOS_ENGAGEMENT_CONTAINER and rerun setup.`);
+  }
+}
+
+console.log(`${statusCode === 201 ? 'Created' : 'Verified'} engagement container ${databaseId}/${resource.id}.`);

--- a/styles/main.css
+++ b/styles/main.css
@@ -3855,6 +3855,8 @@ body {
   box-shadow: var(--shadow-strong);
   z-index: 200;
   padding: 8px 0;
+  max-height: calc(100vh - 72px);
+  overflow-y: auto;
   animation: fadeIn 0.15s ease;
 }
 
@@ -4113,6 +4115,81 @@ body {
 .profile-checklist__restore-icon {
   width: 14px;
   text-align: center;
+}
+
+.profile-insights__chevron {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 16px;
+}
+
+.profile-insights__panel {
+  margin: 2px 8px 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.profile-insights__panel > p {
+  margin: 0;
+}
+
+.profile-insights__periods {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3px;
+  margin-bottom: 10px;
+}
+
+.profile-insights__periods button {
+  min-height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+}
+
+.profile-insights__periods button.active {
+  border-color: var(--accent-github);
+  background: rgba(46, 164, 79, 0.12);
+  color: var(--text-primary);
+}
+
+.profile-insights__metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.profile-insights__metrics > div {
+  display: grid;
+  min-width: 0;
+  min-height: 72px;
+  align-content: start;
+  gap: 2px;
+  padding: 7px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.profile-insights__metrics strong {
+  color: var(--text-primary);
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.profile-insights__trend--up { color: var(--accent-github); }
+.profile-insights__trend--down { color: #ef4444; }
+.profile-insights__private { line-height: 1.25; }
+
+.profile-insights__note {
+  margin-top: 9px !important;
+  line-height: 1.4;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  EngagementValidationError,
+  aggregateProfileInsights,
+  createEngagementEvent,
+  isAutomatedUserAgent,
+  isVerifiedProfileOwner,
+  normalizeEngagementEvent,
+  resolveEngagementSession,
+} from '../lib/engagement.js';
+
+test('allows only documented engagement properties and never stores search text', () => {
+  const event = normalizeEngagementEvent({
+    eventName: 'profile_viewed',
+    targetLogin: 'OctoCat',
+    properties: { source: 'search', query: 'private raw query', email: 'person@example.com' },
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'profile_viewed',
+    targetLogin: 'octocat',
+    properties: { source: 'search' },
+  });
+  assert.throws(() => normalizeEngagementEvent({ eventName: 'unknown' }), EngagementValidationError);
+});
+
+test('deduplicates rerenders inside a session window without storing raw sessions', () => {
+  const options = { session: 'raw-session', secret: 'test-secret', now: '2026-08-21T10:05:00.000Z' };
+  const first = createEngagementEvent({ eventName: 'profile_viewed', targetLogin: 'octocat' }, options);
+  const duplicate = createEngagementEvent({ eventName: 'profile_viewed', targetLogin: 'octocat' }, {
+    ...options,
+    now: '2026-08-21T10:20:00.000Z',
+  });
+  const nextWindow = createEngagementEvent({ eventName: 'profile_viewed', targetLogin: 'octocat' }, {
+    ...options,
+    now: '2026-08-21T10:35:00.000Z',
+  });
+
+  assert.equal(first.id, duplicate.id);
+  assert.notEqual(first.id, nextWindow.id);
+  assert.notEqual(first.sessionHash, 'raw-session');
+  assert.equal(first.partitionKey, 'octocat');
+});
+
+test('preserves distinct share channels while deduplicating retries', () => {
+  const options = { session: 'session', secret: 'secret', now: '2026-08-21T10:05:00.000Z' };
+  const linkedIn = createEngagementEvent({ eventName: 'profile_shared', targetLogin: 'octocat', properties: { channel: 'linkedin' } }, options);
+  const retry = createEngagementEvent({ eventName: 'profile_shared', targetLogin: 'octocat', properties: { channel: 'linkedin' } }, options);
+  const copied = createEngagementEvent({ eventName: 'profile_shared', targetLogin: 'octocat', properties: { channel: 'copy_link' } }, options);
+
+  assert.equal(linkedIn.id, retry.id);
+  assert.notEqual(linkedIn.id, copied.id);
+});
+
+test('accepts only signed server sessions and replaces forged cookies', () => {
+  const created = resolveEngagementSession('', 'secret', () => 'server-id');
+  const restored = resolveEngagementSession(created.cookieValue, 'secret', () => 'unused');
+  const forged = resolveEngagementSession('attacker.bad-signature', 'secret', () => 'replacement');
+
+  assert.deepEqual(restored, { id: 'server-id', cookieValue: null });
+  assert.equal(forged.id, 'replacement');
+  assert.notEqual(forged.cookieValue, 'attacker.bad-signature');
+});
+
+test('classifies crawlers and empty user agents as automated', () => {
+  assert.equal(isAutomatedUserAgent('Mozilla/5.0 Chrome/120'), false);
+  assert.equal(isAutomatedUserAgent('Twitterbot/1.0'), true);
+  assert.equal(isAutomatedUserAgent(''), true);
+});
+
+test('aggregates current and prior periods while suppressing low-volume cohorts', () => {
+  const event = (eventName, createdAt, sessionHash) => ({ eventName, createdAt, sessionHash, privacyHash: sessionHash });
+  const events = [
+    event('profile_viewed', '2026-08-20T12:00:00.000Z', 'a'),
+    event('profile_viewed', '2026-08-20T13:00:00.000Z', 'b'),
+    event('profile_viewed', '2026-08-20T14:00:00.000Z', 'c'),
+    event('profile_viewed', '2026-08-10T12:00:00.000Z', 'd'),
+    event('profile_viewed', '2026-08-10T13:00:00.000Z', 'e'),
+    event('profile_viewed', '2026-08-10T14:00:00.000Z', 'f'),
+    event('card_generated', '2026-08-20T12:00:00.000Z', 'a'),
+  ];
+  const insights = aggregateProfileInsights(events, { now: '2026-08-21T15:00:00.000Z' });
+  const sevenDays = insights.periods.find(period => period.days === 7);
+
+  assert.equal(sevenDays.metrics.profileViews.value, 3);
+  assert.equal(sevenDays.metrics.profileViews.previousValue, 3);
+  assert.equal(sevenDays.metrics.profileViews.change, 0);
+  assert.equal(sevenDays.metrics.cardGenerations.value, null);
+  assert.equal(sevenDays.metrics.cardGenerations.uniqueSessions, null);
+  assert.equal(sevenDays.metrics.cardGenerations.suppressed, true);
+});
+
+test('cookie churn cannot bypass the low-volume privacy threshold', () => {
+  const events = ['session-a', 'session-b', 'session-c'].map(sessionHash => ({
+    eventName: 'profile_viewed',
+    createdAt: '2026-08-20T12:00:00.000Z',
+    sessionHash,
+    privacyHash: 'same-network-cohort',
+  }));
+  const insights = aggregateProfileInsights(events, { now: '2026-08-21T15:00:00.000Z' });
+
+  assert.equal(insights.periods[0].metrics.profileViews.value, null);
+  assert.equal(insights.periods[0].metrics.profileViews.uniqueSessions, null);
+});
+
+test('authorizes only the signed-in owner of a claimed profile', () => {
+  assert.equal(isVerifiedProfileOwner({ login: 'OctoCat' }, { login: 'octocat', claimed: true }), true);
+  assert.equal(isVerifiedProfileOwner({ login: 'someone-else' }, { login: 'octocat', claimed: true }), false);
+  assert.equal(isVerifiedProfileOwner({ login: 'octocat' }, { login: 'octocat', claimed: false }), false);
+  assert.equal(isVerifiedProfileOwner(null, { login: 'octocat', claimed: true }), false);
+});


### PR DESCRIPTION
This PR adds private 7/30/90-day owner insights, privacy-conscious durable engagement ingestion, signed sessions/network-cohort threshold/bot filtering/dedup, search appearances without queries, Cosmos setup/docs, and validation (204 tests + build + desktop/mobile browser checks).

Closes #125. Establishes part of #121's event foundation without closing #121.