### PR TITLE
feat: add leaderboard rank movement periods

### DIFF
--- a/app/api/leaderboard/movement/route.js
+++ b/app/api/leaderboard/movement/route.js
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import {
+  getLatestImpactDayOnOrBefore,
+  getImpactSnapshotForDay,
+} from '../../../../lib/impact-history-store.js';
+import {
+  normalizeLeaderboardLogins,
+  normalizeLeaderboardPeriod,
+} from '../../../../lib/leaderboard-movement.js';
+import { windowStartDay } from '../../../../lib/trending.js';
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const period = normalizeLeaderboardPeriod(searchParams.get('days'));
+  const logins = normalizeLeaderboardLogins(searchParams.get('logins'));
+  if (logins.length === 0) {
+    return NextResponse.json({ error: 'At least one valid login is required' }, { status: 400 });
+  }
+  const cutoffDay = windowStartDay(period);
+
+  try {
+    const baselineDay = await getLatestImpactDayOnOrBefore(cutoffDay);
+    const snapshots = baselineDay
+      ? (await Promise.all(logins.map(login => getImpactSnapshotForDay(login, baselineDay)))).filter(Boolean)
+      : [];
+    return NextResponse.json({
+      period,
+      cutoffDay,
+      baselineDay,
+      hasHistory: snapshots.length > 0,
+      snapshots: snapshots.map(snapshot => ({
+        login: snapshot.login,
+        day: snapshot.day,
+        globalRank: snapshot.globalRank,
+      })),
+    }, {
+      headers: { 'Cache-Control': 'private, max-age=300' },
+    });
+  } catch (error) {
+    console.error('Leaderboard movement error:', error.message);
+    return NextResponse.json({ error: 'Unable to load rank movement' }, { status: 500 });
+  }
+}

--- a/components/LeaderboardPage.jsx
+++ b/components/LeaderboardPage.jsx
@@ -11,6 +11,10 @@ import {
   getLeaderboardFilters,
   normalizeGitHubLogin,
 } from '../lib/leaderboard.js';
+import {
+  buildRankMovement,
+  LEADERBOARD_PERIODS,
+} from '../lib/leaderboard-movement.js';
 import { SCORE_METHODOLOGY } from '../lib/scoring.js';
 
 const PAGE_SIZE = 500;
