### PR TITLE
ux: replace loading bar with compact status

### DIFF
--- a/components/LoadingOverlay.jsx
+++ b/components/LoadingOverlay.jsx
@@ -27,57 +27,12 @@ export default function LoadingOverlay({ error, datasetCount, stage = 'connectin
   }
 
   return (
-    <div className="loading-overlay" role="status" aria-live="polite" aria-label="Loading DevGlobe">
-      <div className="loading-panel">
-        <div className="loading-scene" aria-hidden="true">
-          <div className="loading-scene__orbit"><span /></div>
-          <div className="loading-globe">
-            <svg viewBox="0 0 220 220" className="loading-globe__svg">
-              <defs>
-                <radialGradient id="loadingGlobeFill" cx="35%" cy="28%">
-                  <stop offset="0%" stopColor="currentColor" stopOpacity="0.28" />
-                  <stop offset="75%" stopColor="currentColor" stopOpacity="0.06" />
-                  <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
-                </radialGradient>
-                <clipPath id="loadingGlobeClip"><circle cx="110" cy="110" r="78" /></clipPath>
-              </defs>
-              <circle cx="110" cy="110" r="78" className="loading-globe__surface" />
-              <g clipPath="url(#loadingGlobeClip)" className="loading-globe__grid">
-                <ellipse cx="110" cy="110" rx="78" ry="29" />
-                <ellipse cx="110" cy="110" rx="78" ry="55" />
-                <ellipse cx="110" cy="110" rx="31" ry="78" />
-                <ellipse cx="110" cy="110" rx="58" ry="78" />
-                <path d="M32 110h156M110 32v156" />
-              </g>
-              <g className="loading-globe__routes" clipPath="url(#loadingGlobeClip)">
-                <path d="M58 126 Q103 55 158 94" />
-                <path d="M75 74 Q126 143 168 126" />
-                <path d="M48 105 Q104 128 145 65" />
-              </g>
-              <g className="loading-globe__nodes">
-                <circle cx="58" cy="126" r="4" />
-                <circle cx="158" cy="94" r="4" />
-                <circle cx="75" cy="74" r="3" />
-                <circle cx="168" cy="126" r="3" />
-                <circle cx="145" cy="65" r="3" />
-              </g>
-              <circle cx="110" cy="110" r="78" className="loading-globe__outline" />
-            </svg>
-          </div>
-        </div>
-        <div className="loading-brand">
-          <img src="/devglobe.png" alt="" className="loading-brand__logo" />
-          <span>DevGlobe</span>
-        </div>
-        <h2 className="loading-title">Loading developer map</h2>
-        <p className="loading-status">
-          {STAGE_COPY[stage] || STAGE_COPY.connecting}
-          {datasetCount !== null ? ` · ${datasetCount.toLocaleString()} profiles` : ''}
-        </p>
-        <div className="loading-progress" aria-hidden="true">
-          <div className="loading-progress__bar" />
-        </div>
-      </div>
+    <div className="loading-indicator" role="status" aria-live="polite" aria-label="Loading DevGlobe">
+      <span className="loading-indicator__spinner" aria-hidden="true" />
+      <span>
+        {STAGE_COPY[stage] || STAGE_COPY.connecting}
+        {datasetCount !== null ? ` · ${datasetCount.toLocaleString()} profiles` : ''}
+      </span>
     </div>
   );
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -5519,27 +5519,40 @@ body {
   100% { opacity: 0; transform: translateY(-8px); }
 }
 
-/* Progress bar */
-.loading-progress {
-  width: 100%;
-  height: 3px;
-  background: var(--border);
-  border-radius: 3px;
-  overflow: hidden;
-  margin: 16px 0 0;
+.loading-indicator {
+  position: fixed;
+  top: 108px;
+  left: 50%;
+  z-index: 94;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  max-width: calc(100vw - 32px);
+  min-height: 36px;
+  padding: 8px 13px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel-92);
+  box-shadow: var(--shadow);
+  color: var(--text-secondary);
+  font-size: 12px;
+  pointer-events: none;
+  transform: translateX(-50%);
+  backdrop-filter: blur(12px);
 }
 
-.loading-progress__bar {
-  height: 100%;
-  width: 40%;
-  background: linear-gradient(90deg, var(--accent-blue), var(--accent-purple));
-  border-radius: 3px;
-  animation: progressSlide 1.5s ease-in-out infinite;
+.loading-indicator__spinner {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  border: 2px solid color-mix(in srgb, var(--accent-blue) 28%, transparent);
+  border-top-color: var(--accent-blue);
+  border-radius: 50%;
+  animation: loadingIndicatorSpin 0.8s linear infinite;
 }
 
-@keyframes progressSlide {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(350%); }
+@keyframes loadingIndicatorSpin {
+  to { transform: rotate(360deg); }
 }
 
 .loading-status {
@@ -5996,7 +6009,7 @@ body {
   .loading-globe__routes,
   .loading-globe__nodes circle,
   .loading-fact,
-  .loading-progress__bar {
+  .loading-indicator__spinner {
     animation: none;
   }
 }


### PR DESCRIPTION
This PR replaces the blocking loading artwork/bar with a compact non-interactive status indicator. Full-screen error/retry state is preserved, and a progressive sidebar count handoff is maintained.
Validation:
- 4 focused tests passed
- Production build generated 65 routes
- Mobile browser check confirmed no overlay/bar/overflow and enabled search