### PR TITLE
Prerender MCP documentation route

### DIFF
--- a/app/docs/mcp-server/route.js
+++ b/app/docs/mcp-server/route.js
@@ -1,6 +1,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+export const dynamic = 'force-static';
+
 export async function GET() {
   const markdown = await fs.readFile(path.join(process.cwd(), 'docs', 'mcp-server.md'), 'utf8');
   return new Response(markdown, {

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -13,6 +13,7 @@ import { GET as getRobots } from '../app/robots.txt/route.js';
 import { GET as getUnknownApi } from '../app/api/[...path]/route.js';
 import { GET as searchDevelopers } from '../app/api/search/route.js';
 import { GET as getDeveloper } from '../app/api/developer/route.js';
+import { dynamic as mcpDocsRendering, GET as getMcpDocs } from '../app/docs/mcp-server/route.js';
 import { middleware } from '../middleware.js';
 
 test('advertises agent discovery resources from the homepage', async () => {
@@ -142,8 +143,13 @@ test('negotiates a Markdown homepage with token metadata', async () => {
 });
 
 test('includes MCP documentation in standalone and Docker build inputs', async () => {
+  assert.equal(mcpDocsRendering, 'force-static');
   assert.deepEqual(nextConfig.outputFileTracingIncludes['/docs/mcp-server'], ['./docs/mcp-server.md']);
 
   const dockerIgnore = await fs.readFile('.dockerignore', 'utf8');
   assert.match(dockerIgnore, /^!docs\/mcp-server\.md$/m);
+
+  const response = await getMcpDocs();
+  assert.equal(response.headers.get('content-type'), 'text/markdown; charset=utf-8');
+  assert.match(await response.text(), /^# DevGlobe MCP Server/m);
 });


### PR DESCRIPTION
Azure still returned 500 after tracing/context fixes because runtime fs remained fragile; force-static emits the response at build time. Include validation: 11/11 tests, build classifies route static, standalone returns 200 after runtime markdown is removed.