@@ -45,6 +49,9 @@ export default function LeaderboardPage() {
   const [pendingLookup, setPendingLookup] = useState('');
   const [locatedLogin, setLocatedLogin] = useState('');
   const [lookupStatus, setLookupStatus] = useState('');
+  const [period, setPeriod] = useState(30);
+  const [movementResult, setMovementResult] = useState(null);
+  const [movementStatus, setMovementStatus] = useState('loading');
 
   useEffect(() => {
     const controller = new AbortController();
@@ -111,6 +118,29 @@ export default function LeaderboardPage() {
   const visible = locatedIndex >= 0
     ? ranked.slice(Math.max(0, locatedIndex - 2), Math.min(ranked.length, locatedIndex + 3))
     : ranked.slice(0, displayLimit);
+  const movementLogins = visible.map(developer => developer.login.toLowerCase()).join(',');
+  const movement = useMemo(
+    () => buildRankMovement(developers, movementResult?.snapshots || []),
+    [developers, movementResult]
+  );
+
+  useEffect(() => {
+    if (!movementLogins) return undefined;
+    const controller = new AbortController();
+    setMovementStatus('loading');
+    const params = new URLSearchParams({ days: String(period), logins: movementLogins });
+    fetch(`/api/leaderboard/movement?${params}`, { signal: controller.signal })
+      .then(async response => {
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error || 'Unable to load rank movement');
+        setMovementResult(body);
+        setMovementStatus('ready');
+      })
+      .catch(error => {
+        if (error.name !== 'AbortError') setMovementStatus('error');
+      });
+    return () => controller.abort();
+  }, [movementLogins, period]);
 
   useEffect(() => setDisplayLimit(DISPLAY_STEP), [country, language, sortBy]);
 
@@ -212,6 +242,29 @@ export default function LeaderboardPage() {
           <p title={SCORE_METHODOLOGY.short}>Scores are relative to developers currently indexed by DevGlobe.</p>
         </div>
 
+        <div className="leaderboard-period">
+          <div className="leaderboard-period__tabs" role="group" aria-label="Rank comparison period">
+            {LEADERBOARD_PERIODS.map(days => (
+              <button
+                key={days}
+                type="button"
+                aria-pressed={period === days}
+                className={period === days ? 'active' : ''}
+                onClick={() => setPeriod(days)}
+              >
+                {days} days
+              </button>
+            ))}
+          </div>
+          <p>
+            {movementStatus === 'loading' && 'Loading rank movement...'}
+            {movementStatus === 'error' && 'Rank movement is temporarily unavailable.'}
+            {movementStatus === 'ready' && !movementResult?.hasHistory && 'No historical snapshot is available for this period yet.'}
+            {movementStatus === 'ready' && movementResult?.hasHistory && `Movement compares current rank with the latest snapshot on or before ${movementResult.baselineDay}.`}
+            {' '}The impact score formula does not change.
+          </p>
+        </div>
+
         <form className="leaderboard-find" onSubmit={handleLookup}>
           <div>
             <label htmlFor="leaderboard-login">Where do you rank?</label>
@@ -299,6 +352,7 @@ export default function LeaderboardPage() {
                   <th scope="col">Developer</th>
                   <th scope="col">Location</th>
                   <th scope="col">Impact</th>
+                  <th scope="col">Movement</th>
                   <th scope="col">Stars</th>
                   <th scope="col">Commits</th>
                   <th scope="col">OSS worth</th>
@@ -306,6 +360,19 @@ export default function LeaderboardPage() {
               </thead>
               <tbody>
                 {visible.map(developer => (
+                  (() => {
+                    const rankMovement = movement.get(developer.login.toLowerCase());
+                    const movementUnavailable = movementStatus !== 'ready' || !movementResult?.hasHistory;
+                    const movementLabel = movementUnavailable || rankMovement?.status === 'unavailable'
+                      ? 'Not available'
+                      : rankMovement?.status === 'new'
+                        ? 'New'
+                        : rankMovement?.status === 'unchanged'
+                          ? 'No change'
+                          : rankMovement?.status === 'up'
+                            ? `Up ${rankMovement.delta}`
+                            : `Down ${Math.abs(rankMovement?.delta || 0)}`;
+                    return (
                   <tr
                     key={developer.login}
                     id={`leaderboard-${developer.login.toLowerCase()}`}
@@ -331,10 +398,20 @@ export default function LeaderboardPage() {
                     <td className="leaderboard-board__score" data-label="Impact score">
                       <strong>{developer.score}</strong><span>/100</span>
                     </td>
+                    <td data-label={`${period}-day movement`}>
+                      <span className={`leaderboard-movement leaderboard-movement--${movementUnavailable ? 'unavailable' : rankMovement?.status || 'unavailable'}`}>
+                        <i aria-hidden="true">
+                          {!movementUnavailable && rankMovement?.status === 'up' ? '↑' : !movementUnavailable && rankMovement?.status === 'down' ? '↓' : '·'}
+                        </i>
+                        {movementLabel}
+                      </span>
+                    </td>
                     <td data-label="GitHub stars">{formatNum(developer.totalStars)}</td>
                     <td data-label="Commit activity">{formatNum(developer.totalCommits)}</td>
                     <td data-label="Estimated OSS worth">{formatUsd(developer.ossWorth?.totalDollarValue, true)}</td>
                   </tr>
+                    );
+                  })()
                 ))}
               </tbody>
             </table>

--- a/lib/impact-history-store.js
+++ b/lib/impact-history-store.js
@@ -45,6 +45,44 @@ export async function getLatestImpactDayBefore(day) {
   return days[0] || null;
 }
 
+export async function getLatestImpactDayOnOrBefore(day) {
+  const container = getHistoryContainer();
+  if (!container) {
+    return [...memorySnapshots.values()]
+      .filter(snapshot => snapshot.documentType === 'impact-snapshot')
+      .map(snapshot => snapshot.day)
+      .filter(snapshotDay => snapshotDay <= day)
+      .sort()
+      .at(-1) || null;
+  }
+
+  const { resources: days } = await container.items.query({
+    query: `SELECT TOP 1 VALUE c.day FROM c
+      WHERE c.documentType = 'impact-snapshot' AND c.day <= @day
+      ORDER BY c.day DESC`,
+    parameters: [{ name: '@day', value: day }],
+  }).fetchAll();
+  return days[0] || null;
+}
+
+export async function listImpactSnapshotsForDay(day) {
+  if (!day) return [];
+  const container = getHistoryContainer();
+  if (!container) {
+    return [...memorySnapshots.values()].filter(snapshot =>
+      snapshot.documentType === 'impact-snapshot' && snapshot.day === day
+    );
+  }
+
+  const { resources } = await container.items.query({
+    query: `SELECT c.login, c.day, c.capturedAt, c.score, c.globalRank
+      FROM c
+      WHERE c.documentType = 'impact-snapshot' AND c.day = @day`,
+    parameters: [{ name: '@day', value: day }],
+  }).fetchAll();
+  return resources;
+}
+
 export async function getImpactSnapshotForDay(login, day) {
   if (!day) return null;
   const normalizedLogin = String(login || '').toLowerCase();

--- a/lib/leaderboard-movement.js
+++ b/lib/leaderboard-movement.js
@@ -1,0 +1,36 @@
+export const LEADERBOARD_PERIODS = [7, 30, 90];
+export const LEADERBOARD_MOVEMENT_LIMIT = 100;
+
+export function normalizeLeaderboardPeriod(value) {
+  const period = Number.parseInt(value, 10);
+  return LEADERBOARD_PERIODS.includes(period) ? period : 30;
+}
+
+export function buildRankMovement(developers, baselines) {
+  const baselineByLogin = new Map(
+    baselines.map(snapshot => [snapshot.login.toLowerCase(), snapshot])
+  );
+
+  return new Map(developers.map(developer => {
+    const baseline = baselineByLogin.get(developer.login.toLowerCase());
+    if (!baseline) return [developer.login.toLowerCase(), { status: 'new', delta: null }];
+    if (!Number.isInteger(developer.globalRank) || !Number.isInteger(baseline.globalRank)) {
+      return [developer.login.toLowerCase(), { status: 'unavailable', delta: null }];
+    }
+    const delta = baseline.globalRank - developer.globalRank;
+    return [developer.login.toLowerCase(), {
+      status: delta > 0 ? 'up' : delta < 0 ? 'down' : 'unchanged',
+      delta,
+      previousRank: baseline.globalRank,
+      day: baseline.day,
+    }];
+  }));
+}
+
+export function normalizeLeaderboardLogins(value) {
+  return [...new Set(String(value || '')
+    .split(',')
+    .map(login => login.trim().toLowerCase())
+    .filter(login => /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/.test(login)))]
+    .slice(0, LEADERBOARD_MOVEMENT_LIMIT);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1771,6 +1771,51 @@ body {
   text-align: right;
 }
 
+.leaderboard-period {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 20px;
+}
+
+.leaderboard-period__tabs {
+  display: inline-flex;
+  border: 1px solid var(--board-ink);
+}
+
+.leaderboard-period__tabs button {
+  min-height: 44px;
+  padding: 0 16px;
+  border: 0;
+  border-right: 1px solid var(--board-ink);
+  background: transparent;
+  color: var(--board-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.leaderboard-period__tabs button:last-child {
+  border-right: 0;
+}
+
+.leaderboard-period__tabs button.active {
+  background: var(--board-ink);
+  color: var(--board-paper);
+}
+
+.leaderboard-period > p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--board-muted);
+  font-size: 11px;
+  line-height: 1.5;
+  text-align: right;
+}
+
 .leaderboard-board__controls {
   display: grid;
   grid-template-columns: repeat(3, minmax(150px, 220px)) 1fr;
@@ -1956,6 +2001,7 @@ body {
 .leaderboard-board__table th:nth-child(2) { width: 28%; }
 .leaderboard-board__table th:nth-child(3) { width: 22%; }
 .leaderboard-board__table th:nth-child(4) { width: 90px; }
+.leaderboard-board__table th:nth-child(5) { width: 110px; }
 
 .leaderboard-board__table td {
   height: 82px;
@@ -2047,6 +2093,37 @@ body {
   margin-left: 2px;
 }
 
+.leaderboard-movement {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 5px;
+  margin: 0 !important;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 11px !important;
+  font-weight: 750;
+}
+
+.leaderboard-movement i {
+  width: 16px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  font-style: normal;
+}
+
+.leaderboard-movement--up { color: #087549 !important; }
+.leaderboard-movement--up i { background: #087549; }
+.leaderboard-movement--down { color: #b53f2a !important; }
+.leaderboard-movement--down i { background: #b53f2a; }
+.leaderboard-movement--new { color: var(--board-cyan) !important; }
+.leaderboard-movement--new i { background: var(--board-cyan); }
+.leaderboard-movement--unchanged,
+.leaderboard-movement--unavailable { color: var(--board-muted) !important; }
+.leaderboard-movement--unchanged i,
+.leaderboard-movement--unavailable i { background: var(--board-muted); }
+
 .leaderboard-board__more {
   width: 100%;
   min-height: 52px;
@@ -2104,6 +2181,21 @@ body {
   }
 
   .leaderboard-board__heading > p {
+    text-align: left;
+  }
+
+  .leaderboard-period {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .leaderboard-period__tabs {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .leaderboard-period > p {
     text-align: left;
   }
 

--- a/tests/impact-history-store.test.js
+++ b/tests/impact-history-store.test.js
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   saveImpactSnapshot,
+  getLatestImpactDayOnOrBefore,
+  listImpactSnapshotsForDay,
   listLatestSnapshotsOnOrBeforeDay,
   __resetMemoryImpactHistoryForTests,
 } from '../lib/impact-history-store.js';
@@ -51,4 +53,20 @@ test('listLatestSnapshotsOnOrBeforeDay excludes capture-progress documents', asy
   const results = await listLatestSnapshotsOnOrBeforeDay('2026-07-24');
   assert.equal(results.length, 1);
   assert.equal(results[0].login, 'alice');
+});
+
+test('loads one bounded baseline day for leaderboard movement', async (t) => {
+  __resetMemoryImpactHistoryForTests();
+  t.after(__resetMemoryImpactHistoryForTests);
+
+  await saveImpactSnapshot(snapshot('alice', '2026-07-20', 60, 5));
+  await saveImpactSnapshot(snapshot('alice', '2026-07-24', 70, 3));
+  await saveImpactSnapshot(snapshot('bob', '2026-07-24', 40, 8));
+  await saveImpactSnapshot(snapshot('bob', '2026-07-26', 50, 7));
+
+  const day = await getLatestImpactDayOnOrBefore('2026-07-25');
+  const results = await listImpactSnapshotsForDay(day);
+
+  assert.equal(day, '2026-07-24');
+  assert.deepEqual(results.map(result => result.login).sort(), ['alice', 'bob']);
 });

--- a/tests/leaderboard-movement.test.js
+++ b/tests/leaderboard-movement.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildRankMovement,
+  normalizeLeaderboardLogins,
+  normalizeLeaderboardPeriod,
+} from '../lib/leaderboard-movement.js';
+
+test('accepts only supported leaderboard periods', () => {
+  assert.equal(normalizeLeaderboardPeriod('7'), 7);
+  assert.equal(normalizeLeaderboardPeriod('90'), 90);
+  assert.equal(normalizeLeaderboardPeriod('365'), 30);
+  assert.equal(normalizeLeaderboardPeriod('bad'), 30);
+});
+
+test('derives rank direction and preserves unavailable states', () => {
+  const developers = [
+    { login: 'alice', globalRank: 2 },
+    { login: 'bob', globalRank: 4 },
+    { login: 'carol', globalRank: 6 },
+    { login: 'new-dev', globalRank: 8 },
+  ];
+  const baselines = [
+    { login: 'alice', globalRank: 5, day: '2026-07-01' },
+    { login: 'bob', globalRank: 2, day: '2026-07-01' },
+    { login: 'carol', globalRank: 6, day: '2026-07-01' },
+  ];
+
+  const movement = buildRankMovement(developers, baselines);
+  assert.deepEqual(movement.get('alice'), { status: 'up', delta: 3, previousRank: 5, day: '2026-07-01' });
+  assert.equal(movement.get('bob').status, 'down');
+  assert.equal(movement.get('bob').delta, -2);
+  assert.equal(movement.get('carol').status, 'unchanged');
+  assert.deepEqual(movement.get('new-dev'), { status: 'new', delta: null });
+});
+
+test('normalizes, deduplicates, and bounds movement logins', () => {
+  const logins = Array.from({ length: 105 }, (_, index) => `dev-${index}`).join(',');
+  const result = normalizeLeaderboardLogins(`Alice,alice,invalid login,${logins}`);
+  assert.equal(result[0], 'alice');
+  assert.equal(result.length, 100);
+  assert.equal(result.includes('invalid login'), false);
+});


### PR DESCRIPTION
Summary of 7/30/90 comparison controls, accessible up/down/unchanged/new/unavailable states, one baseline day plus max-100 partition-key point reads, real snapshots only.

Closes #303

**Validation:**
- \
pm test\ 304 passed
- production build passed
- mobile browser verified.