### PR TITLE
Surface developer search results

### DIFF
--- a/components/LeaderboardPage.jsx
+++ b/components/LeaderboardPage.jsx
@@ -249,31 +249,11 @@ export default function LeaderboardPage() {
         </nav>
       </header>
 
-      <section className="leaderboard-page__hero" aria-labelledby="leaderboard-title">
-        <p className="leaderboard-page__eyebrow">OPEN-SOURCE IMPACT / GLOBAL BOARD</p>
-        <div className="leaderboard-page__hero-grid">
-          <div>
-            <h1 id="leaderboard-title">See who is shaping the open web.</h1>
-            <p className="leaderboard-page__intro">
-              Explore developers by a transparent, dataset-relative signal combining public GitHub
-              and Stack Overflow activity. It measures indexed impact, not developer ability.
-            </p>
-          </div>
-          <div className="leaderboard-page__count" aria-live="polite">
-            <strong>{formatNum(totalCount ?? developers.length)}</strong>
-            <span>developers ranked</span>
-            {loadingMore && <small>Loading {formatNum(developers.length)} indexed profiles...</small>}
-          </div>
-        </div>
-      </section>
-
-      <LeaderboardActivityRibbon />
-
-      <section className="leaderboard-board" aria-label="Developer leaderboard">
+      <section className="leaderboard-board" aria-labelledby="leaderboard-title">
         <div className="leaderboard-board__heading">
           <div>
             <p className="leaderboard-page__eyebrow">THE RANKINGS</p>
-            <h2>Global impact</h2>
+            <h1 id="leaderboard-title">Global impact</h1>
           </div>
           <p title={SCORE_METHODOLOGY.short}>
             Scores are relative to developers currently indexed by DevGlobe.{' '}
@@ -466,6 +446,26 @@ export default function LeaderboardPage() {
           </>
         )}
       </section>
+
+      <section className="leaderboard-page__hero" aria-labelledby="leaderboard-context-title">
+        <p className="leaderboard-page__eyebrow">OPEN-SOURCE IMPACT / GLOBAL BOARD</p>
+        <div className="leaderboard-page__hero-grid">
+          <div>
+            <h2 id="leaderboard-context-title">See who is shaping the open web.</h2>
+            <p className="leaderboard-page__intro">
+              Explore developers by a transparent, dataset-relative signal combining public GitHub
+              and Stack Overflow activity. It measures indexed impact, not developer ability.
+            </p>
+          </div>
+          <div className="leaderboard-page__count" aria-live="polite">
+            <strong>{formatNum(totalCount ?? developers.length)}</strong>
+            <span>developers ranked</span>
+            {loadingMore && <small>Loading {formatNum(developers.length)} indexed profiles...</small>}
+          </div>
+        </div>
+      </section>
+
+      <LeaderboardActivityRibbon />
       <LeaderboardTrust />
     </main>
   );

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useCallback } from 'react';
 import SpecialTags from './SpecialTags.jsx';
-import { trackSearchAppearances } from '../lib/analytics.js';
+import { track, trackSearchAppearances } from '../lib/analytics.js';
 import { countryKey } from '../lib/country.js';
 import { publicApiUrl } from '../lib/public-api.js';
 import MissionPreview from './MissionPreview.jsx';
@@ -34,6 +34,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
   const [topN, setTopN] = useState(20);
   const [searching, setSearching] = useState(false);
   const [resultCount, setResultCount] = useState(null);
+  const [visibleResults, setVisibleResults] = useState([]);
   const [singleResult, setSingleResult] = useState(null);
   const [searchError, setSearchError] = useState('');
   const inputRef = useRef(null);
