### PR TITLE
Include MCP documentation in standalone deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   output: 'standalone',
   outputFileTracingIncludes: {
     '/api/card': ['./node_modules/@fontsource/manrope/files/manrope-latin-*-normal.woff'],
+    '/docs/mcp-server': ['./docs/mcp-server.md'],
   },
   async headers() {
     return [

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -140,3 +140,7 @@ test('negotiates a Markdown homepage with token metadata', async () => {
   assert.ok(Number(response.headers.get('x-markdown-tokens')) > 0);
   assert.match(await response.text(), /# DevGlobe/);
 });
+
+test('includes MCP documentation in the standalone deployment artifact', () => {
+  assert.deepEqual(nextConfig.outputFileTracingIncludes['/docs/mcp-server'], ['./docs/mcp-server.md']);
+});


### PR DESCRIPTION
Production /docs/mcp-server returned 500 because docs/mcp-server.md was absent from Next standalone tracing, and validation includes 11 tests plus confirmed .next/standalone/docs/mcp-server.md at 6922 bytes.