### PR TITLE
fix: attribute card activity to generator

### DIFF
--- a/app/api/activities/platform/route.js
+++ b/app/api/activities/platform/route.js
@@ -14,9 +14,12 @@ export async function POST(request) {
     }
 
     const session = await getSession();
+    if (!session?.login || !LOGIN_PATTERN.test(session.login)) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
     const activity = createPlatformActivity({
       type: body.type,
-      login: session?.login || body.targetLogin,
+      login: session.login,
       avatarUrl: session?.avatarUrl,
       targetLogin: body.targetLogin,
     });

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -401,7 +401,6 @@ export default function Home() {
 
   const handleGenerateCard = useCallback((developer) => {
     const rankedDeveloper = developers.find(item => item.login === developer.login) || developer;
-    recordPlatformActivity('generated_card', rankedDeveloper.login);
     if (user?.login?.toLowerCase() === rankedDeveloper.login?.toLowerCase()) {
       fetch('/api/profile-completion', {
         method: 'POST',
@@ -418,7 +417,7 @@ export default function Home() {
     if (rankedDeveloper.lat != null && rankedDeveloper.lng != null) {
       setFlyTarget({ lat: rankedDeveloper.lat, lng: rankedDeveloper.lng });
     }
-  }, [developers, recordPlatformActivity, user]);
+  }, [developers, user]);
 
   const handleOpenOwnProfile = useCallback(async () => {
     if (!user?.login) return;

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -24,14 +24,21 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
   const radarRef = useRef(null);
   const heatmapRef = useRef(null);
   const langRef = useRef(null);
+  const cardGenerationRecordedRef = useRef(false);
 
   useEffect(() => {
     track('profile_viewed', { login: dev.login });
   }, [dev.login]);
 
-  const handleGenerateCard = () => {
+  const recordCardGeneration = () => {
+    if (cardGenerationRecordedRef.current) return;
+    cardGenerationRecordedRef.current = true;
     track('card_generated', { login: dev.login });
     onCardGenerated?.(dev.login);
+  };
+
+  const handleGenerateCard = () => {
+    recordCardGeneration();
     setShowCard(true);
   };
 
@@ -48,7 +55,10 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
   };
 
   useEffect(() => {
-    if (openCardOnMount) setShowCard(true);
+    if (openCardOnMount) {
+      recordCardGeneration();
+      setShowCard(true);
+    }
   }, [openCardOnMount]);
 
   useEffect(() => {


### PR DESCRIPTION
Authenticated session login is now the actor, selected profile remains target, anonymous requests no longer impersonate targets, duplicate writes are prevented; testing: 
ode --test tests/activity.test.js passes.