### PR TITLE
docs: add sponsorship and funding transparency

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,2 @@
-# Replace YOUR_USERNAME with your GitHub username
-github: [YOUR_USERNAME]
-# open_collective: devglobe
-# ko_fi: YOUR_USERNAME
-# custom: ["https://your-link.com"]
+github:
+	- sajeetharan

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Documentation](https://img.shields.io/badge/Documentation-GitHub%20Pages-2ea44f?style=for-the-badge&logo=github)](https://sajeetharan.github.io/devglobe/)
 [![VS Code](https://img.shields.io/badge/VS%20Code-Install-007ACC?style=for-the-badge&logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery)
 [![GitHub Stars](https://img.shields.io/github/stars/sajeetharan/devglobe?style=for-the-badge&logo=github)](https://github.com/sajeetharan/devglobe/stargazers)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/sajeetharan?style=for-the-badge&logo=githubsponsors&label=Sponsor)](https://github.com/sponsors/sajeetharan)
 [![License](https://img.shields.io/github/license/sajeetharan/devglobe?style=for-the-badge)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=for-the-badge)](CONTRIBUTING.md)
 
@@ -289,6 +290,12 @@ CRON_SECRET=the-same-secret-configured-on-the-container-app
 ```
 
 Deploy the complete `functions` directory so each timer and its `function.json` are included.
+
+## Support DevGlobe
+
+DevGlobe is independently maintained and free to use. [GitHub sponsorship](https://github.com/sponsors/sajeetharan) helps fund Azure hosting and observability, public-data refreshes, GitHub API-backed processing, security updates, testing, and open-source maintenance.
+
+Sponsorship never influences developer rankings, search placement, moderation, or access to private developer information. See the [funding and transparency policy](docs-site/guide/funding.md) for tiers, benefits, costs, and current milestones.
 
 ## 🤝 Contributing
 

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -23,6 +23,7 @@ export default defineConfig({
       { text: 'Product', link: '/guide/overview' },
       { text: 'Agents', link: '/agents/overview' },
       { text: 'API', link: '/reference/api' },
+      { text: 'Support', link: '/guide/funding' },
       { text: 'Live app', link: 'https://www.devglobe.dev' },
     ],
     sidebar: [
@@ -32,6 +33,7 @@ export default defineConfig({
           { text: 'Overview', link: '/guide/overview' },
           { text: 'Feature guide', link: '/guide/features' },
           { text: 'Scoring and OSS Worth', link: '/guide/methodology' },
+          { text: 'Funding and transparency', link: '/guide/funding' },
         ],
       },
       {

--- a/docs-site/guide/funding.md
+++ b/docs-site/guide/funding.md
@@ -1,0 +1,57 @@
+# Funding and Transparency
+
+DevGlobe is independently maintained and free to use. GitHub Sponsors helps pay for the public infrastructure and maintenance required to keep the project available and trustworthy.
+
+[Sponsor DevGlobe on GitHub](https://github.com/sponsors/sajeetharan)
+
+## What funding supports
+
+- Azure application hosting, storage, and observability
+- Public developer-data refreshes and GitHub API-backed processing
+- Security updates, testing, and dependency maintenance
+- Documentation, community support, and open-source development
+
+## Sponsorship tiers
+
+| Tier | Monthly amount | Benefits |
+| --- | ---: | --- |
+| Supporter | $5 | Sponsor badge and monthly project update |
+| Builder | $15 | Supporter benefits and optional name recognition |
+| Community Partner | $50 | Builder benefits and an optional linked logo |
+| Ecosystem Sponsor | $250 | Community Partner benefits and a quarterly roadmap discussion |
+
+Recognition is optional and published only with the sponsor's approval. Roadmap discussions provide context and feedback opportunities; they do not purchase product decisions or priority.
+
+## Independence and privacy
+
+Sponsorship never influences:
+
+- Developer rankings, scores, or search placement
+- Profile moderation or verification decisions
+- Introduction acceptance or opportunity matching
+- Access to private developer information, analytics, or credentials
+
+Sponsors receive no preferential access to developers. DevGlobe's public-evidence methodology and consent boundaries apply equally to everyone.
+
+## Monthly costs
+
+Actual recurring costs will be published here from provider invoices after the first reporting period. Account identifiers, secrets, credits, and security-sensitive billing details will not be disclosed.
+
+| Category | Current monthly cost |
+| --- | ---: |
+| Azure hosting and storage | Pending first report |
+| Monitoring and analytics | Pending first report |
+| Data processing and refreshes | Pending first report |
+| Other project services | Pending first report |
+
+Monthly reports will show sponsorship income separately from project expenditure and note material donated credits or grants.
+
+## Current milestones
+
+- Increase meaningful developer-profile claims
+- Grow repeat MCP and agent usage
+- Improve contribution-mission matching and completion
+- Expand consent-based collaboration outcomes
+- Keep public discovery reliable, privacy-preserving, and documented
+
+Milestone updates and material funding-policy changes are recorded in this page's Git history.


### PR DESCRIPTION
## Summary
- configure the GitHub Sponsors repository button
- add sponsor calls to action in the README
- publish sponsorship tiers, ethical boundaries, costs, and milestones
- expose the funding page in the public docs navigation

## Validation
- npm run docs:build