### PR TITLE
Update PostCSS security overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3598,35 +3598,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha1-bnUTV4DH4Q3zQzvyJmxVLTXIxiA=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.17",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.41",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
@@ -8881,9 +8852,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "funding": [
         {
           "type": "github",
@@ -9469,9 +9440,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha1-krRRBQqfkU2mdVrzUr3AGSUIZW0=",
+      "version": "8.5.26",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha1-bnUTV4DH4Q3zQzvyJmxVLTXIxiA=",
       "funding": [
         {
           "type": "opencollective",
@@ -9488,9 +9459,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -11453,35 +11424,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha1-bnUTV4DH4Q3zQzvyJmxVLTXIxiA=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.17",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitepress": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "vitepress": "^1.6.4"
   },
   "overrides": {
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18",
+    "postcss": "8.5.26"
   }
 }


### PR DESCRIPTION
This PR supersedes stale PRs #110/#130, pins postcss 8.5.26 and nanoid 3.3.18, clears postcss/nanoid audit entries, and validation: 235 tests pass; build compiled/typechecked/generated 58/58 pages but local Windows trace finalization hung.