### PR TITLE
fix: allow Trending endpoint caching

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -570,7 +570,7 @@ export default function Home() {
   // the globe's highlight rings, so both stay in sync off a single request.
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/trending', { cache: 'no-store' })
+    fetch('/api/trending')
       .then(async response => {
         const data = await response.json();
         if (!response.ok) throw new Error(data.error || 'Unable to load trending developers');


### PR DESCRIPTION
## Summary
- remove the client-side cache: no-store override from the Trending request
- allow the API's existing CDN cache policy to serve the expensive Cosmos/history response
- prevent the Trending tab from remaining in its loading state

## Validation
- 
ode --test tests/trending.test.js (5 passed)