### PR TITLE
Include MCP documentation in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,8 @@ temp-query.js
 .env*
 !.env.example
 docs
+!docs/
+docs/*
+!docs/mcp-server.md
 docs-site
 tests

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -141,6 +141,9 @@ test('negotiates a Markdown homepage with token metadata', async () => {
   assert.match(await response.text(), /# DevGlobe/);
 });
 
-test('includes MCP documentation in the standalone deployment artifact', () => {
+test('includes MCP documentation in standalone and Docker build inputs', async () => {
   assert.deepEqual(nextConfig.outputFileTracingIncludes['/docs/mcp-server'], ['./docs/mcp-server.md']);
+
+  const dockerIgnore = await fs.readFile('.dockerignore', 'utf8');
+  assert.match(dockerIgnore, /^!docs\/mcp-server\.md$/m);
 });


### PR DESCRIPTION
PR #269 correctly traced the file locally, but .dockerignore excluded docs/ from Azure ACR builds, causing production 500; this change re-includes only docs/mcp-server.md; validation is 11/11 readiness tests and local standalone endpoint 200, while Docker daemon was unavailable locally.