### PR TITLE
fix: make mission preview dismissible

### DIFF
--- a/components/MissionPreview.jsx
+++ b/components/MissionPreview.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { track } from '../lib/analytics.js';
 
 export default function MissionPreview({ signedIn = false, onOpenActivity }) {
+  const [visible, setVisible] = useState(true);
   const [login, setLogin] = useState('');
   const [status, setStatus] = useState('idle');
   const [result, setResult] = useState(null);
@@ -36,8 +37,21 @@ export default function MissionPreview({ signedIn = false, onOpenActivity }) {
     track('mission_preview_signin_selected', { journey: 'mission_preview' });
   }
 
+  if (!visible) return null;
+
   return (
     <section className="mission-preview" aria-labelledby="mission-preview-title">
+      <button
+        type="button"
+        className="mission-preview__close"
+        onClick={() => setVisible(false)}
+        aria-label="Close mission preview"
+        title="Close mission preview"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
       <div className="mission-preview__intro">
         <span>NEW TO OPEN SOURCE?</span>
         <h2 id="mission-preview-title">Preview your mission</h2>

--- a/styles/main.css
+++ b/styles/main.css
@@ -678,6 +678,7 @@ body {
 }
 
 .mission-preview {
+  position: relative;
   display: grid;
   width: min(760px, calc(100vw - 32px));
   grid-template-columns: minmax(220px, 0.8fr) minmax(320px, 1.2fr);
@@ -690,6 +691,22 @@ body {
   box-shadow: var(--shadow-strong);
 }
 
+.mission-preview__close {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  padding: 12px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.mission-preview__close:hover { color: var(--text-primary); }
+.mission-preview__close svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-width: 2; }
 .mission-preview__intro { display: grid; align-content: center; gap: 3px; }
 .mission-preview__intro > span { color: #4ade80; font-size: 9px; font-weight: 800; }
 .mission-preview__intro h2 { margin: 0; color: var(--text-primary); font-size: 15px; }
@@ -717,6 +734,13 @@ body {
   background: transparent;
   color: var(--text-primary);
   font: 12px var(--font);
+}
+.mission-preview__form input::selection { background: rgba(34, 211, 238, 0.24); color: var(--text-primary); }
+.mission-preview__form input:-webkit-autofill,
+.mission-preview__form input:-webkit-autofill:focus {
+  box-shadow: 0 0 0 1000px var(--bg-card) inset;
+  -webkit-text-fill-color: var(--text-primary);
+  caret-color: var(--text-primary);
 }
 .mission-preview__form button,
 .mission-preview__actions :is(a, button),


### PR DESCRIPTION
## Summary
- add an accessible close button to the mission preview panel
- normalize username selection and browser autofill colors on the dark input
- preserve the existing visible keyboard focus treatment

## Validation
- 283 tests passed
- production build completed with 63/63 pages
- browser-validated close behavior
- git diff --check

Follow-up to #290