### PR TITLE
fix: show accepted missions in activity

### DIFF
--- a/app/api/daily-mission/route.js
+++ b/app/api/daily-mission/route.js
@@ -7,6 +7,8 @@ import { ContributionOpportunitiesUnavailableError, fetchGitHubContributionCandi
 import { acquireDailyMissionLease, getContributionOpportunityStateContainer, reserveGlobalRecommendationRefresh } from '../../../lib/contribution-opportunity-store.js';
 import { DailyMissionError, addCompletedMission, applyMissionAction, cachedMissionPool, missionDay, selectDailyMission } from '../../../lib/daily-mission.js';
 import { MissionVerificationUnavailableError, verifyGitHubMissionCompletion } from '../../../lib/github-mission-verification.js';
+import { saveActivities } from '../../../lib/activity-store.js';
+import { createPlatformActivity } from '../../../lib/platform-activity.js';
 
 async function getOwner(container, login) {
   const { resources } = await container.items.query({
@@ -61,6 +63,21 @@ function completedMissions(state) {
   return Array.isArray(state?.completedMissions) ? state.completedMissions : [];
 }
 
+async function recordMissionAcceptanceActivity(developer, mission) {
+  if (mission?.status !== 'accepted' || !mission.acceptedAt) return;
+  try {
+    await saveActivities([createPlatformActivity({
+      id: `platform:mission-accepted:${mission.id}`,
+      type: 'mission_accepted',
+      login: developer.login,
+      avatarUrl: developer.avatarUrl,
+      now: new Date(mission.acceptedAt),
+    })]);
+  } catch (error) {
+    console.error('Mission acceptance activity write failed:', error.message);
+  }
+}
+
 export async function GET() {
   try {
     const owner = await loadOwner();
@@ -69,6 +86,7 @@ export async function GET() {
     const day = missionDay(now);
     const state = owner.developer.contributionOpportunity || {};
     if (state.dailyMission?.day === day && state.dailyMission.status !== 'passed') {
+      await recordMissionAcceptanceActivity(owner.developer, state.dailyMission);
       return missionResponse(state.dailyMission, { completedMissions: completedMissions(state) });
     }
 
@@ -155,6 +173,7 @@ export async function POST(request) {
           : completedMissions(current),
       };
     });
+    if (action === 'accept') await recordMissionAcceptanceActivity(owner.developer, updated.dailyMission);
     return missionResponse(updated.dailyMission, { completedMissions: completedMissions(updated) });
   } catch (error) {
     if (error instanceof MissionVerificationUnavailableError) {

--- a/lib/platform-activity.js
+++ b/lib/platform-activity.js
@@ -21,9 +21,10 @@ export function normalizePlatformActivity(activity) {
     : activity;
 }
 
-export function createPlatformActivity({ type, login, avatarUrl, targetLogin, now = new Date() }) {
+export function createPlatformActivity({ id, type, login, avatarUrl, targetLogin, now = new Date() }) {
   const isCard = type === 'generated_card';
   const isReadme = type === 'generated_readme';
+  const isMissionAcceptance = type === 'mission_accepted';
   const target = targetLogin || login;
   const description = isCard
     ? target !== login
@@ -31,9 +32,11 @@ export function createPlatformActivity({ type, login, avatarUrl, targetLogin, no
       : SELF_CARD_DESCRIPTION
     : isReadme
       ? target !== login ? `generated @${target}'s GitHub profile README` : 'generated their GitHub profile README'
-      : 'signed in to DevGlobe';
+      : isMissionAcceptance
+        ? 'accepted an open-source mission'
+        : 'signed in to DevGlobe';
   return {
-    id: `platform:${randomUUID()}`,
+    id: id || `platform:${randomUUID()}`,
     login,
     avatarUrl: avatarUrl || null,
     type,

--- a/tests/activity.test.js
+++ b/tests/activity.test.js
@@ -88,6 +88,24 @@ test('creates platform README activity for the actor and target', () => {
   assert.equal(activity.documentType, 'platform-activity');
 });
 
+test('creates privacy-safe mission acceptance activity', () => {
+  const activity = createPlatformActivity({
+    id: 'platform:mission-accepted:octocat:2026-08-13:101',
+    type: 'mission_accepted',
+    login: 'octocat',
+    avatarUrl: 'https://example.test/octocat.png',
+    now: new Date('2026-08-13T12:00:00Z'),
+  });
+
+  assert.equal(activity.id, 'platform:mission-accepted:octocat:2026-08-13:101');
+  assert.equal(activity.login, 'octocat');
+  assert.equal(activity.avatarUrl, 'https://example.test/octocat.png');
+  assert.equal(activity.description, 'accepted an open-source mission');
+  assert.equal(activity.url, '/developer/octocat');
+  assert.equal(activity.documentType, 'platform-activity');
+  assert.equal('repo' in activity && activity.repo !== null, false);
+});
+
 test('creates stable fallback activities within an hourly window', () => {
   const first = createFallbackActivities(Date.parse('2026-08-13T12:10:00Z'));
   const second = createFallbackActivities(Date.parse('2026-08-13T12:50:00Z'));


### PR DESCRIPTION
## Summary
- publish authenticated mission accepts to the DevGlobe activity feed
- keep issue and repository details out of the public activity record
- reconcile existing accepted missions with deterministic, duplicate-safe activity IDs

## Validation
- npm.cmd test (284 tests passed)
- npm.cmd run build (63/63 pages generated)
- git diff --check