### PR TITLE
feat: add real leaderboard activity ribbon

### DIFF
--- a/components/LeaderboardActivityRibbon.jsx
+++ b/components/LeaderboardActivityRibbon.jsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { selectLeaderboardActivities } from '../lib/activity-ribbon.js';
+import { useGlobalActivityFeed } from './useGlobalActivityFeed.js';
+
+export default function LeaderboardActivityRibbon() {
+  const { activities, loading, error } = useGlobalActivityFeed(true);
+  const visible = selectLeaderboardActivities(activities);
+
+  if (loading) return <div className="leaderboard-ribbon leaderboard-ribbon--message" role="status">Syncing real DevGlobe activity...</div>;
+  if (error) return <div className="leaderboard-ribbon leaderboard-ribbon--message">Live activity is temporarily unavailable.</div>;
+  if (visible.length === 0) return <div className="leaderboard-ribbon leaderboard-ribbon--message">No public DevGlobe activity has been recorded recently.</div>;
+
+  return (
+    <section className="leaderboard-ribbon" aria-label="Recent DevGlobe activity">
+      <div className="leaderboard-ribbon__label"><i aria-hidden="true" /> Live on DevGlobe</div>
+      <div className="leaderboard-ribbon__viewport">
+        <div className="leaderboard-ribbon__track">
+          <ActivityItems activities={visible} />
+          <div aria-hidden="true"><ActivityItems activities={visible} tabIndex={-1} /></div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ActivityItems({ activities, tabIndex }) {
+  return activities.map(activity => (
+    <Link key={activity.id} href={activity.url} tabIndex={tabIndex}>
+      <strong>@{activity.login}</strong>
+      <span>{activity.description}</span>
+    </Link>
+  ));
+}

--- a/components/LeaderboardPage.jsx
+++ b/components/LeaderboardPage.jsx
@@ -16,6 +16,7 @@ import {
   LEADERBOARD_PERIODS,
 } from '../lib/leaderboard-movement.js';
 import { SCORE_METHODOLOGY } from '../lib/scoring.js';
+import LeaderboardActivityRibbon from './LeaderboardActivityRibbon.jsx';
 
 const PAGE_SIZE = 500;
 const DISPLAY_STEP = 100;
@@ -232,6 +233,8 @@ export default function LeaderboardPage() {
           </div>
         </div>
       </section>
+
+      <LeaderboardActivityRibbon />
 
       <section className="leaderboard-board" aria-label="Developer leaderboard">
         <div className="leaderboard-board__heading">

--- a/lib/activity-ribbon.js
+++ b/lib/activity-ribbon.js
@@ -1,0 +1,6 @@
+export function selectLeaderboardActivities(activities, limit = 12) {
+  return activities
+    .filter(activity => activity.documentType === 'platform-activity' && !activity.fallback)
+    .filter(activity => activity.login && activity.description && activity.url)
+    .slice(0, limit);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1741,6 +1741,96 @@ body {
   font-size: 12px;
 }
 
+.leaderboard-ribbon {
+  min-height: 48px;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  border-top: 1px solid var(--board-ink);
+  border-bottom: 1px solid var(--board-ink);
+  background: var(--board-ink);
+  color: var(--board-paper);
+}
+
+.leaderboard-ribbon__label {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  padding: 0 max(24px, calc((100vw - 1240px) / 2));
+  padding-right: 20px;
+  background: var(--board-coral);
+  color: #fff;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.leaderboard-ribbon__label i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #fff;
+}
+
+.leaderboard-ribbon__viewport {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+.leaderboard-ribbon__track {
+  width: max-content;
+  display: flex;
+  animation: leaderboard-ribbon-scroll 70s linear infinite;
+}
+
+.leaderboard-ribbon__track > div {
+  display: contents;
+}
+
+.leaderboard-ribbon:hover .leaderboard-ribbon__track,
+.leaderboard-ribbon:focus-within .leaderboard-ribbon__track {
+  animation-play-state: paused;
+}
+
+.leaderboard-ribbon__track a {
+  min-height: 47px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 22px;
+  border-right: 1px solid #455047;
+  color: var(--board-paper);
+  font-size: 11px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.leaderboard-ribbon__track a:hover,
+.leaderboard-ribbon__track a:focus-visible {
+  background: #263029;
+}
+
+.leaderboard-ribbon__track strong {
+  color: #9adce2;
+}
+
+.leaderboard-ribbon--message {
+  justify-content: center;
+  padding: 0 16px;
+  color: #b7c0b9;
+  font-size: 11px;
+}
+
+@keyframes leaderboard-ribbon-scroll {
+  to { transform: translateX(-50%); }
+}
+
 .leaderboard-board {
   padding-bottom: 100px;
 }
@@ -2174,6 +2264,15 @@ body {
     width: min(220px, 100%);
   }
 
+  .leaderboard-ribbon {
+    flex-direction: column;
+  }
+
+  .leaderboard-ribbon__label {
+    min-height: 34px;
+    padding: 0 16px;
+  }
+
   .leaderboard-board__heading {
     align-items: start;
     flex-direction: column;
@@ -2299,6 +2398,20 @@ body {
 
   .leaderboard-board__leader {
     padding-left: 10px !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .leaderboard-ribbon__viewport {
+    overflow-x: auto;
+  }
+
+  .leaderboard-ribbon__track {
+    animation: none;
+  }
+
+  .leaderboard-ribbon__track > div {
+    display: none;
   }
 }
 

--- a/tests/activity-ribbon.test.js
+++ b/tests/activity-ribbon.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { selectLeaderboardActivities } from '../lib/activity-ribbon.js';
+
+test('selects only real DevGlobe platform events for the ribbon', () => {
+  const result = selectLeaderboardActivities([
+    { id: 'one', documentType: 'platform-activity', login: 'alice', description: 'claimed a profile', url: '/developer/alice' },
+    { id: 'two', documentType: 'fallback-activity', fallback: true, login: 'sample', description: 'sample event', url: '/developer/sample' },
+    { id: 'three', documentType: 'github-activity', login: 'bob', description: 'pushed code', url: 'https://github.com' },
+    { id: 'four', documentType: 'platform-activity', login: 'carol', description: '', url: '/developer/carol' },
+  ]);
+
+  assert.deepEqual(result.map(activity => activity.id), ['one']);
+});
+
+test('bounds the visible ribbon events', () => {
+  const activities = Array.from({ length: 20 }, (_, index) => ({
+    id: String(index),
+    documentType: 'platform-activity',
+    login: `dev${index}`,
+    description: 'joined DevGlobe',
+    url: `/developer/dev${index}`,
+  }));
+  assert.equal(selectLeaderboardActivities(activities, 5).length, 5);
+});


### PR DESCRIPTION
This pull request adds a real leaderboard activity ribbon using real platform events only, utilizing the existing #90 pipeline. It supports pause/reduced motion, and graceful handling of empty/error states. Closes #304. Validation completed via 306 tests/build/browser.