### PR TITLE
feat: add completed mission history

### DIFF
--- a/app/api/daily-mission/route.js
+++ b/app/api/daily-mission/route.js
@@ -5,7 +5,7 @@ import { isAllowedMutationOrigin } from '../../../lib/request-origin.js';
 import { normalizeContributionPreferences, rankContributionOpportunities } from '../../../lib/contribution-opportunities.js';
 import { ContributionOpportunitiesUnavailableError, fetchGitHubContributionCandidates } from '../../../lib/github-contribution-opportunities.js';
 import { acquireDailyMissionLease, getContributionOpportunityStateContainer, reserveGlobalRecommendationRefresh } from '../../../lib/contribution-opportunity-store.js';
-import { DailyMissionError, applyMissionAction, cachedMissionPool, missionDay, selectDailyMission } from '../../../lib/daily-mission.js';
+import { DailyMissionError, addCompletedMission, applyMissionAction, cachedMissionPool, missionDay, selectDailyMission } from '../../../lib/daily-mission.js';
 import { MissionVerificationUnavailableError, verifyGitHubMissionCompletion } from '../../../lib/github-mission-verification.js';
 
 async function getOwner(container, login) {
@@ -57,6 +57,10 @@ function missionResponse(mission, extra = {}) {
   return NextResponse.json({ mission, ...extra }, { headers: { 'Cache-Control': 'private, no-store' } });
 }
 
+function completedMissions(state) {
+  return Array.isArray(state?.completedMissions) ? state.completedMissions : [];
+}
+
 export async function GET() {
   try {
     const owner = await loadOwner();
@@ -65,7 +69,7 @@ export async function GET() {
     const day = missionDay(now);
     const state = owner.developer.contributionOpportunity || {};
     if (state.dailyMission?.day === day && state.dailyMission.status !== 'passed') {
-      return missionResponse(state.dailyMission);
+      return missionResponse(state.dailyMission, { completedMissions: completedMissions(state) });
     }
 
     let pool = state.dailyMissionPool?.day === day ? state.dailyMissionPool.opportunities : null;
@@ -90,7 +94,7 @@ export async function GET() {
         dailyMissionPool: { day, opportunities: pool },
       };
     });
-    return missionResponse(updated.dailyMission);
+    return missionResponse(updated.dailyMission, { completedMissions: completedMissions(updated) });
   } catch (error) {
     if (error instanceof ContributionOpportunitiesUnavailableError) return missionResponse(null, { unavailable: true });
     console.error('Daily mission read failed:', error.message);
@@ -142,9 +146,16 @@ export async function POST(request) {
           excludedIssueIds: history.issueIds,
         })
         : changed;
-      return { ...current, dailyMission: responseMission, dailyMissionHistory: history };
+      return {
+        ...current,
+        dailyMission: responseMission,
+        dailyMissionHistory: history,
+        completedMissions: action === 'complete'
+          ? addCompletedMission(current.completedMissions, changed)
+          : completedMissions(current),
+      };
     });
