### PR TITLE
feat: strengthen acquisition and growth tracking

### DIFF
--- a/.github/workflows/weekly-spotlight.yml
+++ b/.github/workflows/weekly-spotlight.yml
@@ -1,0 +1,34 @@
+name: Generate weekly developer spotlight
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Generate review-ready spotlight
+        env:
+          DEVELOPER_SNAPSHOT_URL: https://devglobeactivityfn.z13.web.core.windows.net/developers.json
+        run: npm run activation-campaign -- --limit=5 --output=weekly-spotlight.json
+
+      - name: Upload spotlight for review
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-developer-spotlight
+          path: weekly-spotlight.json
+          retention-days: 14

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -201,7 +201,8 @@ export default function Home() {
           return { ok: false, ...result };
         }
         setClaimStatus('claimed');
-        track('claim_completed', { profile_status: 'public' });
+        const source = new URLSearchParams(window.location.search).get('utm_source') || 'direct';
+        track('claim_completed', { login: user.login, source });
         setClaimedLogins(prev => new Set(prev).add(user.login));
         let claimedDeveloper = developers.find(developer => developer.login === user.login);
         // If a new profile was created, reload developers to include it

--- a/app/share/[login]/page.jsx
+++ b/app/share/[login]/page.jsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
 import { getSiteUrl, SOCIAL_PREVIEW_VERSION } from '../../../lib/site.js';
 import { attributedGlobePath } from '../../../lib/share-attribution.js';
+import SharePageActions from '../../../components/SharePageActions.jsx';
 
 export const revalidate = 86400;
 
@@ -40,8 +40,14 @@ export default async function DeveloperSharePage({ params, searchParams }) {
   const encodedLogin = encodeURIComponent(login);
   const siteUrl = getSiteUrl();
   const pageUrl = `${siteUrl}/share/${encodedLogin}`;
-  const profilePath = attributedGlobePath(login, tracking);
-  const globePath = attributedGlobePath(null, tracking);
+  const attribution = {
+    utm_source: 'share_page',
+    utm_medium: 'referral',
+    utm_campaign: 'identity_card',
+    ...tracking,
+  };
+  const profilePath = attributedGlobePath(login, attribution);
+  const createPath = attributedGlobePath(null, attribution);
   const profileDescription = `Explore @${login}'s open-source developer identity, global rank, country rank, and public contribution impact on DevGlobe.`;
   const structuredData = {
     '@context': 'https://schema.org',
@@ -80,10 +86,12 @@ export default async function DeveloperSharePage({ params, searchParams }) {
           src={`/api/preview/v${SOCIAL_PREVIEW_VERSION}/${encodedLogin}.png`}
           alt={`Developer card for @${login}`}
         />
-        <div className="share-page__actions">
-          <Link href={profilePath}>Explore @{login} on DevGlobe</Link>
-          <Link className="share-page__home" href={globePath}>Open the globe</Link>
-        </div>
+        <SharePageActions
+          login={login}
+          profilePath={profilePath}
+          createPath={createPath}
+          previewVersion={SOCIAL_PREVIEW_VERSION}
+        />
       </div>
     </main>
   );

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -7,6 +7,48 @@ const siteUrl = getSiteUrl();
 
 export const revalidate = 86400;
 
+export function buildSitemapEntries(profileLogins, lastModified = new Date()) {
+  const logins = [...new Set(profileLogins.filter(Boolean))];
+  return [
+    {
+      url: siteUrl,
+      lastModified,
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/agents`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/hacktoberfest`,
+      lastModified,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${siteUrl}/countries`,
+      lastModified,
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    ...logins.flatMap(login => [
+      {
+        url: `${siteUrl}/developer/${encodeURIComponent(login)}`,
+        changeFrequency: 'daily',
+        priority: 0.7,
+      },
+      {
+        url: `${siteUrl}/share/${encodeURIComponent(login)}`,
+        changeFrequency: 'monthly',
+        priority: 0.6,
+      },
+    ]),
+  ];
+}
+
 async function getProfileLogins() {
   const container = getCosmosContainer();
   if (!container) {
@@ -28,30 +70,5 @@ async function getProfileLogins() {
 
 export default async function sitemap() {
   const profileLogins = await getProfileLogins();
-
-  return [
-    {
-      url: siteUrl,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 1,
-    },
-    {
-      url: `${siteUrl}/agents`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${siteUrl}/hacktoberfest`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-    ...profileLogins.map(login => ({
-      url: `${siteUrl}/share/${encodeURIComponent(login)}`,
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    })),
-  ];
+  return buildSitemapEntries(profileLogins);
 }

--- a/components/SharePageActions.jsx
+++ b/components/SharePageActions.jsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { track } from '../lib/analytics.js';
+import { identityCardShareUrl } from '../lib/share-attribution.js';
+
+export default function SharePageActions({ login, profilePath, createPath, previewVersion }) {
+  const [shareStatus, setShareStatus] = useState('');
+
+  async function shareCard() {
+    const url = identityCardShareUrl(window.location.origin, login, 'native_share', previewVersion);
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: `@${login}'s developer card`,
+          text: `Explore @${login}'s open-source developer identity on DevGlobe.`,
+          url,
+        });
+        setShareStatus('Shared');
+        track('identity_card_shared', { login, channel: 'native_share' });
+      } else {
+        await navigator.clipboard.writeText(url);
+        setShareStatus('Link copied');
+        track('identity_card_shared', { login, channel: 'copy_link' });
+      }
+    } catch (error) {
+      if (error.name !== 'AbortError') setShareStatus('Unable to share');
+    }
+  }
+
+  return (
+    <div className="share-page__actions">
+      <Link className="share-page__profile" href={profilePath}>Explore @{login}</Link>
+      <Link className="share-page__create" href={createPath}>Create your card</Link>
+      <button type="button" onClick={shareCard}>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+          <path d="m8.6 10.5 6.8-4M8.6 13.5l6.8 4" />
+        </svg>
+        Share card
+      </button>
+      <span className="share-page__share-status" role="status" aria-live="polite">{shareStatus}</span>
+    </div>
+  );
+}

