### PR TITLE
Route MCP discovery through public API

### DIFF
--- a/lib/devglobe-mcp-client.js
+++ b/lib/devglobe-mcp-client.js
@@ -79,22 +79,24 @@ async function readJson(response) {
 
 export function createDevGlobeMcpClient({
   baseUrl = process.env.DEVGLOBE_API_URL,
+  publicApiBaseUrl = baseUrl,
   agentToken = process.env.DEVGLOBE_AGENT_TOKEN,
   fetchImpl = fetch,
 } = {}) {
   const origin = normalizeBaseUrl(baseUrl);
+  const publicApiOrigin = normalizeBaseUrl(publicApiBaseUrl);
 
   return {
     async searchDevelopers({ query, location, language, opportunityType, availableForAgents = false, limit = 10 }) {
       const searchText = [query, location, language].filter(Boolean).join(' ');
-      const searchUrl = new URL('/api/search', origin);
+      const searchUrl = new URL('/api/search', publicApiOrigin);
       searchUrl.searchParams.set('q', searchText);
       searchUrl.searchParams.set('mode', 'text');
       searchUrl.searchParams.set('top', String(Math.min(limit, 20)));
       const search = await readJson(await fetchImpl(searchUrl));
 
       const developers = await Promise.all(search.results.map(async result => {
-        const profileUrl = new URL('/api/developer', origin);
+        const profileUrl = new URL('/api/developer', publicApiOrigin);
         profileUrl.searchParams.set('id', result.login || result.id);
         return readJson(await fetchImpl(profileUrl));
       }));
@@ -109,7 +111,7 @@ export function createDevGlobeMcpClient({
     },
 
     async getDeveloperProfile(login) {
-      const url = new URL('/api/developer', origin);
+      const url = new URL('/api/developer', publicApiOrigin);
       url.searchParams.set('id', login);
       const developer = await readJson(await fetchImpl(url));
       return projectDeveloper(developer, origin);

--- a/lib/remote-mcp.js
+++ b/lib/remote-mcp.js
@@ -54,7 +54,11 @@ export function handleMcpOptions(request) {
   return withSecurityHeaders(response, origin);
 }
 
-export async function handleRemoteMcpRequest(request, { fetchImpl = fetch, metricRecorder = recordMcpMetric } = {}) {
+export async function handleRemoteMcpRequest(request, {
+  fetchImpl = fetch,
+  metricRecorder = recordMcpMetric,
+  apiBaseUrl = process.env.DEVGLOBE_API_URL || process.env.NEXT_PUBLIC_API_URL,
+} = {}) {
   if (!isMcpOriginAllowed(request)) {
     return withSecurityHeaders(new Response(JSON.stringify({
       jsonrpc: '2.0',
@@ -86,6 +90,7 @@ export async function handleRemoteMcpRequest(request, { fetchImpl = fetch, metri
   const agentToken = authorization.match(/^Bearer\s+(.+)$/i)?.[1];
   const client = createDevGlobeMcpClient({
     baseUrl: new URL(request.url).origin,
+    publicApiBaseUrl: apiBaseUrl || new URL(request.url).origin,
     agentToken,
     fetchImpl,
   });

--- a/tests/remote-mcp.test.js
+++ b/tests/remote-mcp.test.js
@@ -105,6 +105,32 @@ test('remote MCP performs anonymous public developer discovery', async () => {
   assert.equal(response.result.structuredContent.results[0].availableForAgents, true);
 });
 
+test('remote MCP uses the configured public API instead of fetching its own origin', async () => {
+  const requestedOrigins = [];
+  const fetchImpl = async url => {
+    const parsed = new URL(url);
+    requestedOrigins.push(parsed.origin);
+    return parsed.pathname === '/api/search'
+      ? Response.json({ results: [{ login: 'open-dev' }] })
+      : Response.json({ login: 'open-dev' });
+  };
+
+  await readMcpResponse(await handleRemoteMcpRequest(mcpRequest({
+    jsonrpc: '2.0',
+    id: 9,
+    method: 'tools/call',
+    params: { name: 'search_developers', arguments: { query: 'React', limit: 1 } },
+  }), {
+    fetchImpl,
+    apiBaseUrl: 'https://devglobe-public-api.azurewebsites.net',
+  }));
+
+  assert.deepEqual(requestedOrigins, [
+    'https://devglobe-public-api.azurewebsites.net',
+    'https://devglobe-public-api.azurewebsites.net',
+  ]);
+});
+
 test('remote MCP forwards bearer credentials for introduction tools', async () => {
   let authorization;
   let requestBody;
@@ -126,7 +152,10 @@ test('remote MCP forwards bearer credentials for introduction tools', async () =
         project: 'Example UI',
       },
     },
-  }, { Authorization: 'Bearer issued-agent-token' }), { fetchImpl }));
+  }, { Authorization: 'Bearer issued-agent-token' }), {
+    fetchImpl,
+    apiBaseUrl: 'https://devglobe-public-api.azurewebsites.net',
+  }));
   assert.equal(response.result.isError, undefined);
   assert.equal(authorization, 'Bearer issued-agent-token');
   assert.equal(requestBody.developerLogin, 'open-dev');


### PR DESCRIPTION
Public search/profile reads use configured Azure API while authenticated introductions remain same-origin. Validation: 17 focused tests passed, compile/type/static page generation passed, but local Windows build trace finalization hung after 58/58 pages.