### PR TITLE
feat: link Hacktoberfest from homepage

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -26,6 +26,13 @@ export default function Header({ onHome, theme, onToggleTheme, user, onLogout, o
             <path d="M6 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm-2 5c-2.97 0-6 1.49-6 3v1h12v-1c0-1.51-3.03-3-6-3zm-4.9 3c.4-1 2.2-2 4.9-2s4.5 1 4.9 2H1.1zM12.5 4h-1a.5.5 0 0 0 0 1h1v1a.5.5 0 0 0 1 0V5h1a.5.5 0 0 0 0-1h-1V3a.5.5 0 0 0-1 0v1z"></path>
           </svg><span className="btn__label">Add Me To Globe</span>
         </button>
+        <a href="/hacktoberfest" className="btn btn--hacktoberfest" aria-label="Open Hacktoberfest 2026 Matchmaker" title="Hacktoberfest 2026 Matchmaker">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <rect x="3" y="5" width="18" height="16" rx="2" />
+            <path d="M16 3v4M8 3v4M3 11h18M8 15h3v3H8z" />
+          </svg>
+          <span className="btn__label">Hacktoberfest</span>
+        </a>
         <button
           type="button"
           className={`btn btn--activity${activityOpen ? ' btn--active' : ''}`}

--- a/styles/main.css
+++ b/styles/main.css
@@ -229,6 +229,17 @@ body {
   box-shadow: none;
 }
 
+.btn--hacktoberfest {
+  border: 1px solid color-mix(in srgb, #f97316 55%, var(--border));
+  background: color-mix(in srgb, #f97316 12%, transparent);
+  color: var(--text-primary);
+}
+
+.btn--hacktoberfest:hover {
+  background: color-mix(in srgb, #f97316 20%, transparent);
+  border-color: #f97316;
+}
+
 .btn--tour {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- add an accessible Hacktoberfest 2026 Matchmaker link to the homepage header
- use the existing responsive header behavior so the label collapses on smaller screens
- confirm the deployed country statistics route now returns HTTP 200

## Validation
- 
ode --test tests/hacktoberfest-matches.test.js tests/trending.test.js (9 passed)
- 
pm run build (passed; /countries and /hacktoberfest generated)