### PR TITLE
feat: add public Hacktoberfest Matchmaker

### DIFF
--- a/app/api/hacktoberfest-matches/route.js
+++ b/app/api/hacktoberfest-matches/route.js
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server.js';
+import { getCosmosContainer } from '../../../lib/cosmos.js';
+import {
+  CONTRIBUTION_LANGUAGES,
+  normalizeContributionPreferences,
+  rankContributionOpportunities,
+} from '../../../lib/contribution-opportunities.js';
+import {
+  ContributionOpportunitiesUnavailableError,
+  fetchGitHubContributionCandidates,
+} from '../../../lib/github-contribution-opportunities.js';
+import {
+  getContributionOpportunityStateContainer,
+  reserveGlobalRecommendationRefresh,
+} from '../../../lib/contribution-opportunity-store.js';
+
+const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
+
+function profileLanguages(developer) {
+  const languages = (developer.languages || []).map(language => language?.name).filter(Boolean);
+  return (languages.length ? languages : [developer.topLanguage].filter(Boolean))
+    .map(language => String(language).toLowerCase())
+    .filter(language => CONTRIBUTION_LANGUAGES.includes(language));
+}
+
+async function findDeveloper(container, login) {
+  const { resources } = await container.items.query({
+    query: `SELECT TOP 1 c.login, c.name, c.avatarUrl, c.topLanguage, c.languages
+      FROM c
+      WHERE LOWER(c.login) = @login
+        AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')`,
+    parameters: [{ name: '@login', value: login.toLowerCase() }],
+  }).fetchAll();
+  return resources[0] || null;
+}
+
+export function createHacktoberfestMatchesHandler(dependencies = {}) {
+  const getDeveloperContainer = dependencies.getDeveloperContainer || (() => getCosmosContainer());
+  const getStateContainer = dependencies.getStateContainer || getContributionOpportunityStateContainer;
+  const reserveRefresh = dependencies.reserveRefresh || reserveGlobalRecommendationRefresh;
+  const fetchCandidates = dependencies.fetchCandidates || fetchGitHubContributionCandidates;
+  const now = dependencies.now || (() => new Date());
+
+  return async function getHacktoberfestMatches(request) {
+    const login = new URL(request.url).searchParams.get('login')?.trim() || '';
+    if (!LOGIN_PATTERN.test(login)) {
+      return NextResponse.json({ error: 'Enter a valid GitHub username' }, { status: 400 });
+    }
+
+    try {
+      const developerContainer = getDeveloperContainer();
+      const stateContainer = getStateContainer();
+      if (!developerContainer || !stateContainer) {
+        return NextResponse.json({ error: 'Hacktoberfest matching is unavailable' }, { status: 503 });
+      }
+
+      const developer = await findDeveloper(developerContainer, login);
+      if (!developer) {
+        return NextResponse.json({ error: 'Developer not found on DevGlobe' }, { status: 404 });
+      }
+
+      const preferences = normalizeContributionPreferences({
+        campaign: 'hacktoberfest-2026',
+        difficulty: 'beginner',
+        interests: [],
+        languages: profileLanguages(developer),
+      });
+      if (preferences.languages.length === 0) {
+        return NextResponse.json({ error: 'No supported languages found for this profile' }, { status: 422 });
+      }
+
+      const requestedAt = now();
+      const retryAfterSeconds = await reserveRefresh(stateContainer, requestedAt);
+      if (retryAfterSeconds > 0) {
+        return NextResponse.json(
+          { error: 'Matching is busy. Try again shortly.', retryAfterSeconds },
+          { status: 429, headers: { 'Retry-After': String(retryAfterSeconds) } },
+        );
+      }
+
+      const candidates = await fetchCandidates(preferences, {
+        token: process.env.GITHUB_TOKEN,
+        now: requestedAt,
+      });
+      const matches = rankContributionOpportunities(candidates, preferences, [], requestedAt).slice(0, 3);
+
+      return NextResponse.json({
+        developer: {
+          login: developer.login,
+          name: developer.name || developer.login,
+          avatarUrl: developer.avatarUrl || null,
+          languages: preferences.languages,
+        },
+        matches,
+      }, { headers: { 'Cache-Control': 'private, no-store' } });
+    } catch (error) {
+      if (error instanceof ContributionOpportunitiesUnavailableError) {
+        return NextResponse.json({ error: 'Hacktoberfest matching is temporarily unavailable' }, { status: 503 });
+      }
+      console.error('Public Hacktoberfest matching failed:', error.message);
+      return NextResponse.json({ error: 'Unable to find Hacktoberfest matches' }, { status: 500 });
+    }
+  };
+}
+
+export const GET = createHacktoberfestMatchesHandler();

