### PR TITLE
Show DevGlobe activity by default

### DIFF
--- a/components/GlobalActivityFeed.jsx
+++ b/components/GlobalActivityFeed.jsx
@@ -25,7 +25,7 @@ function relativeTime(timestamp) {
 }
 
 export default function GlobalActivityFeed({ active }) {
-  const [selectedSource, setSelectedSource] = useState('github');
+  const [selectedSource, setSelectedSource] = useState('devglobe');
   const {
     activities,
     loading,


### PR DESCRIPTION
The Activity panel now initially selects DevGlobe. Validation 'npm run build' passed.