### PR TITLE
feat: add Hacktoberfest Open Source Passport

### DIFF
--- a/app/api/contribution-opportunities/route.js
+++ b/app/api/contribution-opportunities/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getSession } from '../../../lib/auth.js';
 import { getCosmosContainer } from '../../../lib/cosmos.js';
 import {
+  CONTRIBUTION_CAMPAIGNS,
   CONTRIBUTION_DIFFICULTIES,
   CONTRIBUTION_INTERESTS,
   CONTRIBUTION_LANGUAGES,
@@ -30,7 +31,12 @@ class RecommendationRateLimitError extends Error {
 }
 
 function options() {
-  return { interests: CONTRIBUTION_INTERESTS, difficulties: CONTRIBUTION_DIFFICULTIES, languages: CONTRIBUTION_LANGUAGES };
+  return {
+    campaigns: CONTRIBUTION_CAMPAIGNS,
+    interests: CONTRIBUTION_INTERESTS,
+    difficulties: CONTRIBUTION_DIFFICULTIES,
+    languages: CONTRIBUTION_LANGUAGES,
+  };
 }
 
 function mutationError(request) {

--- a/app/api/contribution-opportunities/route.js
+++ b/app/api/contribution-opportunities/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSession } from '../../../lib/auth.js';
 import { getCosmosContainer } from '../../../lib/cosmos.js';
+import { isAllowedMutationOrigin } from '../../../lib/request-origin.js';
 import {
   CONTRIBUTION_CAMPAIGNS,
   CONTRIBUTION_DIFFICULTIES,
@@ -43,8 +44,7 @@ function mutationError(request) {
   if (request.headers.get('content-type')?.split(';')[0].trim().toLowerCase() !== 'application/json') {
     return NextResponse.json({ error: 'Content-Type must be application/json' }, { status: 415 });
   }
-  const origin = request.headers.get('origin');
-  if (origin && origin !== new URL(request.url).origin) {
+  if (!isAllowedMutationOrigin(request)) {
     return NextResponse.json({ error: 'Cross-origin mutation denied' }, { status: 403 });
   }
   return null;

--- a/components/ContributionOpportunitiesModal.jsx
+++ b/components/ContributionOpportunitiesModal.jsx
@@ -21,6 +21,7 @@ export default function ContributionOpportunitiesModal({ onClose }) {
   const [preferences, setPreferences] = useState(null);
   const [status, setStatus] = useState('loading');
   const [error, setError] = useState('');
+  const [languageQuery, setLanguageQuery] = useState('');
   const modalRef = useRef(null);
 
   async function load() {
@@ -128,6 +129,11 @@ export default function ContributionOpportunitiesModal({ onClose }) {
   }
 
   const isHacktoberfest = preferences?.campaign === 'hacktoberfest-2026';
+  const visibleLanguages = preferences && result
+    ? result.options.languages
+      .filter(language => language.includes(languageQuery.trim().toLowerCase()))
+      .sort((left, right) => Number(preferences.languages.includes(right)) - Number(preferences.languages.includes(left)) || left.localeCompare(right))
+    : [];
 
   return (
     <div className="contribution-modal__backdrop" role="presentation" onMouseDown={event => event.target === event.currentTarget && onClose()}>
@@ -172,14 +178,30 @@ export default function ContributionOpportunitiesModal({ onClose }) {
               </div>
             </div>
             <div className="contribution-preferences__group contribution-preferences__languages">
-              <strong>Preferred languages</strong>
+              <div className="contribution-preferences__languages-heading">
+                <strong>Preferred languages</strong>
+                <span>{preferences.languages.length}/5 selected</span>
+              </div>
+              <div className="contribution-preferences__language-tools">
+                <input
+                  type="search"
+                  value={languageQuery}
+                  onChange={event => setLanguageQuery(event.target.value)}
+                  placeholder="Filter languages"
+                  aria-label="Filter preferred languages"
+                />
+                {preferences.languages.length > 0 && (
+                  <button type="button" onClick={() => setPreferences(current => ({ ...current, languages: [] }))}>Clear</button>
+                )}
+              </div>
               <div className="contribution-preferences__choices contribution-preferences__choices--languages">
-                {result.options.languages.map(language => (
+                {visibleLanguages.map(language => (
                   <label key={language}>
                     <input type="checkbox" checked={preferences.languages.includes(language)} onChange={() => toggleLanguage(language)} disabled={!preferences.languages.includes(language) && preferences.languages.length >= 5} />
                     <span>{language}</span>
                   </label>
                 ))}
+                {visibleLanguages.length === 0 && <span className="contribution-preferences__no-languages">No matching languages</span>}
               </div>
             </div>
             <label className="contribution-preferences__field">

--- a/components/ContributionOpportunitiesModal.jsx
+++ b/components/ContributionOpportunitiesModal.jsx
@@ -11,6 +11,10 @@ const INTEREST_LABELS = {
   features: 'Features',
   testing: 'Testing',
 };
+const CAMPAIGN_LABELS = {
+  all: 'All opportunities',
+  'hacktoberfest-2026': 'Hacktoberfest 2026',
+};
 
 export default function ContributionOpportunitiesModal({ onClose }) {
   const [result, setResult] = useState(null);
@@ -84,6 +88,11 @@ export default function ContributionOpportunitiesModal({ onClose }) {
     }));
   }
 
+  function selectCampaign(campaign) {
+    setPreferences(current => ({ ...current, campaign }));
+    track('contribution_campaign_selected', { campaign, journey: 'contribution' });
+  }
+
   async function savePreferences(event) {
     event.preventDefault();
     setStatus('saving');
@@ -118,16 +127,39 @@ export default function ContributionOpportunitiesModal({ onClose }) {
     }
   }
 
+  const isHacktoberfest = preferences?.campaign === 'hacktoberfest-2026';
+
   return (
     <div className="contribution-modal__backdrop" role="presentation" onMouseDown={event => event.target === event.currentTarget && onClose()}>
       <section className="contribution-modal" role="dialog" aria-modal="true" aria-labelledby="contribution-title" ref={modalRef} tabIndex="-1">
         <button type="button" className="contribution-modal__close" onClick={onClose} aria-label="Close contribution opportunities">&times;</button>
-        <span className="contribution-modal__eyebrow">OPEN SOURCE, READY FOR HELP</span>
-        <h2 id="contribution-title">Contribution opportunities</h2>
-        <p className="contribution-modal__intro">Fresh, unassigned issues from public repositories with contribution guidance.</p>
+        <span className="contribution-modal__eyebrow">{isHacktoberfest ? 'HACKTOBERFEST 2026' : 'OPEN SOURCE, READY FOR HELP'}</span>
+        <h2 id="contribution-title">{isHacktoberfest ? 'Open Source Passport' : 'Contribution opportunities'}</h2>
+        <p className="contribution-modal__intro">
+          {isHacktoberfest
+            ? 'Find fresh, contribution-ready Hacktoberfest issues matched to your skills. Choose meaningful work and follow each project’s contribution guide.'
+            : 'Fresh, unassigned issues from public repositories with contribution guidance.'}
+        </p>
 
         {preferences && result && (
           <form className="contribution-preferences" onSubmit={savePreferences}>
+            <fieldset className="contribution-campaign">
+              <legend>Campaign</legend>
+              <div className="contribution-campaign__options">
+                {result.options.campaigns.map(campaign => (
+                  <label key={campaign}>
+                    <input
+                      type="radio"
+                      name="contribution-campaign"
+                      value={campaign}
+                      checked={preferences.campaign === campaign}
+                      onChange={() => selectCampaign(campaign)}
+                    />
+                    <span>{CAMPAIGN_LABELS[campaign]}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
             <div className="contribution-preferences__group">
               <strong>Interests</strong>
               <div className="contribution-preferences__choices">
@@ -160,11 +192,17 @@ export default function ContributionOpportunitiesModal({ onClose }) {
           </form>
         )}
 
-        {status === 'loading' && <p className="contribution-modal__state">Finding contribution-ready issues...</p>}
+        {status === 'loading' && <p className="contribution-modal__state">{isHacktoberfest ? 'Finding Hacktoberfest issues for your passport...' : 'Finding contribution-ready issues...'}</p>}
         {status === 'error' && <p className="contribution-modal__state contribution-modal__state--error">{error}</p>}
         {error && status !== 'error' && <p className="contribution-modal__state contribution-modal__state--error">{error}</p>}
         {status === 'ready' && result?.unavailable && <p className="contribution-modal__state">Recommendations are temporarily unavailable. Your preferences are still saved.</p>}
-        {status === 'ready' && !result?.unavailable && result?.opportunities.length === 0 && <p className="contribution-modal__state">No contribution-ready issues match these preferences yet. Try another language or difficulty.</p>}
+        {status === 'ready' && !result?.unavailable && result?.opportunities.length === 0 && (
+          <p className="contribution-modal__state">
+            {isHacktoberfest
+              ? 'No Hacktoberfest issues match these preferences yet. Try another language or difficulty, or check all opportunities.'
+              : 'No contribution-ready issues match these preferences yet. Try another language or difficulty.'}
+          </p>
+        )}
 
         {result?.opportunities.length > 0 && (
           <div className="contribution-results" aria-live="polite">
@@ -174,11 +212,12 @@ export default function ContributionOpportunitiesModal({ onClose }) {
                   <span>{opportunity.repository}</span>
                   <button type="button" onClick={() => dismiss(opportunity.id)} aria-label={`Dismiss ${opportunity.title}`} title="Dismiss recommendation">&times;</button>
                 </div>
+                {opportunity.labels.includes('hacktoberfest') && <span className="contribution-result__campaign">Hacktoberfest 2026</span>}
                 <h3>{opportunity.title}</h3>
                 <div className="contribution-result__reasons">
                   {opportunity.reasons.map(reason => <span key={reason}>{reason}</span>)}
                 </div>
-                <a href={opportunity.url} target="_blank" rel="noopener noreferrer" onClick={() => track('next_action_selected', { action: 'open_contribution_issue', journey: 'contribution' })}>Open issue on GitHub</a>
+                <a href={opportunity.url} target="_blank" rel="noopener noreferrer" onClick={() => track('next_action_selected', { action: 'open_contribution_issue', campaign: result.preferences.campaign, journey: 'contribution' })}>Open issue on GitHub</a>
               </article>
             ))}
           </div>

--- a/docs/prd/hacktoberfest-open-source-passport.md
+++ b/docs/prd/hacktoberfest-open-source-passport.md
@@ -1,0 +1,133 @@
+# Hacktoberfest 2026 Open Source Passport
+
+## Status
+
+- Owner: DevGlobe
+- Target: September 2026 readiness, October 2026 campaign
+- Tracking issue: [#248](https://github.com/sajeetharan/devglobe/issues/248)
+- Related: [#126](https://github.com/sajeetharan/devglobe/issues/126), [#26](https://github.com/sajeetharan/devglobe/issues/26), [#31](https://github.com/sajeetharan/devglobe/issues/31), [#119](https://github.com/sajeetharan/devglobe/issues/119)
+
+## Problem
+
+Hacktoberfest brings developers who are actively looking for open-source work, but DevGlobe's contribution recommendations present only an evergreen discovery journey. A developer cannot isolate event-ready issues or tell whether a result is part of the campaign.
+
+Maintainers also need contributors to choose well-scoped work and follow project guidance. A campaign that rewards raw pull-request volume would increase noise and conflict with DevGlobe's focus on verified, meaningful contributions.
+
+## Product decision
+
+Add an **Open Source Passport** mode to the existing Contribution opportunities experience. It reuses the current matching, eligibility, dismissal, caching, and rate-limit controls while requiring the GitHub issue label `hacktoberfest`.
+
+The MVP is a trustworthy discovery mode, not a contribution ledger. Passport history, stamps, and rewards require a later verified GitHub contribution model.
+
+## Goals
+
+- Help claimed developers find fresh Hacktoberfest issues suited to their languages, interests, and chosen difficulty.
+- Make event participation visible without replacing the repository's own contribution workflow.
+- Send higher-intent visits to contribution-ready issues.
+- Establish a reusable campaign dimension for future community contribution events.
+- Favor quality and maintainer guidance over contribution volume.
+
+## Non-goals
+
+- Assigning, reserving, or claiming GitHub issues from DevGlobe.
+- Counting self-reported pull requests or merged contributions.
+- Awarding points based only on pull-request volume.
+- Modifying the core DevGlobe developer score.
+- Reproducing GitHub issue bodies, comments, or contributor identities.
+- Determining whether a pull request qualifies under official event rules.
+
+## Audience
+
+### Contributor
+
+A claimed DevGlobe developer who wants event-ready work matched to known skills without scanning unrelated repositories.
+
+### Maintainer
+
+An open-source maintainer who has explicitly labeled an issue for Hacktoberfest and published contribution guidance.
+
+## MVP journey
+
+1. A claimed developer opens Contribution opportunities.
+2. The developer selects **Hacktoberfest 2026** in the campaign control and updates matches.
+3. DevGlobe searches for open, unassigned, recently updated issues carrying both the selected difficulty label and `hacktoberfest`.
+4. Existing repository and issue safety checks remove ineligible results.
+5. Each result identifies the campaign and explains its skill match.
+6. The developer opens the canonical GitHub issue and follows the repository's contribution guide.
+7. The selected campaign persists with existing contribution preferences.
+
+## Functional requirements
+
+### Campaign preference
+
+- Support the finite values `all` and `hacktoberfest-2026`.
+- Default existing and new preference documents to `all`.
+- Reject unknown campaign values at the API boundary.
+- Include the campaign in the recommendation cache key.
+- Return supported campaigns with existing preference options.
+
+### Discovery and ranking
+
+- Add `label:"hacktoberfest"` to GitHub issue search in campaign mode.
+- Require the normalized `hacktoberfest` issue label again during local ranking.
+- Preserve language, interest, difficulty, freshness, assignment, repository status, and contribution-guide checks.
+- Preserve the eight-result limit and deterministic ordering.
+- Do not loosen current per-user or global GitHub refresh budgets.
+
+### Experience
+
+- Present All opportunities and Hacktoberfest 2026 as a keyboard-accessible segmented choice.
+- Use Open Source Passport identity and campaign-specific introductory, loading, and empty-state copy.
+- Mark matching cards with a Hacktoberfest 2026 badge.
+- Keep repository name, match reasons, dismissal, and the canonical GitHub action available.
+- Maintain a single-column result layout on narrow viewports.
+
+### Analytics
+
+- Track campaign selection with the campaign key and contribution journey.
+- Add the campaign key to issue-open events.
+- Do not collect issue bodies, contributor identities, pull-request identities, or GitHub activity through these events.
+
+## Eligibility and safety
+
+Campaign issues must satisfy all existing contribution-readiness rules: public and active repository, open and unlocked issue, no assignee, recent update, meaningful title, and an exposed contribution guide. Known promotional or spam-like titles remain excluded.
+
+The event label is a maintainer signal, not a DevGlobe quality guarantee. The interface must direct contributors to project guidance and must not imply that opening an issue, submitting a pull request, or receiving a merge guarantees official Hacktoberfest credit.
+
+Before campaign launch, maintainers should confirm the published Hacktoberfest 2026 participation rules and update product copy if label or repository participation requirements differ.
+
+## Data and privacy
+
+The existing owner-scoped preference object stores only the campaign key alongside languages, interests, and difficulty. Cached results continue to contain bounded public issue summaries. The feature adds no contributor activity store and no new personal data.
+
+## Success metrics
+
+- Percentage of contribution-opportunity sessions selecting Hacktoberfest mode.
+- Campaign result availability rate after eligibility checks.
+- Campaign issue open-through rate.
+- Return rate to Contribution opportunities during the campaign.
+- Upstream-unavailable and empty-result rates by selected language and difficulty.
+
+No success metric should reward raw pull-request volume.
+
+## Rollout
+
+1. Ship preference, query, ranking, and UI support behind the finite campaign value.
+2. Validate keyboard navigation and responsive layout in authenticated staging.
+3. Confirm official 2026 participation guidance before promoting the mode.
+4. Curate DevGlobe's own `hacktoberfest` issues and contribution guidance.
+5. Launch the campaign entry point, monitor GitHub quota and empty-result rates, and remove promotional emphasis after the event while retaining saved preferences safely.
+
+## Test plan
+
+- Preference normalization defaults to `all` and rejects unknown campaigns.
+- Campaign ranking excludes otherwise eligible issues without `hacktoberfest`.
+- GitHub search includes the campaign label only in campaign mode.
+- Existing all-opportunities behavior remains unchanged.
+- Cached recommendations vary by campaign preference.
+- Selector, loading, empty, unavailable, and populated states work by keyboard and at mobile widths.
+- Campaign selection and issue-open analytics contain no new personal identifiers.
+
+## Follow-up phase
+
+Verified passport stamps, shareable campaign cards, and aggregate globe activity may be considered after DevGlobe can verify GitHub identity, pull-request state, repository acceptance, and consent. Any recognition model must resist duplicate, spam, late, and low-quality activity and remain separate from the core developer score.

--- a/lib/contribution-opportunities.js
+++ b/lib/contribution-opportunities.js
@@ -7,6 +7,7 @@ export const CONTRIBUTION_INTERESTS = [
   'testing',
 ];
 export const CONTRIBUTION_DIFFICULTIES = ['beginner', 'intermediate', 'advanced'];
+export const CONTRIBUTION_CAMPAIGNS = ['all', 'hacktoberfest-2026'];
 export const CONTRIBUTION_LANGUAGES = [
   'c', 'c#', 'c++', 'css', 'go', 'html', 'java', 'javascript', 'kotlin',
   'php', 'python', 'ruby', 'rust', 'swift', 'typescript',
@@ -25,6 +26,9 @@ const DIFFICULTY_TERMS = {
   beginner: ['good first issue', 'beginner', 'easy', 'first-timers-only'],
   intermediate: ['help wanted', 'intermediate'],
   advanced: ['advanced', 'challenging', 'expert'],
+};
+const CAMPAIGN_LABELS = {
+  'hacktoberfest-2026': 'hacktoberfest',
 };
 
 export class ContributionPreferenceError extends Error {}
@@ -47,7 +51,13 @@ export function normalizeContributionPreferences(input, fallbackLanguages = []) 
     });
   const difficulty = String(input?.difficulty || 'beginner').toLowerCase();
   if (!CONTRIBUTION_DIFFICULTIES.includes(difficulty)) throw new ContributionPreferenceError('Invalid difficulty');
-  return { interests, languages, difficulty };
+  const campaign = String(input?.campaign || 'all').toLowerCase();
+  if (!CONTRIBUTION_CAMPAIGNS.includes(campaign)) throw new ContributionPreferenceError('Invalid campaign');
+  return { interests, languages, difficulty, campaign };
+}
+
+export function contributionCampaignLabel(campaign) {
+  return CAMPAIGN_LABELS[campaign] || null;
 }
 
 function issueLabels(issue) {
@@ -73,9 +83,11 @@ export function isContributionReadyIssue(candidate, now = new Date()) {
 export function rankContributionOpportunities(candidates, preferences, dismissedIds = [], now = new Date()) {
   const dismissed = new Set(dismissedIds.map(String));
   const languages = new Set(preferences.languages.map(language => language.toLowerCase()));
+  const campaignLabel = contributionCampaignLabel(preferences.campaign);
   return candidates
     .filter(candidate => !dismissed.has(String(candidate.issue?.id)))
     .filter(candidate => isContributionReadyIssue(candidate, now))
+    .filter(candidate => !campaignLabel || issueLabels(candidate.issue).includes(campaignLabel))
     .filter(candidate => includesTerm(issueLabels(candidate.issue), DIFFICULTY_TERMS[preferences.difficulty]))
     .map(candidate => {
       const labels = issueLabels(candidate.issue);

--- a/lib/github-contribution-opportunities.js
+++ b/lib/github-contribution-opportunities.js
@@ -1,3 +1,5 @@
+import { contributionCampaignLabel } from './contribution-opportunities.js';
+
 const GITHUB_API = 'https://api.github.com';
 
 export class ContributionOpportunitiesUnavailableError extends Error {}
@@ -22,6 +24,7 @@ export async function fetchGitHubContributionCandidates(preferences, options = {
   if (!token) throw new ContributionOpportunitiesUnavailableError('GitHub recommendations are not configured');
   const since = new Date((options.now || new Date()).getTime() - 180 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const languages = preferences.languages.length ? preferences.languages.slice(0, 1) : [''];
+  const campaignLabel = contributionCampaignLabel(preferences.campaign);
   let searches;
   try {
     searches = await Promise.all(languages.map(async language => {
@@ -32,6 +35,7 @@ export async function fetchGitHubContributionCandidates(preferences, options = {
         'archived:false',
         `updated:>=${since}`,
         `label:"${difficultyLabel(preferences.difficulty)}"`,
+        campaignLabel ? `label:"${campaignLabel}"` : '',
         language ? `language:"${language}"` : '',
       ].filter(Boolean).join(' ');
       const response = await fetchImpl(`${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=desc&per_page=20`, {

--- a/lib/request-origin.js
+++ b/lib/request-origin.js
@@ -1,0 +1,32 @@
+function firstHeaderValue(value) {
+  return value?.split(',')[0].trim() || '';
+}
+
+export function isAllowedMutationOrigin(request) {
+  const origin = request.headers.get('origin');
+  if (!origin) return true;
+
+  let requestUrl;
+  let normalizedOrigin;
+  try {
+    requestUrl = new URL(request.url);
+    normalizedOrigin = new URL(origin).origin;
+  } catch {
+    return false;
+  }
+  if (normalizedOrigin !== origin) return false;
+
+  const allowedOrigins = new Set([requestUrl.origin]);
+  const forwardedHost = firstHeaderValue(request.headers.get('x-forwarded-host'));
+  const host = forwardedHost || firstHeaderValue(request.headers.get('host'));
+  const protocol = firstHeaderValue(request.headers.get('x-forwarded-proto')) || requestUrl.protocol.slice(0, -1);
+  if (host && ['http', 'https'].includes(protocol)) {
+    try {
+      allowedOrigins.add(new URL(`${protocol}://${host}`).origin);
+    } catch {
+      return false;
+    }
+  }
+
+  return allowedOrigins.has(normalizedOrigin);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -5001,7 +5001,7 @@ body {
 
 .contribution-preferences {
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(150px, 0.8fr) minmax(120px, 0.5fr) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 0.35fr) auto;
   align-items: end;
   gap: 12px;
   padding: 14px 0 18px;
@@ -5110,13 +5110,67 @@ body {
 }
 
 .contribution-preferences__choices--languages {
-  max-height: 66px;
-  overflow-y: auto;
-  padding-right: 3px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
 }
 
-.contribution-preferences__choices--languages span {
+.contribution-preferences__languages {
+  grid-column: 1 / -1;
+}
+
+.contribution-preferences__languages-heading,
+.contribution-preferences__language-tools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.contribution-preferences__languages-heading span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.contribution-preferences__language-tools input {
+  width: min(260px, 100%);
+  min-height: 34px;
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 11px;
+}
+
+.contribution-preferences__language-tools button {
+  padding: 5px 7px;
+  border: 0;
+  background: transparent;
+  color: #38bdf8;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.contribution-preferences__choices--languages label {
+  justify-content: center;
+  min-width: 0;
+}
+
+.contribution-preferences__choices--languages label span {
+  overflow: hidden;
+  text-overflow: ellipsis;
   text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.contribution-preferences__no-languages {
+  grid-column: 1 / -1;
+  padding: 8px 0;
+  color: var(--text-muted);
+  font-size: 10px;
 }
 
 .contribution-preferences__choices label:has(input:disabled) {
@@ -5257,6 +5311,7 @@ body {
   .contribution-modal { max-height: calc(100dvh - 16px); padding: 20px 16px; }
   .contribution-preferences { grid-template-columns: 1fr 1fr; }
   .contribution-preferences__group { grid-column: 1 / -1; }
+  .contribution-preferences__choices--languages { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .contribution-preferences__save { width: 100%; }
   .contribution-results { grid-template-columns: 1fr; }
 }
@@ -5264,6 +5319,8 @@ body {
 @media (max-width: 430px) {
   .contribution-preferences { grid-template-columns: 1fr; }
   .contribution-preferences__group { grid-column: auto; }
+  .contribution-preferences__languages { grid-column: auto; }
+  .contribution-preferences__choices--languages { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 .introduction-inbox__backdrop {

--- a/styles/main.css
+++ b/styles/main.css
@@ -5009,6 +5009,68 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.contribution-campaign {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 7px;
+  min-width: 0;
+  margin: 0;
+  padding: 0 0 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.contribution-campaign legend {
+  margin-bottom: 7px;
+  padding: 0;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.contribution-campaign__options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: min(360px, 100%);
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+}
+
+.contribution-campaign__options label {
+  min-width: 0;
+  cursor: pointer;
+}
+
+.contribution-campaign__options input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.contribution-campaign__options span {
+  display: grid;
+  place-items: center;
+  min-height: 30px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.contribution-campaign__options input:checked + span {
+  background: #f97316;
+  color: #111827;
+}
+
+.contribution-campaign__options input:focus-visible + span {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
 .contribution-preferences__group,
 .contribution-preferences__field {
   display: grid;
@@ -5154,6 +5216,16 @@ body {
   font-size: 13px;
   line-height: 1.4;
   overflow-wrap: anywhere;
+}
+
+.contribution-result__campaign {
+  justify-self: start;
+  padding: 3px 6px;
+  border: 1px solid rgba(249, 115, 22, 0.65);
+  border-radius: 4px;
+  color: #fb923c;
+  font-size: 9px;
+  font-weight: 700;
 }
 
 .contribution-result__reasons {

--- a/tests/contribution-opportunities.test.js
+++ b/tests/contribution-opportunities.test.js
@@ -49,9 +49,11 @@ test('normalizes finite interests, languages, and difficulty', () => {
     interests: ['documentation', 'testing'],
     languages: ['javascript'],
     difficulty: 'beginner',
+    campaign: 'all',
   });
   assert.throws(() => normalizeContributionPreferences({ interests: ['money'], languages: [], difficulty: 'easy' }), ContributionPreferenceError);
   assert.throws(() => normalizeContributionPreferences({ interests: [], languages: ['brainfuck'], difficulty: 'beginner' }), ContributionPreferenceError);
+  assert.throws(() => normalizeContributionPreferences({ interests: [], languages: [], difficulty: 'beginner', campaign: 'october' }), ContributionPreferenceError);
 });
 
 test('accepts only fresh public unassigned issues with contribution guidance', () => {
@@ -106,6 +108,29 @@ test('discovers public issues and verifies repository contribution guidance', as
   assert.equal(candidates[0].hasContributionGuide, true);
   assert.ok(requested[0].includes('language%3A%22JavaScript%22'));
   assert.ok(requested[0].includes('label%3A%22good%20first%20issue%22'));
+});
+
+test('requires and searches for the Hacktoberfest label in campaign mode', async () => {
+  const candidates = [
+    candidate({ issue: { id: 1, labels: [{ name: 'good first issue' }] } }),
+    candidate({ issue: { id: 2, labels: [{ name: 'good first issue' }, { name: 'Hacktoberfest' }] } }),
+  ];
+  const preferences = {
+    interests: ['documentation'],
+    languages: ['javascript'],
+    difficulty: 'beginner',
+    campaign: 'hacktoberfest-2026',
+  };
+  const requested = [];
+  const fetchImpl = async url => {
+    requested.push(url);
+    if (url.includes('/search/issues')) return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  assert.deepEqual(rankContributionOpportunities(candidates, preferences, [], now).map(item => item.id), ['2']);
+  await fetchGitHubContributionCandidates(preferences, { fetchImpl, token: 'token', now });
+  assert.ok(requested[0].includes('label%3A%22hacktoberfest%22'));
 });
 
 test('reports unavailable discovery when GitHub is not configured', async () => {

--- a/tests/request-origin.test.js
+++ b/tests/request-origin.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isAllowedMutationOrigin } from '../lib/request-origin.js';
+
+function request(url, headers = {}) {
+  return { url, headers: new Headers(headers) };
+}
+
+test('allows requests without an Origin header', () => {
+  assert.equal(isAllowedMutationOrigin(request('http://localhost:3000/api/example')), true);
+});
+
+test('allows direct same-origin mutations', () => {
+  assert.equal(isAllowedMutationOrigin(request('http://localhost:3000/api/example', {
+    origin: 'http://localhost:3000',
+    host: 'localhost:3000',
+  })), true);
+});
+
+test('allows the public origin forwarded by a trusted proxy boundary', () => {
+  assert.equal(isAllowedMutationOrigin(request('http://app:3000/api/example', {
+    origin: 'https://www.devglobe.dev',
+    host: 'app:3000',
+    'x-forwarded-host': 'www.devglobe.dev',
+    'x-forwarded-proto': 'https',
+  })), true);
+});
+
+test('rejects cross-origin and malformed origins', () => {
+  assert.equal(isAllowedMutationOrigin(request('https://www.devglobe.dev/api/example', {
+    origin: 'https://attacker.example',
+    host: 'www.devglobe.dev',
+  })), false);
+  assert.equal(isAllowedMutationOrigin(request('https://www.devglobe.dev/api/example', {
+    origin: 'not-a-url',
+  })), false);
+});


### PR DESCRIPTION
## Summary

- add the Hacktoberfest 2026 Open Source Passport campaign to contribution opportunities
- require the `hacktoberfest` label in campaign discovery and ranking
- improve preferred-language selection with search, selected-first ordering, count, and responsive layout
- accept valid same-origin mutations behind trusted proxy headers
- document scope, privacy, rollout, and follow-up work in the PRD

## Validation

- `npm test` — 223 passed
- `npm run build` — compiled, type-checked, and generated all 53 routes
- desktop and 390px mobile browser smoke checks

Closes #248