### PR TITLE
Promote Hacktoberfest in activity banner

### DIFF
--- a/components/PlatformActivityBanner.jsx
+++ b/components/PlatformActivityBanner.jsx
@@ -41,6 +41,13 @@ export default function PlatformActivityBanner() {
       </Link>
       <a className="activity-banner__detail" href={activity.url}>{activity.description}</a>
       <time dateTime={activity.createdAt}>{relativeTime(activity.createdAt)}</time>
+      <Link className="activity-banner__campaign" href="/hacktoberfest" aria-label="Explore Hacktoberfest 2026 contribution opportunities">
+        <span>Hacktoberfest 2026</span>
+        <strong>Find your issue</strong>
+        <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M3 8h10M9 4l4 4-4 4" />
+        </svg>
+      </Link>
     </aside>
   );
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -193,6 +193,38 @@ body {
   font-size: 9px;
 }
 
+.activity-banner__campaign {
+  display: inline-flex;
+  min-height: 28px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+  margin-left: 8px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, #f97316 65%, var(--border));
+  border-radius: 6px;
+  background: color-mix(in srgb, #f97316 14%, transparent);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.activity-banner__campaign span {
+  color: #fb923c;
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.activity-banner__campaign strong {
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.activity-banner__campaign:hover {
+  border-color: #f97316;
+  background: color-mix(in srgb, #f97316 22%, transparent);
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -4108,6 +4140,12 @@ body {
   }
   .activity-banner__detail {
     min-width: 0;
+  }
+  .activity-banner__campaign {
+    margin-left: auto;
+  }
+  .activity-banner__campaign span {
+    display: none;
   }
   .globe-avatar-marker {
     width: 20px;


### PR DESCRIPTION
This PR introduces a persistent, prominent Hacktoberfest celebration CTA style within the PlatformActivityBanner (live activity-strip) on desktop, with a responsive shorter mobile-friendly caption to avoid element wrapping issues. 
pm run build completed successfully, and validation has been verified (including desktop/mobile overflow checks).