--- a/components/UserMenu.jsx
+++ b/components/UserMenu.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { track } from '../lib/analytics.js';
+import { developerInviteUrl } from '../lib/share-attribution.js';
 import ProfileCompletionChecklist from './ProfileCompletionChecklist.jsx';
 import ProfileInsights from './ProfileInsights.jsx';
 
@@ -78,14 +79,15 @@ export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onO
   }
 
   async function inviteDeveloper() {
-    const url = `${window.location.origin}/?ref=${encodeURIComponent(user.login)}`;
     const text = 'Find your open-source profile, developer rank, and OSS Worth on DevGlobe.';
     try {
       if (navigator.share) {
+        const url = developerInviteUrl(window.location.origin, user.login, 'native_share');
         await navigator.share({ title: 'Join me on DevGlobe', text, url });
         setInviteStatus('Invite shared');
         track('developer_invite_shared', { channel: 'native_share' });
       } else {
+        const url = developerInviteUrl(window.location.origin, user.login, 'copy_link');
         await navigator.clipboard.writeText(`${text}\n${url}`);
         setInviteStatus('Invite copied');
         track('developer_invite_shared', { channel: 'copy_link' });

--- a/docs/growth-attribution.md
+++ b/docs/growth-attribution.md
@@ -1,0 +1,20 @@
+# Growth attribution
+
+Identity card shares and member invitations use `utm_source`, `utm_medium`, and `utm_campaign`. Review the rolling seven-day funnel in the Application Insights workspace with:
+
+```kusto
+let window = 7d;
+let actions = AppEvents
+| where TimeGenerated >= ago(window)
+| where Name in ("card_generated", "claim_completed", "identity_card_shared", "profile_viewed", "developer_invite_shared")
+| extend Source=tostring(Properties.source), Channel=tostring(Properties.channel)
+| summarize Events=count(), Users=dcount(UserId), Sessions=dcount(SessionId) by Name, Source, Channel;
+let arrivals = AppPageViews
+| where TimeGenerated >= ago(window)
+| extend Source=extract(@"[?&]utm_source=([^&]+)", 1, Url), Campaign=extract(@"[?&]utm_campaign=([^&]+)", 1, Url)
+| summarize Events=count(), Users=dcount(UserId), Sessions=dcount(SessionId) by Name="page_view", Source, Channel=Campaign;
+union actions, arrivals
+| order by Name asc, Events desc
+```
+
+Compare referral arrivals, profile views, card generations, shares, and claims seven days after each distribution change. The weekly spotlight workflow produces a review-only artifact every Monday; publishing remains a human decision.

--- a/lib/activation-campaign.js
+++ b/lib/activation-campaign.js
@@ -33,7 +33,7 @@ export function selectActivationCandidates(developers = [], limit = 100) {
 }
 
 export function buildOutreachMessage(developer, siteUrl = getSiteUrl()) {
-  const profileUrl = `${siteUrl}/developer/${encodeURIComponent(developer.login)}?utm_source=manual_outreach&utm_medium=community`;
+  const profileUrl = `${siteUrl}/developer/${encodeURIComponent(developer.login)}?utm_source=manual_outreach&utm_medium=community&utm_campaign=developer_activation`;
   const expertise = developer.topLanguage ? `, especially your ${developer.topLanguage} work` : '';
   return `Hi ${displayName(developer)}, DevGlobe mapped your public developer profile${expertise} and highlighted ${contributionSignal(developer)}. You can review it here: ${profileUrl}\n\nIf it looks right, sign in with GitHub to claim it and unlock a verified identity card, impact history, AI collaboration controls, and weekly rankings. No obligation; I would value any feedback.`;
 }
@@ -44,5 +44,5 @@ export function buildWeeklySpotlight(developers = [], siteUrl = getSiteUrl()) {
   const lines = candidates.map((developer, index) => (
     `${index + 1}. ${displayName(developer)} (@${developer.login}) - ${developer.topLanguage || 'Open source'} - ${contributionSignal(developer)}`
   ));
-  return `This week's DevGlobe open-source spotlight:\n\n${lines.join('\n')}\n\nExplore the profiles and find your own developer identity: ${siteUrl}/?utm_source=weekly_spotlight&utm_medium=social\n\n#DevGlobe #OpenSource #DeveloperCommunity`;
+  return `This week's DevGlobe open-source spotlight:\n\n${lines.join('\n')}\n\nExplore the profiles and find your own developer identity: ${siteUrl}/?utm_source=weekly_spotlight&utm_medium=social&utm_campaign=developer_spotlight\n\n#DevGlobe #OpenSource #DeveloperCommunity`;
 }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,6 +1,7 @@
 const ENGAGEMENT_EVENT_MAP = {
 	agent_profile_shared: 'profile_shared',
 	card_generated: 'card_generated',
+	claim_completed: 'profile_claimed',
 	comparison_started: 'comparison_started',
 	identity_card_shared: 'profile_shared',
 	mission_accepted: 'mission_accepted',

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -15,6 +15,7 @@ export const ENGAGEMENT_EVENTS = new Set([
   'mission_viewed',
   'next_action_selected',
   'profile_shared',
+  'profile_claimed',
   'profile_viewed',
   'recommendation_opened',
   'search_appearance',
@@ -60,7 +61,7 @@ export function normalizeEngagementEvent(input) {
   const eventName = String(input?.eventName || '').trim();
   if (!ENGAGEMENT_EVENTS.has(eventName)) throw new EngagementValidationError('Unsupported engagement event');
   const targetLogin = normalizeTargetLogin(input.targetLogin);
-  if (['card_generated', 'profile_shared', 'profile_viewed', 'search_appearance'].includes(eventName) && !targetLogin) {
+  if (['card_generated', 'profile_claimed', 'profile_shared', 'profile_viewed', 'search_appearance'].includes(eventName) && !targetLogin) {
     throw new EngagementValidationError('Target login is required');
   }
   return { eventName, targetLogin, properties: normalizeProperties(input.properties) };

--- a/lib/share-attribution.js
+++ b/lib/share-attribution.js
@@ -18,6 +18,15 @@ export function identityCardShareUrl(siteUrl, login, channel, version) {
   return url.toString();
 }
 
+export function developerInviteUrl(siteUrl, login, channel) {
+  const url = new URL('/', siteUrl);
+  url.searchParams.set('ref', login);
+  url.searchParams.set('utm_source', channel);
+  url.searchParams.set('utm_medium', 'referral');
+  url.searchParams.set('utm_campaign', 'developer_invite');
+  return url.toString();
+}
+
 export function attributedGlobePath(login, params = {}) {
   const query = trackingParams(params);
   if (login) query.set('dev', login);

--- a/scripts/generate-activation-campaign.js
+++ b/scripts/generate-activation-campaign.js
@@ -13,19 +13,28 @@ const requestedLimit = Number.parseInt(limitArg?.split('=')[1] || '100', 10);
 const limit = Number.isInteger(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 100) : 100;
 const container = getCosmosContainer(process.env.COSMOS_CONTAINER || 'developers');
 
-if (!container) {
-  console.error('Cosmos DB is not configured.');
-  process.exit(1);
+async function loadDevelopers() {
+  if (container) {
+    const { resources } = await container.items.query({
+      query: `SELECT TOP 500 c.login, c.name, c.location, c.topLanguage, c.score,
+          c.totalStars, c.totalCommits, c.followers, c.soReputation, c.claimed
+        FROM c
+        WHERE (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')
+          AND (NOT IS_DEFINED(c.claimed) OR c.claimed != true)
+        ORDER BY c.score DESC`,
+    }).fetchAll();
+    return resources;
+  }
+
+  const sourceUrl = process.env.DEVELOPER_SNAPSHOT_URL?.trim();
+  if (!sourceUrl) throw new Error('Cosmos DB or DEVELOPER_SNAPSHOT_URL is required.');
+  const response = await fetch(sourceUrl);
+  if (!response.ok) throw new Error(`Developer snapshot returned ${response.status}.`);
+  const payload = await response.json();
+  return Array.isArray(payload) ? payload : payload.developers || [];
 }
 
-const { resources } = await container.items.query({
-  query: `SELECT TOP 500 c.login, c.name, c.location, c.topLanguage, c.score,
-      c.totalStars, c.totalCommits, c.followers, c.soReputation, c.claimed
-    FROM c
-    WHERE (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')
-      AND (NOT IS_DEFINED(c.claimed) OR c.claimed != true)
-    ORDER BY c.score DESC`,
-}).fetchAll();
+const resources = await loadDevelopers();
 
 const candidates = selectActivationCandidates(resources, limit);
 const output = {

--- a/styles/main.css
+++ b/styles/main.css
@@ -7204,26 +7204,50 @@ body {
 
 .share-page__actions {
   display: flex;
+  position: relative;
   justify-content: center;
+  align-items: center;
   gap: 10px;
   margin-top: 22px;
+  padding-bottom: 24px;
 }
 
-.share-page__actions a {
+.share-page__actions a,
+.share-page__actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 44px;
   padding: 10px 16px;
   border: 1px solid rgba(8, 145, 178, 0.5);
   border-radius: 6px;
   background: rgba(8, 145, 178, 0.16);
   color: #67e8f9;
+  font-family: inherit;
   font-size: 13px;
   font-weight: 700;
   text-decoration: none;
+  cursor: pointer;
 }
 
-.share-page__actions .share-page__home {
+.share-page__actions .share-page__create {
+  border-color: #22d3ee;
+  background: #22d3ee;
+  color: #071018;
+}
+
+.share-page__actions button {
   border-color: rgba(255, 255, 255, 0.14);
   background: rgba(255, 255, 255, 0.06);
   color: #cbd5e1;
+}
+
+.share-page__share-status {
+  position: absolute;
+  bottom: 0;
+  color: #94a3b8;
+  font-size: 12px;
 }
 .badge-card {
   margin: 40px auto 0;
@@ -7401,7 +7425,8 @@ body {
     flex-direction: column;
   }
 
-  .share-page__actions a {
+  .share-page__actions a,
+  .share-page__actions button {
     text-align: center;
   }
 }
@@ -7780,7 +7805,8 @@ body {
     padding: 24px 12px max(24px, env(safe-area-inset-bottom));
   }
 
-  .share-page__actions a {
+  .share-page__actions a,
+  .share-page__actions button {
     display: inline-flex;
     min-height: 44px;
     align-items: center;

--- a/tests/activation-campaign.test.js
+++ b/tests/activation-campaign.test.js
@@ -21,6 +21,7 @@ test('builds personalized outreach with a measurable profile link and claim bene
   assert.match(message, /Hi Higher/);
   assert.match(message, /500 public commits/);
   assert.match(message, /utm_source=manual_outreach/);
+  assert.match(message, /utm_campaign=developer_activation/);
   assert.match(message, /verified identity card/);
 });
 
@@ -29,4 +30,5 @@ test('builds a weekly spotlight from public contribution signals', () => {
   assert.match(spotlight, /Higher \(@higher\)/);
   assert.doesNotMatch(spotlight, /Claimed/);
   assert.match(spotlight, /utm_source=weekly_spotlight/);
+  assert.match(spotlight, /utm_campaign=developer_spotlight/);
 });

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -182,3 +182,16 @@ test('suppresses each low-volume mission metric and counts recovered availabilit
   assert.equal(metrics.acceptanceRate, null);
   assert.equal(metrics.availabilityRate, 1);
 });
+
+test('requires a target profile for a completed claim', () => {
+  assert.deepEqual(normalizeEngagementEvent({
+    eventName: 'profile_claimed',
+    targetLogin: 'OctoCat',
+    properties: { source: 'linkedin' },
+  }), {
+    eventName: 'profile_claimed',
+    targetLogin: 'octocat',
+    properties: { source: 'linkedin' },
+  });
+  assert.throws(() => normalizeEngagementEvent({ eventName: 'profile_claimed' }), EngagementValidationError);
+});

--- a/tests/share-attribution.test.js
+++ b/tests/share-attribution.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { attributedGlobePath, identityCardShareUrl } from '../lib/share-attribution.js';
+import { attributedGlobePath, developerInviteUrl, identityCardShareUrl } from '../lib/share-attribution.js';
 
 test('builds channel-specific identity card referral URLs', () => {
   const linkedIn = new URL(identityCardShareUrl('https://www.devglobe.dev', 'octo cat', 'linkedin', '4'));
@@ -28,4 +28,14 @@ test('preserves only campaign attribution when entering the globe', () => {
   assert.equal(url.searchParams.get('utm_medium'), 'social');
   assert.equal(url.searchParams.get('utm_campaign'), 'identity_card');
   assert.equal(url.searchParams.has('token'), false);
+});
+
+test('attributes member invitations without exposing identity outside ref', () => {
+  const url = new URL(developerInviteUrl('https://www.devglobe.dev', 'octocat', 'native_share'));
+
+  assert.equal(url.pathname, '/');
+  assert.equal(url.searchParams.get('ref'), 'octocat');
+  assert.equal(url.searchParams.get('utm_source'), 'native_share');
+  assert.equal(url.searchParams.get('utm_medium'), 'referral');
+  assert.equal(url.searchParams.get('utm_campaign'), 'developer_invite');
 });

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSitemapEntries } from '../app/sitemap.js';
+
+test('includes every existing indexable acquisition route', () => {
+  const entries = buildSitemapEntries(['octocat', 'octo cat', 'octocat']);
+  const paths = entries.map(entry => new URL(entry.url).pathname);
+
+  assert.ok(paths.includes('/countries'));
+  assert.ok(paths.includes('/developer/octocat'));
+  assert.ok(paths.includes('/share/octocat'));
+  assert.ok(paths.includes('/developer/octo%20cat'));
+  assert.equal(paths.filter(path => path === '/developer/octocat').length, 1);
+});


### PR DESCRIPTION
Stronger share-page CTAs with native share/copy feedback; UTM attribution for card shares, invitations, spotlight and outreach links; durable claim completion attribution; sitemap expansion for countries, developer and share routes; weekly review-only spotlight artifact from public snapshot; seven-day Application Insights measurement guide.

Testing: `npm test` 295 passed; `npm run build` generated 63/63 pages; live snapshot-backed campaign generation validated.