--- a/app/hacktoberfest/page.jsx
+++ b/app/hacktoberfest/page.jsx
@@ -1,0 +1,16 @@
+import HacktoberfestMatchmaker from '../../components/HacktoberfestMatchmaker.jsx';
+
+export const metadata = {
+  title: 'Hacktoberfest Matchmaker | DevGlobe',
+  description: 'Enter your GitHub username and find contribution-ready Hacktoberfest issues matched to your public DevGlobe profile.',
+  alternates: { canonical: '/hacktoberfest' },
+  openGraph: {
+    title: 'Find your Hacktoberfest matches | DevGlobe',
+    description: 'Three fresh, unassigned Hacktoberfest issues matched to your languages.',
+    url: '/hacktoberfest',
+  },
+};
+
+export default function HacktoberfestPage() {
+  return <HacktoberfestMatchmaker />;
+}

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -42,6 +42,12 @@ export default async function sitemap() {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: `${siteUrl}/hacktoberfest`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
     ...profileLogins.map(login => ({
       url: `${siteUrl}/share/${encodeURIComponent(login)}`,
       changeFrequency: 'monthly',

--- a/components/HacktoberfestMatchmaker.jsx
+++ b/components/HacktoberfestMatchmaker.jsx
@@ -1,0 +1,164 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { track } from '../lib/analytics.js';
+import styles from './HacktoberfestMatchmaker.module.css';
+
+export default function HacktoberfestMatchmaker() {
+  const [login, setLogin] = useState('');
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState('');
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    const initialLogin = new URLSearchParams(window.location.search).get('login') || '';
+    if (/^[a-z\d-]{1,39}$/i.test(initialLogin)) setLogin(initialLogin);
+    track('recommendation_opened', { journey: 'hacktoberfest_matchmaker' });
+  }, []);
+
+  async function findMatches(event) {
+    event.preventDefault();
+    const normalizedLogin = login.trim().replace(/^@/, '');
+    setStatus('loading');
+    setError('');
+    setResult(null);
+    track('next_action_selected', { action: 'hacktoberfest_username_submit', journey: 'hacktoberfest_matchmaker' });
+
+    try {
+      const response = await fetch(`/api/hacktoberfest-matches?login=${encodeURIComponent(normalizedLogin)}`, { cache: 'no-store' });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Unable to find matches');
+      setResult(data);
+      setStatus('ready');
+      window.history.replaceState({}, '', `/hacktoberfest?login=${encodeURIComponent(data.developer.login)}`);
+    } catch (matchError) {
+      setError(matchError.message);
+      setStatus('error');
+    }
+  }
+
+  return (
+    <main className={styles.page}>
+      <nav className={styles.nav} aria-label="Hacktoberfest Matchmaker navigation">
+        <Link href="/" className={styles.brand}>
+          <img src="/devglobe.png" alt="" />
+          <span>DevGlobe</span>
+        </Link>
+        <a href="https://github.com/sajeetharan/devglobe" target="_blank" rel="noreferrer">GitHub</a>
+      </nav>
+
+      <section className={styles.workspace}>
+        <header className={styles.intro}>
+          <span className={styles.eyebrow}>HACKTOBERFEST 2026</span>
+          <h1>Find an issue worth opening.</h1>
+          <p>Enter your GitHub username. DevGlobe uses your public language profile to find three fresh, unassigned issues with contribution guidance.</p>
+          <dl className={styles.criteria}>
+            <div><dt>01</dt><dd>Matched to your languages</dd></div>
+            <div><dt>02</dt><dd>Open and unassigned</dd></div>
+            <div><dt>03</dt><dd>Contribution guide verified</dd></div>
+          </dl>
+        </header>
+
+        <div className={styles.tool} aria-busy={status === 'loading'}>
+          <div className={styles.toolHeading}>
+            <span>OPEN SOURCE PASSPORT</span>
+            <span>Public beta</span>
+          </div>
+          <form onSubmit={findMatches} className={styles.form}>
+            <label htmlFor="hacktoberfest-login">GitHub username</label>
+            <div className={styles.inputRow}>
+              <span aria-hidden="true">@</span>
+              <input
+                id="hacktoberfest-login"
+                name="login"
+                value={login}
+                onChange={event => setLogin(event.target.value)}
+                placeholder="octocat"
+                autoComplete="username"
+                spellCheck="false"
+                required
+                maxLength="40"
+              />
+              <button type="submit" disabled={status === 'loading'}>
+                {status === 'loading' ? 'Matching...' : 'Find my matches'}
+              </button>
+            </div>
+            <p>Public DevGlobe data only. No sign-in required.</p>
+          </form>
+
+          {status === 'loading' && (
+            <div className={styles.state} role="status">
+              <span className={styles.spinner} aria-hidden="true" />
+              <div><strong>Checking contribution-ready issues</strong><span>This can take a few seconds.</span></div>
+            </div>
+          )}
+          {status === 'error' && (
+            <div className={`${styles.state} ${styles.error}`} role="alert">
+              <div><strong>We could not build this passport</strong><span>{error}</span></div>
+            </div>
+          )}
+
+          {status === 'ready' && result && (
+            <section className={styles.results} aria-labelledby="match-results-title">
+              <div className={styles.profile}>
+                {result.developer.avatarUrl
+                  ? <img src={result.developer.avatarUrl} alt="" />
+                  : <span className={styles.avatarFallback} aria-hidden="true">{result.developer.login[0].toUpperCase()}</span>}
+                <div>
+                  <span>Matches for @{result.developer.login}</span>
+                  <h2 id="match-results-title">Your Hacktoberfest shortlist</h2>
+                </div>
+                <div className={styles.languages} aria-label="Matched languages">
+                  {result.developer.languages.map(language => <span key={language}>{language}</span>)}
+                </div>
+              </div>
+
+              {result.matches.length > 0 ? (
+                <div className={styles.matchList}>
+                  {result.matches.map((match, index) => (
+                    <article className={styles.match} key={match.id}>
+                      <span className={styles.matchNumber}>0{index + 1}</span>
+                      <div className={styles.matchBody}>
+                        <span className={styles.repository}>{match.repository}</span>
+                        <h3>{match.title}</h3>
+                        <div className={styles.reasons}>
+                          {match.reasons.map(reason => <span key={reason}>{reason}</span>)}
+                        </div>
+                      </div>
+                      <a
+                        href={match.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => track('next_action_selected', { action: 'open_hacktoberfest_match', journey: 'hacktoberfest_matchmaker' })}
+                      >
+                        Open issue
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                          <path d="M7 17 17 7M7 7h10v10" />
+                        </svg>
+                      </a>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.state} role="status">
+                  <div><strong>No strong matches right now</strong><span>Fresh issues change often. Try again later or use the full contribution finder.</span></div>
+                </div>
+              )}
+
+              <div className={styles.saveCta}>
+                <div><strong>Want more control?</strong><span>Sign in to choose interests and difficulty, save preferences, and dismiss results.</span></div>
+                <a href={`/api/auth/github?login=${encodeURIComponent(result.developer.login)}`}>Sign in to personalize</a>
+              </div>
+            </section>
+          )}
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <span>Built for useful contributions, not contribution counts.</span>
+        <Link href="/">Explore DevGlobe</Link>
+      </footer>
+    </main>
+  );
+}

--- a/components/HacktoberfestMatchmaker.module.css
+++ b/components/HacktoberfestMatchmaker.module.css
@@ -1,0 +1,144 @@
+.page {
+  --match-bg: #081019;
+  --match-surface: #101b27;
+  --match-surface-strong: #152332;
+  --match-line: #263748;
+  --match-text: #f3f6f8;
+  --match-muted: #9badbc;
+  --match-cyan: #53d5e8;
+  --match-orange: #f97316;
+  min-height: 100vh;
+  overflow-x: hidden;
+  background:
+    linear-gradient(rgba(83, 213, 232, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(83, 213, 232, 0.035) 1px, transparent 1px),
+    var(--match-bg);
+  background-size: 32px 32px;
+  color: var(--match-text);
+}
+
+.nav,
+.workspace,
+.footer {
+  width: min(1160px, calc(100% - 48px));
+  margin-inline: auto;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72px;
+  border-bottom: 1px solid var(--match-line);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--match-text);
+  font-size: 18px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.brand img { width: 34px; height: 34px; object-fit: contain; }
+.nav > a:last-child, .footer a { color: var(--match-muted); font-size: 13px; font-weight: 700; }
+.nav a:focus-visible, .page button:focus-visible, .page input:focus-visible, .page article a:focus-visible, .footer a:focus-visible { outline: 2px solid var(--match-cyan); outline-offset: 3px; }
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(520px, 1.18fr);
+  gap: 64px;
+  align-items: start;
+  padding: 72px 0 64px;
+}
+
+.intro { padding-top: 34px; }
+.eyebrow { color: var(--match-orange); font-size: 12px; font-weight: 800; }
+.intro h1 { max-width: 520px; margin: 16px 0 20px; font-size: 64px; line-height: 1.02; letter-spacing: 0; }
+.intro > p { max-width: 530px; margin: 0; color: var(--match-muted); font-size: 17px; line-height: 1.65; }
+
+.criteria { margin: 44px 0 0; border-top: 1px solid var(--match-line); }
+.criteria div { display: grid; grid-template-columns: 42px 1fr; gap: 12px; padding: 15px 0; border-bottom: 1px solid var(--match-line); }
+.criteria dt { color: var(--match-cyan); font-family: monospace; font-size: 12px; }
+.criteria dd { margin: 0; color: #c9d4dc; font-size: 13px; }
+
+.tool { border: 1px solid var(--match-line); background: rgba(16, 27, 39, 0.96); box-shadow: 0 28px 70px rgba(0, 0, 0, 0.28); }
+.toolHeading { display: flex; justify-content: space-between; gap: 12px; padding: 13px 18px; border-bottom: 1px solid var(--match-line); color: var(--match-muted); font-size: 10px; font-weight: 800; }
+.toolHeading span:last-child { color: var(--match-cyan); }
+.form { padding: 24px; }
+.form label { display: block; margin-bottom: 8px; color: var(--match-text); font-size: 13px; font-weight: 750; }
+.inputRow { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; min-height: 52px; border: 1px solid #405569; background: #081019; }
+.inputRow > span { padding-left: 16px; color: var(--match-muted); font-size: 16px; }
+.inputRow input { min-width: 0; height: 50px; border: 0; outline: 0; background: transparent; color: var(--match-text); font: inherit; font-size: 15px; }
+.inputRow button { align-self: stretch; min-width: 150px; border: 0; background: var(--match-orange); color: #fff; cursor: pointer; font: inherit; font-size: 12px; font-weight: 800; }
+.inputRow button:hover { background: #ea650b; }
+.inputRow button:disabled { cursor: wait; opacity: 0.7; }
+.form > p { margin: 9px 0 0; color: var(--match-muted); font-size: 11px; }
+
+.state { display: flex; align-items: center; gap: 14px; margin: 0 24px 24px; padding: 17px; border: 1px solid var(--match-line); border-left: 3px solid var(--match-cyan); background: #0b151f; }
+.state > div { display: grid; gap: 3px; }
+.state strong { font-size: 13px; }
+.state span { color: var(--match-muted); font-size: 12px; line-height: 1.45; }
+.error { border-left-color: #fb7185; }
+.spinner { flex: 0 0 20px; width: 20px; height: 20px; border: 2px solid rgba(83, 213, 232, 0.2); border-top-color: var(--match-cyan); border-radius: 50%; animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.results { border-top: 1px solid var(--match-line); }
+.profile { display: grid; grid-template-columns: 44px minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 20px 24px; }
+.profile > img,
+.avatarFallback { width: 44px; height: 44px; border: 1px solid var(--match-line); border-radius: 50%; object-fit: cover; }
+.avatarFallback { display: grid; place-items: center; background: var(--match-surface-strong); color: var(--match-cyan); font-size: 15px; font-weight: 800; }
+.profile > div:nth-child(2) { min-width: 0; }
+.profile > div:nth-child(2) span { color: var(--match-cyan); font-size: 10px; font-weight: 800; }
+.profile h2 { margin: 3px 0 0; font-size: 17px; letter-spacing: 0; }
+.languages { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 5px; }
+.languages span, .reasons span { padding: 4px 7px; border: 1px solid var(--match-line); color: var(--match-muted); font-size: 9px; text-transform: capitalize; white-space: nowrap; }
+
+.matchList { border-top: 1px solid var(--match-line); }
+.match { display: grid; grid-template-columns: 30px minmax(0, 1fr) auto; gap: 14px; align-items: center; padding: 18px 24px; border-bottom: 1px solid var(--match-line); transition: background-color 0.15s ease; }
+.match:hover { background: var(--match-surface-strong); }
+.matchNumber { align-self: start; padding-top: 2px; color: var(--match-orange); font-family: monospace; font-size: 10px; }
+.matchBody { display: grid; gap: 6px; min-width: 0; }
+.repository { color: var(--match-cyan); font-size: 10px; font-weight: 800; overflow-wrap: anywhere; }
+.match h3 { margin: 0; font-size: 13px; line-height: 1.45; letter-spacing: 0; overflow-wrap: anywhere; }
+.reasons { display: flex; flex-wrap: wrap; gap: 5px; }
+.reasons span { border-color: rgba(74, 222, 128, 0.28); color: #86dba3; }
+.match > a { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 42px; padding: 0 12px; border: 1px solid #3a6171; color: var(--match-cyan); font-size: 11px; font-weight: 800; text-decoration: none; white-space: nowrap; }
+.match > a:hover { background: rgba(83, 213, 232, 0.08); }
+
+.saveCta { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 20px 24px; background: #0b151f; }
+.saveCta > div { display: grid; gap: 3px; }
+.saveCta strong { font-size: 12px; }
+.saveCta span { max-width: 390px; color: var(--match-muted); font-size: 11px; line-height: 1.45; }
+.saveCta > a { flex: 0 0 auto; padding: 10px 12px; border: 1px solid var(--match-line); color: var(--match-text); font-size: 11px; font-weight: 800; text-decoration: none; }
+
+.footer { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 24px 0 36px; border-top: 1px solid var(--match-line); color: var(--match-muted); font-size: 12px; }
+
+@media (max-width: 920px) {
+  .workspace { grid-template-columns: 1fr; gap: 44px; }
+  .intro { max-width: 680px; padding-top: 0; }
+  .intro h1 { font-size: 56px; }
+  .criteria { max-width: 560px; }
+}
+
+@media (max-width: 620px) {
+  .nav, .workspace, .footer { width: min(100% - 28px, 1160px); }
+  .workspace { padding: 48px 0; }
+  .intro h1 { font-size: 44px; }
+  .intro > p { font-size: 15px; }
+  .inputRow { grid-template-columns: auto minmax(0, 1fr); }
+  .inputRow button { grid-column: 1 / -1; min-height: 48px; }
+  .profile { grid-template-columns: 44px minmax(0, 1fr); }
+  .languages { grid-column: 1 / -1; justify-content: flex-start; }
+  .match { grid-template-columns: 24px minmax(0, 1fr); padding: 17px 16px; }
+  .match > a { grid-column: 2; justify-self: stretch; }
+  .saveCta, .footer { align-items: flex-start; flex-direction: column; }
+  .saveCta > a { width: 100%; text-align: center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation-duration: 1.6s; }
+  .match { transition: none; }
+}

--- a/tests/hacktoberfest-matches.test.js
+++ b/tests/hacktoberfest-matches.test.js
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHacktoberfestMatchesHandler } from '../app/api/hacktoberfest-matches/route.js';
+import { ContributionOpportunitiesUnavailableError } from '../lib/github-contribution-opportunities.js';
+
+const now = new Date('2026-08-22T12:00:00.000Z');
+
+function developerContainer(resources = [{
+  login: 'octocat',
+  name: 'The Octocat',
+  avatarUrl: 'https://github.com/octocat.png',
+  languages: [{ name: 'TypeScript' }, { name: 'JavaScript' }],
+}]) {
+  return {
+    items: {
+      query: () => ({ fetchAll: async () => ({ resources }) }),
+    },
+  };
+}
+
+function candidate(id) {
+  return {
+    issue: {
+      id,
+      title: `Improve TypeScript documentation example ${id}`,
+      state: 'open',
+      html_url: `https://github.com/org/repo/issues/${id}`,
+      updated_at: '2026-08-21T12:00:00.000Z',
+      labels: [{ name: 'hacktoberfest' }, { name: 'good first issue' }, { name: 'documentation' }],
+      assignees: [],
+    },
+    repository: {
+      full_name: 'org/repo',
+      language: 'TypeScript',
+      private: false,
+      archived: false,
+      disabled: false,
+      has_issues: true,
+      stargazers_count: 100,
+    },
+    hasContributionGuide: true,
+  };
+}
+
+test('public matcher validates GitHub usernames before querying', async () => {
+  const handler = createHacktoberfestMatchesHandler();
+  const response = await handler(new Request('http://localhost/api/hacktoberfest-matches?login=not valid'));
+
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error, 'Enter a valid GitHub username');
+});
+
+test('public matcher derives profile languages and returns three Hacktoberfest matches', async () => {
+  let receivedPreferences;
+  const handler = createHacktoberfestMatchesHandler({
+    getDeveloperContainer: () => developerContainer(),
+    getStateContainer: () => ({}),
+    reserveRefresh: async () => 0,
+    fetchCandidates: async preferences => {
+      receivedPreferences = preferences;
+      return [candidate(1), candidate(2), candidate(3), candidate(4)];
+    },
+    now: () => now,
+  });
+  const response = await handler(new Request('http://localhost/api/hacktoberfest-matches?login=OctoCat'));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(receivedPreferences, {
+    campaign: 'hacktoberfest-2026',
+    difficulty: 'beginner',
+    interests: [],
+    languages: ['typescript', 'javascript'],
+  });
+  assert.equal(body.developer.login, 'octocat');
+  assert.equal(body.matches.length, 3);
+  assert.ok(body.matches.every(match => match.labels.includes('hacktoberfest')));
+});
+
+test('public matcher reports unknown profiles without consuming refresh quota', async () => {
+  let refreshes = 0;
+  const handler = createHacktoberfestMatchesHandler({
+    getDeveloperContainer: () => developerContainer([]),
+    getStateContainer: () => ({}),
+    reserveRefresh: async () => { refreshes += 1; return 0; },
+  });
+  const response = await handler(new Request('http://localhost/api/hacktoberfest-matches?login=missing'));
+
+  assert.equal(response.status, 404);
+  assert.equal(refreshes, 0);
+});
+
+test('public matcher preserves shared quota and discovery failures', async () => {
+  const busyHandler = createHacktoberfestMatchesHandler({
+    getDeveloperContainer: () => developerContainer(),
+    getStateContainer: () => ({}),
+    reserveRefresh: async () => 17,
+  });
+  const busyResponse = await busyHandler(new Request('http://localhost/api/hacktoberfest-matches?login=octocat'));
+  assert.equal(busyResponse.status, 429);
+  assert.equal(busyResponse.headers.get('retry-after'), '17');
+
+  const unavailableHandler = createHacktoberfestMatchesHandler({
+    getDeveloperContainer: () => developerContainer(),
+    getStateContainer: () => ({}),
+    reserveRefresh: async () => 0,
+    fetchCandidates: async () => { throw new ContributionOpportunitiesUnavailableError(); },
+  });
+  const unavailableResponse = await unavailableHandler(new Request('http://localhost/api/hacktoberfest-matches?login=octocat'));
+  assert.equal(unavailableResponse.status, 503);
+});


### PR DESCRIPTION
This PR adds the public Hacktoberfest Matchmaker feature.

### Summary of Changes:
- **Anonymous Username-to-Three-Match Flow**: Allows any user to input a GitHub username and receive up to 3 tailored Hacktoberfest matches anonymously.
- **Reuse of Public Profile Language Signals and Verified Contribution Engine**: Fully leverages language/topic analysis from existing user profile workflows.
- **Shared Quota and Safe Errors**: Includes rate limiting, quota management, and user-friendly error boundaries to gracefully handle errors (including unknown profiles).
- **Responsive Accessible UI with Deferred Sign-In**: Fully accessible form/results view designed for both desktop (1280px) and mobile (390px) viewports with zero horizontal overflow.
- **Sitemap, Metadata, & Analytics Integration**: Exposed publicly with proper SEO tagging in sitemap, document metadata, and analytics/telemetry hookups.

### Validation Details:
- 227 tests passed.
- Next.js production build compiled/type-checked/generated 55 routes successfully.
- Cross-viewport responsiveness verified down to 390px (no overflow).
- Graceful API error boundaries and custom styling tested.
- Note: The standalone trace warning on Windows is solely due to the temporary node_modules junction being present during build, which has been removed.

Closes #251