-    return missionResponse(updated.dailyMission);
+    return missionResponse(updated.dailyMission, { completedMissions: completedMissions(updated) });
   } catch (error) {
     if (error instanceof MissionVerificationUnavailableError) {
       return NextResponse.json({ error: error.message }, { status: 503, headers: { 'Cache-Control': 'private, no-store' } });

--- a/components/TodayMission.jsx
+++ b/components/TodayMission.jsx
@@ -5,6 +5,7 @@ import { track } from '../lib/analytics.js';
 
 export default function TodayMission({ active }) {
   const [mission, setMission] = useState(null);
+  const [completedMissions, setCompletedMissions] = useState([]);
   const [status, setStatus] = useState('loading');
   const [message, setMessage] = useState('');
   const [claimLogin, setClaimLogin] = useState('');
@@ -34,6 +35,7 @@ export default function TodayMission({ active }) {
       }
       if (!response.ok) throw new Error(data.error || 'Unable to load today’s mission');
       setMission(data.mission);
+      setCompletedMissions(Array.isArray(data.completedMissions) ? data.completedMissions : []);
       setStatus(data.unavailable ? 'unavailable' : data.mission ? 'ready' : 'empty');
       if (data.unavailable) {
         track('mission_unavailable', { journey: 'daily_mission' });
@@ -93,6 +95,7 @@ export default function TodayMission({ active }) {
       }
       if (!response.ok) throw new Error(data.error || 'Unable to update today’s mission');
       setMission(data.mission);
+      setCompletedMissions(Array.isArray(data.completedMissions) ? data.completedMissions : []);
       setStatus(data.mission ? 'ready' : 'empty');
       track(`mission_${action === 'complete' ? 'completed' : `${action}ed`}`, { journey: 'daily_mission' });
     } catch (error) {
@@ -158,6 +161,30 @@ export default function TodayMission({ active }) {
           </div>
           {message && <p className="today-mission__error" role="alert">{message}</p>}
         </div>
+      )}
+
+      {completedMissions.length > 0 && (
+        <section className="today-mission__history" aria-labelledby="completed-missions-title">
+          <div className="today-mission__history-heading">
+            <h3 id="completed-missions-title">Completed missions</h3>
+            <span>{completedMissions.length}</span>
+          </div>
+          <ul>
+            {completedMissions.map(completed => (
+              <li key={completed.id}>
+                <div>
+                  <a href={completed.opportunity?.url} target="_blank" rel="noopener noreferrer">
+                    {completed.opportunity?.title || 'Completed issue'}
+                  </a>
+                  <span>{completed.opportunity?.repository || 'GitHub'} · {new Date(completed.completedAt).toLocaleDateString()}</span>
+                </div>
+                {completed.completionEvidence?.url && (
+                  <a href={completed.completionEvidence.url} target="_blank" rel="noopener noreferrer">View PR</a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
     </section>
   );

--- a/docs/prd/follow-the-sun-daily-missions.md
+++ b/docs/prd/follow-the-sun-daily-missions.md
@@ -52,7 +52,7 @@ Signed-out visitors see a GitHub sign-in action. Signed-in developers without a 
 5. Pass selects the next item from the already-fetched daily pool and does not consume another GitHub request.
 6. After accepting, the developer can open the issue and choose **Verify completion**.
 7. DevGlobe checks public GitHub issue timeline and pull-request data. An issue being closed alone is not completion evidence.
-8. The completed state and merged pull-request link remain visible for the rest of the UTC day. A new mission can be assigned the following day.
+8. The completed state and merged pull-request link remain visible for the rest of the UTC day. Verified completions are also retained in a bounded mission history with links to the issue and merged pull request. A new mission can be assigned the following day.
 
 ## Functional requirements
 

--- a/lib/daily-mission.js
+++ b/lib/daily-mission.js
@@ -1,4 +1,5 @@
 const MISSION_DURATION_MINUTES = 15;
+const COMPLETED_MISSION_HISTORY_LIMIT = 25;
 const ACTIONS = new Set(['accept', 'pass', 'complete']);
 
 export class DailyMissionError extends Error {}
@@ -51,4 +52,10 @@ export function applyMissionAction(mission, action, now = new Date(), expectedMi
     status: action === 'accept' ? 'accepted' : action === 'complete' ? 'completed' : 'passed',
     [`${action === 'complete' ? 'completed' : `${action}ed`}At`]: new Date(now).toISOString(),
   };
+}
+
+export function addCompletedMission(history, mission, limit = COMPLETED_MISSION_HISTORY_LIMIT) {
+  if (mission?.status !== 'completed') return Array.isArray(history) ? history : [];
+  const previous = Array.isArray(history) ? history : [];
+  return [mission, ...previous.filter(entry => entry?.id !== mission.id)].slice(0, limit);
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -2115,6 +2115,78 @@ body {
 
 .today-mission__error { color: #fca5a5 !important; }
 
+.today-mission__history {
+  display: grid;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.today-mission__history-heading,
+.today-mission__history li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.today-mission__history-heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
+.today-mission__history-heading span {
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.today-mission__history ul {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.today-mission__history li {
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--overlay-subtle);
+}
+
+.today-mission__history li > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.today-mission__history a {
+  color: var(--mission-link);
+  font-size: 9px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.today-mission__history li > div > a {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.today-mission__history li span {
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font-size: 8px;
+}
+
+.today-mission__history a:hover { text-decoration: underline; }
+.today-mission__history a:focus-visible { outline: 2px solid #38bdf8; outline-offset: 2px; }
+
 .global-activity {
   display: flex;
   min-height: 0;

--- a/tests/daily-mission.test.js
+++ b/tests/daily-mission.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { DailyMissionError, applyMissionAction, cachedMissionPool, missionDay, selectDailyMission } from '../lib/daily-mission.js';
+import { DailyMissionError, addCompletedMission, applyMissionAction, cachedMissionPool, missionDay, selectDailyMission } from '../lib/daily-mission.js';
 
 const NOW = new Date('2026-08-25T08:30:00.000Z');
 const opportunities = [
@@ -26,6 +26,16 @@ test('moves a mission through accept and complete states', () => {
   assert.equal(accepted.status, 'accepted');
   assert.equal(completed.status, 'completed');
   assert.equal(completed.completedAt, NOW.toISOString());
+});
+
+test('keeps completed mission history newest first, deduplicated, and bounded', () => {
+  const completed = applyMissionAction(applyMissionAction(selectDailyMission(opportunities, { login: 'octocat', now: NOW }), 'accept', NOW), 'complete', NOW);
+  const previous = Array.from({ length: 25 }, (_, index) => ({ id: `older-${index}`, status: 'completed' }));
+  const history = addCompletedMission(previous, completed);
+
+  assert.equal(history.length, 25);
+  assert.equal(history[0].id, completed.id);
+  assert.equal(addCompletedMission(history, completed).filter(mission => mission.id === completed.id).length, 1);
 });
 
 test('allows a pass but rejects invalid or stale transitions', () => {


### PR DESCRIPTION
## Summary
- persist up to 25 verified completed missions per claimed developer
- show issue, repository, completion date, and merged PR in the Activity view
- document and test bounded, deduplicated history behavior

## Validation
- `npm test` (275 passed)
- `npm run build`
- desktop and 390px browser layout checks