@@ -44,6 +45,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
     if (!q.trim()) {
       onReset();
       setResultCount(null);
+      setVisibleResults([]);
       setSingleResult(null);
       setSearchError('');
       return;
@@ -83,6 +85,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
 
       onResults(results);
       setResultCount(results.length);
+      setVisibleResults(results.slice(0, 3));
       setSingleResult(results.length === 1 ? results[0] : null);
       trackSearchAppearances(results.map(result => result.login), m);
       onSearchState?.({ query: q.trim(), results });
@@ -105,6 +108,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
         const results = data.results || [];
         onResults(results);
         setResultCount(results.length);
+        setVisibleResults(results.slice(0, 3));
         const matchedDeveloper = results.length === 1
           ? developers.find(developer => developer.login === results[0].login) || results[0]
           : null;
@@ -167,10 +171,20 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
   const handleClear = () => {
     setQuery('');
     setResultCount(null);
+    setVisibleResults([]);
     setSingleResult(null);
     setSearchError('');
     onReset();
     inputRef.current?.focus();
+  };
+
+  const handleSelectResult = (developer) => {
+    track('next_action_selected', {
+      action: 'open_search_result',
+      journey: 'developer_discovery',
+      source: mode,
+    });
+    onSelectDeveloper(developer);
   };
 
   return (
@@ -268,42 +282,49 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
               ✕ Clear
             </button>
           </div>
-          {singleResult && (
-            <div className="search-bar__card-suggestion">
-              <button
-                type="button"
-                className="search-bar__profile-result"
-                onClick={() => onSelectDeveloper(singleResult)}
-                aria-label={`Open ${singleResult.name || singleResult.login}'s profile`}
-              >
-                <img src={singleResult.avatarUrl} alt="" />
-                <span className="search-bar__card-identity">
-                  <strong>
-                    {singleResult.name || singleResult.login}
-                    <SpecialTags tags={singleResult.specialTags} compact />
-                  </strong>
-                  <span>
-                    @{singleResult.login}
-                    {singleResult.globalRank ? ` · Global #${singleResult.globalRank}` : ''}
+          {visibleResults.length > 0 && (
+            <div className="search-bar__suggestions" role="list" aria-label="Top developer matches">
+              {visibleResults.map((developer, index) => (
+                <div className="search-bar__card-suggestion" role="listitem" key={developer.login}>
+                  <button
+                    type="button"
+                    className="search-bar__profile-result"
+                    onClick={() => handleSelectResult(developer)}
+                    aria-label={`View ${developer.name || developer.login}'s profile`}
+                  >
+                    <img src={developer.avatarUrl} alt="" />
+                    <span className="search-bar__card-identity">
+                      <strong>
+                        {developer.name || developer.login}
+                        <SpecialTags tags={developer.specialTags} compact />
+                      </strong>
+                      <span>
+                        @{developer.login}
+                        {developer.globalRank ? ` · Global #${developer.globalRank}` : ''}
+                      </span>
+                    </span>
+                    <span className="search-bar__view-profile">View profile</span>
+                  </button>
+                  <span className="search-bar__card-actions">
+                    {index === 0 && singleResult && (
+                      <button type="button" className="search-bar__card-action search-bar__card-action--readme" onClick={() => onOpenReadmeFeature(developer)}>
+                        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                          <path d="M4 3h11l5 5v13H4z" /><path d="M14 3v6h6M8 13h8M8 17h6" />
+                        </svg>
+                        README
+                      </button>
+                    )}
+                    <button type="button" className="search-bar__card-action" onClick={() => onGenerateCard(developer)} aria-label={`Generate a card for ${developer.name || developer.login}`}>
+                      <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                        <rect x="3" y="3" width="18" height="18" rx="2" />
+                        <circle cx="8.5" cy="8.5" r="1.5" />
+                        <path d="M21 15l-5-5L5 21" />
+                      </svg>
+                      Card
+                    </button>
                   </span>
-                </span>
-              </button>
-              <span className="search-bar__card-actions">
-                <button type="button" className="search-bar__card-action search-bar__card-action--readme" onClick={() => onOpenReadmeFeature(singleResult)}>
-                  <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                    <path d="M4 3h11l5 5v13H4z" /><path d="M14 3v6h6M8 13h8M8 17h6" />
-                  </svg>
-                  Preview README
-                </button>
-                <button type="button" className="search-bar__card-action" onClick={() => onGenerateCard(singleResult)}>
-                  <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                    <rect x="3" y="3" width="18" height="18" rx="2" />
-                    <circle cx="8.5" cy="8.5" r="1.5" />
-                    <path d="M21 15l-5-5L5 21" />
-                  </svg>
-                  Generate Card
-                </button>
-              </span>
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -8621,6 +8621,18 @@ body {
   .share-page__actions button {
     text-align: center;
   }
+
+  .search-bar__profile-result,
+  .search-bar__card-action {
+    min-height: 44px;
+  }
+}
+
+.search-bar__suggestions {
+  max-height: min(240px, 38vh);
+  margin-top: 8px;
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
 }
 
 .search-bar__card-suggestion {
@@ -8628,14 +8640,16 @@ body {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
-  margin-top: 8px;
   padding: 9px;
+}
+
+.search-bar__card-suggestion + .search-bar__card-suggestion {
   border-top: 1px solid var(--border);
 }
 
 .search-bar__profile-result {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr);
+  grid-template-columns: 36px minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
   min-width: 0;
@@ -8650,6 +8664,13 @@ body {
 
 .search-bar__profile-result:hover .search-bar__card-identity strong {
   color: #22d3ee;
+}
+
+.search-bar__view-profile {
+  color: #22d3ee;
+  font-size: 10px;
+  font-weight: 800;
+  white-space: nowrap;
 }
 
 .search-bar__profile-result:focus-visible {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1745,7 +1745,7 @@ body {
   gap: clamp(32px, 7vw, 96px);
 }
 
-.leaderboard-page__hero h1 {
+.leaderboard-page__hero h2 {
   max-width: 760px;
   margin: 0;
   font-family: var(--font);
@@ -1892,7 +1892,7 @@ body {
   border-top: 0;
 }
 
-.leaderboard-board__heading h2 {
+.leaderboard-board__heading h1 {
   margin: 0;
   font-family: var(--font);
   font-size: clamp(28px, 4vw, 40px);
@@ -2497,20 +2497,37 @@ body {
   }
 
   .leaderboard-page__hero {
-    padding-top: 54px;
-    padding-bottom: 52px;
+    padding-top: 36px;
+    padding-bottom: 36px;
+  }
+
+  .leaderboard-board {
+    margin-top: 16px;
   }
 
   .leaderboard-page__hero-grid {
     grid-template-columns: 1fr;
+    gap: 28px;
   }
 
-  .leaderboard-page__hero h1 {
-    font-size: clamp(42px, 13vw, 64px);
+  .leaderboard-page__hero h2 {
+    font-size: clamp(32px, 9vw, 40px);
+    line-height: 1.08;
+  }
+
+  .leaderboard-page__intro {
+    margin-top: 18px;
+    font-size: 14px;
+    line-height: 1.6;
   }
 
   .leaderboard-page__count {
-    width: min(220px, 100%);
+    width: 100%;
+    padding-top: 14px;
+  }
+
+  .leaderboard-page__count strong {
+    font-size: 30px;
   }
 
   .leaderboard-ribbon {
@@ -2526,10 +2543,15 @@ body {
     align-items: start;
     flex-direction: column;
     gap: 12px;
+    padding-top: 24px;
+  }
+
+  .leaderboard-board__heading h1 {
+    font-size: 24px;
   }
 
   .leaderboard-board__heading > p {
-    text-align: left;
+    display: none;
   }
 
   .leaderboard-period {
@@ -2544,15 +2566,29 @@ body {
   }
 
   .leaderboard-period > p {
-    text-align: left;
+    display: none;
   }
 
   .leaderboard-board__controls {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-bottom: 16px;
   }
 
   .leaderboard-find {
     grid-template-columns: 1fr 1fr;
+    padding: 14px;
+  }
+
+  .leaderboard-find label {
+    font-size: 16px;
+  }
+
+  .leaderboard-find > div:first-child span {
+    display: none;
+  }
+
+  .leaderboard-board__score strong {
+    font-size: 20px;
   }
 
   .leaderboard-find > div:first-child,
@@ -2598,9 +2634,9 @@ body {
 
   .leaderboard-board__table tr {
     display: grid;
-    grid-template-columns: 44px minmax(0, 1fr) auto;
-    gap: 12px;
-    padding: 18px 0;
+    grid-template-columns: 40px minmax(0, 1fr) minmax(88px, 0.65fr);
+    gap: 10px 12px;
+    padding: 16px 0;
     border-bottom: 1px solid var(--board-line);
   }
 
@@ -2611,7 +2647,15 @@ body {
   }
 
   .leaderboard-board__rank {
-    grid-row: 1 / 3;
+    width: 36px;
+    height: 36px;
+    display: grid !important;
+    grid-row: 1;
+    place-items: center;
+    border: 1px solid var(--board-line) !important;
+    border-radius: 50%;
+    background: var(--bg-card);
+    font-size: 14px !important;
   }
 
   .leaderboard-board__developer {
@@ -2619,7 +2663,8 @@ body {
   }
 
   .leaderboard-board__table td:nth-child(3) {
-    grid-column: 2;
+    grid-column: 2 / -1;
+    padding-bottom: 2px;
   }
 
   .leaderboard-board__table td:nth-child(4) {
@@ -2629,12 +2674,15 @@ body {
   }
 
   .leaderboard-board__table td:nth-child(n + 5) {
-    display: inline-flex;
-    grid-column: 2 / -1;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 28px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 5px;
+    min-height: 48px;
+    padding-top: 8px;
     border-top: 1px dotted var(--board-line);
+    font-variant-numeric: tabular-nums;
   }
 
   .leaderboard-board__table td:nth-child(n + 5)::before {
@@ -2645,8 +2693,31 @@ body {
     text-transform: uppercase;
   }
 
+  .leaderboard-board__table td:nth-child(5),
+  .leaderboard-board__table td:nth-child(7) {
+    grid-column: 2;
+  }
+
+  .leaderboard-board__table td:nth-child(6),
+  .leaderboard-board__table td:nth-child(8) {
+    grid-column: 3;
+  }
+
+  .leaderboard-board__table td:nth-child(5),
+  .leaderboard-board__table td:nth-child(6) {
+    grid-row: 3;
+  }
+
+  .leaderboard-board__table td:nth-child(7),
+  .leaderboard-board__table td:nth-child(8) {
+    grid-row: 4;
+  }
+
   .leaderboard-board__leader {
-    padding-left: 10px !important;
+    margin: 0 -8px;
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+    border-radius: 6px;
   }
 
   .leaderboard-trust {


### PR DESCRIPTION
## Summary
- show the top three developer matches directly below search
- add explicit profile and identity-card actions
- track search-result profile selections as discovery actions
- preserve compact responsive layout with 44px mobile touch targets

## Validation
- npm test (306 passed)
- npm run build
- desktop and 390px browser checks
