### PR TITLE
Improve MCP agent adoption and observability

### DIFF
--- a/.agents/skills/devglobe/SKILL.md
+++ b/.agents/skills/devglobe/SKILL.md
@@ -44,3 +44,27 @@ Machine-readable server card: https://www.devglobe.dev/.well-known/mcp/server-ca
 For reusable examples, see https://sajeetharan.github.io/devglobe/agents/workflows.
 
 Private email addresses and private AI profile settings are never returned.
+
+## Ready-to-run examples
+
+Find maintainers for a project:
+
+```json
+{"tool":"search_developers","arguments":{"query":"TypeScript open-source maintainers","location":"Germany","opportunityType":"open-source","availableForAgents":true,"limit":5}}
+```
+
+Inspect a selected result, then find alternatives:
+
+```json
+{"tool":"get_developer_profile","arguments":{"login":"sajeetharan"}}
+{"tool":"find_similar_developers","arguments":{"login":"sajeetharan","limit":5}}
+```
+
+Find recent momentum or one contribution opportunity:
+
+```json
+{"tool":"get_trending_developers","arguments":{"days":30,"limit":10}}
+{"tool":"preview_contribution_mission","arguments":{"login":"sajeetharan"}}
+```
+
+Do not invent tool names or arguments. On `invalid_request`, change the input before retrying. Retry only errors whose envelope has `retryable: true`, honoring `retryAfterSeconds` when present.

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,40 @@
+name: Publish MCP Registry metadata
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server.json'
+      - '.github/workflows/publish-mcp-registry.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate MCP contracts
+        run: node --test tests/remote-mcp.test.js tests/mcp-agent.test.js tests/mcp-retry-contract.test.js tests/agent-readiness.test.js
+
+      - name: Install MCP publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish remote server metadata
+        run: ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ app/promo/
 public/promo/
 *.log
 dist/
-dashboards/
+dashboards/*
+!dashboards/devglobe-product-adoption-dashboard.json
+!dashboards/devglobe-product-adoption-workbook.json
 docs/adx-growth-dashboard.md
 scripts/build-devglobe-growth-dashboard.cjs
 .env*.local

--- a/app/.well-known/mcp/server-card.json/route.js
+++ b/app/.well-known/mcp/server-card.json/route.js
@@ -3,7 +3,7 @@ import { getSiteUrl } from '../../../../lib/site.js';
 export function GET() {
   const siteUrl = getSiteUrl();
   return Response.json({
-    serverInfo: { name: 'devglobe', version: '1.1.0' },
+    serverInfo: { name: 'devglobe', version: '1.2.0' },
     description: 'Search public developer profiles and request consent-gated introductions.',
     homepage: `${siteUrl}/agents`,
     transport: {

--- a/dashboards/devglobe-product-adoption-dashboard.json
+++ b/dashboards/devglobe-product-adoption-dashboard.json
@@ -1,0 +1,955 @@
+{
+  "$schema": "https://dataexplorer.azure.com/static/d/schema/75/dashboard.json",
+  "id": "80fefe87-c06a-452a-b2fb-2bc274df46dc",
+  "eTag": "8d11eb60-64ff-44e0-aa80-b6c647b28c19",
+  "title": "DevGlobe Product Adoption",
+  "schema_version": 75,
+  "tiles": [
+    {
+      "id": "1f02964a-301f-4ead-9ac0-111ec7df615d",
+      "title": "Product Adoption Overview",
+      "visualType": "markdownCard",
+      "pageId": "681c892f-d0ac-44ee-9fca-4800ab9c4550",
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 18,
+        "height": 2
+      },
+      "markdownText": "## Product adoption\nA product-owner view of reach, meaningful use, and repeat adoption. All metrics use privacy-safe browser session hashes and intentional product events.",
+      "visualOptions": {}
+    },
+    {
+      "id": "4a2f6e37-2edf-4da0-b588-14dda7b32386",
+      "title": "Last 30 Days",
+      "visualType": "multistat",
+      "pageId": "681c892f-d0ac-44ee-9fca-4800ab9c4550",
+      "layout": {
+        "x": 0,
+        "y": 2,
+        "width": 18,
+        "height": 4
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "c3828a64-f31f-49af-b5ed-b864cd0dd2bd"
+      },
+      "visualOptions": {
+        "multiStat__textSize": "auto",
+        "multiStat__valueColumn": null,
+        "colorRulesDisabled": false,
+        "multiStat__displayOrientation": "horizontal",
+        "multiStat__labelColumn": null,
+        "multiStat__slot": {
+          "width": 18,
+          "height": 4
+        },
+        "colorRules": []
+      }
+    },
+    {
+      "id": "494431b0-b75e-49a2-ac9f-889c54b3937c",
+      "title": "Daily Active and Engaged Sessions",
+      "visualType": "line",
+      "pageId": "681c892f-d0ac-44ee-9fca-4800ab9c4550",
+      "layout": {
+        "x": 0,
+        "y": 6,
+        "width": 12,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "781206d1-eeea-479c-9dce-9b6ee6785e11"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": false,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Day",
+        "yColumns": [
+          "ActiveSessions",
+          "EngagedSessions"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "00505c1e-d4f3-4c07-9d6d-da982f7cad9e",
+      "title": "Adoption Health",
+      "visualType": "multistat",
+      "pageId": "681c892f-d0ac-44ee-9fca-4800ab9c4550",
+      "layout": {
+        "x": 12,
+        "y": 6,
+        "width": 6,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "d8804887-97f4-481c-ac01-2c976056de3a"
+      },
+      "visualOptions": {
+        "multiStat__textSize": "auto",
+        "multiStat__valueColumn": null,
+        "colorRulesDisabled": false,
+        "multiStat__displayOrientation": "horizontal",
+        "multiStat__labelColumn": null,
+        "multiStat__slot": {
+          "width": 6,
+          "height": 6
+        },
+        "colorRules": []
+      }
+    },
+    {
+      "id": "44005080-1ce4-49b8-996a-f166cd3fbe6f",
+      "title": "Completed Weekly Adoption",
+      "visualType": "column",
+      "pageId": "681c892f-d0ac-44ee-9fca-4800ab9c4550",
+      "layout": {
+        "x": 0,
+        "y": 12,
+        "width": 12,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "c104926e-7389-407e-9712-8ba235013ddc"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": false,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Week",
+        "yColumns": [
+          "ActiveSessions",
+          "ValueSessions"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "0f89bc58-908a-43c7-927c-7d48b6a078c4",
+      "title": "Value Actions",
+      "visualType": "table",
+      "pageId": "681c892f-d0ac-44ee-9fca-4800ab9c4550",
+      "layout": {
+        "x": 12,
+        "y": 12,
+        "width": 6,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "77cdd4bb-6029-4fb3-a3f8-9b7b4f47e6fc"
+      },
+      "visualOptions": {
+        "table__enableRenderLinks": false,
+        "colorRulesDisabled": true,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "crossFilter": [],
+        "drillthrough": [],
+        "table__renderLinks": [],
+        "colorRules": []
+      }
+    },
+    {
+      "id": "cafd752d-62e4-4e8d-b8c2-56c30103cdac",
+      "title": "Usage and Acquisition",
+      "visualType": "markdownCard",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 18,
+        "height": 2
+      },
+      "markdownText": "## Usage and acquisition\nUnderstand which experiences users adopt and which attributed sources, journeys, and channels produce meaningful sessions.",
+      "visualOptions": {}
+    },
+    {
+      "id": "78b34ef1-cf47-49b4-9c6c-5aabe9a437ad",
+      "title": "Usage KPIs - Last 30 Days",
+      "visualType": "multistat",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 0,
+        "y": 2,
+        "width": 18,
+        "height": 4
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "50351041-70e4-4eb7-a69f-ef0186c39436"
+      },
+      "visualOptions": {
+        "multiStat__textSize": "auto",
+        "multiStat__valueColumn": null,
+        "colorRulesDisabled": false,
+        "multiStat__displayOrientation": "horizontal",
+        "multiStat__labelColumn": null,
+        "multiStat__slot": {
+          "width": 18,
+          "height": 4
+        },
+        "colorRules": []
+      }
+    },
+    {
+      "id": "204bcd8b-1f81-488d-9a63-75a0ab6fe54b",
+      "title": "Daily Usage by Product Area",
+      "visualType": "column",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 0,
+        "y": 6,
+        "width": 12,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "42da2618-10fb-42dd-8aec-4da6c38099f3"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": false,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Day",
+        "yColumns": [
+          "Actions"
+        ],
+        "seriesColumns": [
+          "EventGroup"
+        ],
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "9c17acb8-33a2-4e24-8618-4e1a321baf50",
+      "title": "Acquisition Sources",
+      "visualType": "pie",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 12,
+        "y": 6,
+        "width": 6,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "1f5b9b0f-1654-4152-90b7-bdb1a3a5b5bb"
+      },
+      "visualOptions": {
+        "hideLegend": false,
+        "legendLocation": "bottom",
+        "xColumn": null,
+        "yColumns": null,
+        "seriesColumns": null,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "labelDisabled": false,
+        "pie__label": [
+          "name",
+          "percentage"
+        ],
+        "tooltipDisabled": false,
+        "pie__tooltip": [
+          "name",
+          "percentage",
+          "value"
+        ],
+        "pie__orderBy": "size",
+        "pie__kind": "donut",
+        "pie__topNSlices": null,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "35ffbe6d-c159-4cd4-a88d-443ddfe402f3",
+      "title": "Feature Adoption",
+      "visualType": "bar",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 0,
+        "y": 12,
+        "width": 12,
+        "height": 7
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "666638ec-ecc3-4117-a6c1-66a7d33bb9c9"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": true,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Feature",
+        "yColumns": [
+          "Sessions"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "60508728-6973-4921-b27f-9a404ce827c8",
+      "title": "Journey Performance",
+      "visualType": "table",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 12,
+        "y": 12,
+        "width": 6,
+        "height": 7
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "1aab62eb-db45-4949-b84e-ca6e2c95b152"
+      },
+      "visualOptions": {
+        "table__enableRenderLinks": false,
+        "colorRulesDisabled": true,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "crossFilter": [],
+        "drillthrough": [],
+        "table__renderLinks": [],
+        "colorRules": []
+      }
+    },
+    {
+      "id": "6996d41e-a1b7-47ce-9e5b-5a8bc90904d3",
+      "title": "Sharing Channels",
+      "visualType": "table",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 0,
+        "y": 19,
+        "width": 9,
+        "height": 5
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "70e862c3-22da-490e-a5c4-5e75ff0a9123"
+      },
+      "visualOptions": {
+        "table__enableRenderLinks": false,
+        "colorRulesDisabled": true,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "crossFilter": [],
+        "drillthrough": [],
+        "table__renderLinks": [],
+        "colorRules": []
+      }
+    },
+    {
+      "id": "f44e23f1-3a68-4ec9-a7b7-794f5bbd6511",
+      "title": "Most Viewed Profiles",
+      "visualType": "table",
+      "pageId": "ffa5c4f3-2760-4230-8a43-1842b3885f95",
+      "layout": {
+        "x": 9,
+        "y": 19,
+        "width": 9,
+        "height": 5
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "20866c12-9951-4da0-891b-8805385be1b7"
+      },
+      "visualOptions": {
+        "table__enableRenderLinks": false,
+        "colorRulesDisabled": true,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "crossFilter": [],
+        "drillthrough": [],
+        "table__renderLinks": [],
+        "colorRules": []
+      }
+    },
+    {
+      "id": "ba763cd7-5c9b-45c7-a646-079e1f75f7af",
+      "title": "Funnels and Retention",
+      "visualType": "markdownCard",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 18,
+        "height": 2
+      },
+      "markdownText": "## Funnels and retention\nConversion steps are ordered within the same privacy-safe session. Returning browsers are session hashes first seen before the reporting day; they are directional, not authenticated-user retention.",
+      "visualOptions": {}
+    },
+    {
+      "id": "2f7fde2c-5138-48f4-b661-5699f85d68d6",
+      "title": "Discovery Conversion - Last 30 Days",
+      "visualType": "multistat",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 0,
+        "y": 2,
+        "width": 18,
+        "height": 4
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "885f12be-031a-4c6c-970b-2e1773ec7847"
+      },
+      "visualOptions": {
+        "multiStat__textSize": "auto",
+        "multiStat__valueColumn": null,
+        "colorRulesDisabled": false,
+        "multiStat__displayOrientation": "horizontal",
+        "multiStat__labelColumn": null,
+        "multiStat__slot": {
+          "width": 18,
+          "height": 4
+        },
+        "colorRules": []
+      }
+    },
+    {
+      "id": "9d0e2aad-5e91-45bf-9e42-6e7f2a9b4c68",
+      "title": "Discovery to Sharing Funnel",
+      "visualType": "bar",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 0,
+        "y": 6,
+        "width": 9,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "b3383a24-4e32-42f9-8897-3b5d1a85dcbc"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": true,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Step",
+        "yColumns": [
+          "Sessions"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "937d0930-414f-4499-b6e1-d3f42f40a67c",
+      "title": "Exploration Funnel",
+      "visualType": "bar",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 9,
+        "y": 6,
+        "width": 9,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "37aa074e-ea6e-4b81-ae31-44088df50909"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": true,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Step",
+        "yColumns": [
+          "Sessions"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "523e02e7-d8d2-4f12-bb04-141d8fcb7393",
+      "title": "Daily Mission Funnel",
+      "visualType": "bar",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 0,
+        "y": 12,
+        "width": 9,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "8eb6e0ec-da6b-4194-b976-81db8bfce92f"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": true,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Step",
+        "yColumns": [
+          "Sessions"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "71ce4845-149d-4412-8bc5-555955628071",
+      "title": "New vs Returning Browsers",
+      "visualType": "line",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 9,
+        "y": 12,
+        "width": 9,
+        "height": 6
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "2f47d8ba-c374-4066-a880-f51560c2a46f"
+      },
+      "visualOptions": {
+        "multipleYAxes": {
+          "base": {
+            "id": "-1",
+            "label": "",
+            "columns": [],
+            "yAxisMaximumValue": null,
+            "yAxisMinimumValue": null,
+            "yAxisScale": "linear",
+            "horizontalLines": []
+          },
+          "additional": [],
+          "showMultiplePanels": false
+        },
+        "hideLegend": false,
+        "legendLocation": "right",
+        "xColumnTitle": "",
+        "xColumn": "Day",
+        "yColumns": [
+          "NewBrowsers",
+          "ReturningBrowsers"
+        ],
+        "seriesColumns": null,
+        "xAxisScale": "linear",
+        "verticalLine": "",
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "forceAxisTicks": false,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "c65da334-81a7-4ee8-869b-5f623c6e2e66",
+      "title": "Session Engagement Depth",
+      "visualType": "pie",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 0,
+        "y": 18,
+        "width": 6,
+        "height": 5
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "33b1ae43-22ca-4554-9d55-b5480cf4f85b"
+      },
+      "visualOptions": {
+        "hideLegend": false,
+        "legendLocation": "bottom",
+        "xColumn": null,
+        "yColumns": null,
+        "seriesColumns": null,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "labelDisabled": false,
+        "pie__label": [
+          "name",
+          "percentage"
+        ],
+        "tooltipDisabled": false,
+        "pie__tooltip": [
+          "name",
+          "percentage",
+          "value"
+        ],
+        "pie__orderBy": "size",
+        "pie__kind": "donut",
+        "pie__topNSlices": null,
+        "seriesColors": {},
+        "crossFilter": [],
+        "drillthrough": []
+      }
+    },
+    {
+      "id": "73317797-4e7b-416e-820b-34eda84f652b",
+      "title": "Journey Conversion",
+      "visualType": "table",
+      "pageId": "200f2597-ebae-43d1-9118-f36801d3b40b",
+      "layout": {
+        "x": 6,
+        "y": 18,
+        "width": 12,
+        "height": 5
+      },
+      "queryRef": {
+        "kind": "query",
+        "queryId": "fc9ea4f3-46db-4f72-b858-bcfc304305b0"
+      },
+      "visualOptions": {
+        "table__enableRenderLinks": false,
+        "colorRulesDisabled": true,
+        "crossFilterDisabled": false,
+        "drillthroughDisabled": false,
+        "crossFilter": [],
+        "drillthrough": [],
+        "table__renderLinks": [],
+        "colorRules": []
+      }
+    }
+  ],
+  "pages": [
+    {
+      "name": "Adoption Overview",
+      "id": "681c892f-d0ac-44ee-9fca-4800ab9c4550"
+    },
+    {
+      "name": "Usage & Acquisition",
+      "id": "ffa5c4f3-2760-4230-8a43-1842b3885f95"
+    },
+    {
+      "name": "Funnels & Retention",
+      "id": "200f2597-ebae-43d1-9118-f36801d3b40b"
+    }
+  ],
+  "dataSources": [
+    {
+      "id": "81da50c0-1748-4322-bacc-29b64472b427",
+      "kind": "manual-kusto",
+      "name": "DevGlobe Product Analytics",
+      "clusterUri": "https://devlglobe.eastus2.kusto.windows.net",
+      "database": "devglobe-analytics"
+    }
+  ],
+  "queries": [
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nlet S=E | summarize EventTypes=dcount(EventName), HasValue=countif(EventName in (\"card_generated\", \"profile_shared\", \"profile_claimed\", \"mission_completed\", \"next_action_selected\")) > 0 by SessionHash;\nunion\n  (S | summarize Value=count() | extend Metric=\"Active sessions\"),\n  (S | where EventTypes >= 2 | summarize Value=count() | extend Metric=\"Engaged sessions\"),\n  (S | where HasValue | summarize Value=count() | extend Metric=\"Value sessions\"),\n  (E | where EventName == \"profile_viewed\" | summarize Value=count() | extend Metric=\"Profile views\"),\n  (E | summarize Value=dcount(TargetLogin) | extend Metric=\"Profiles reached\")\n| project Metric, Value",
+      "id": "c3828a64-f31f-49af-b5ed-b864cd0dd2bd",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(90d) .. now())\n| summarize Events=count(), EventTypes=dcount(EventName) by Day=startofday(EventTime), SessionHash\n| summarize ActiveSessions=count(), EngagedSessions=countif(EventTypes >= 2), Events=sum(Events) by Day\n| order by Day asc",
+      "id": "781206d1-eeea-479c-9dce-9b6ee6785e11",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nlet S=E | summarize EventTypes=dcount(EventName), Events=count(), HasValue=countif(EventName in (\"card_generated\", \"profile_shared\", \"profile_claimed\", \"mission_completed\", \"next_action_selected\")) > 0 by SessionHash;\nlet Totals=S | summarize Active=count(), Engaged=countif(EventTypes >= 2), ValueSessions=countif(HasValue), AvgEvents=round(avg(Events), 2);\nTotals\n| extend EngagementRate=iff(Active == 0, 0.0, round(100.0 * Engaged / Active, 1)), ValueRate=iff(Active == 0, 0.0, round(100.0 * ValueSessions / Active, 1))\n| project Metric=pack_array(\"Engagement rate\", \"Value-session rate\", \"Events per session\"), Value=pack_array(EngagementRate, ValueRate, AvgEvents)\n| mv-expand Metric to typeof(string), Value to typeof(real)",
+      "id": "d8804887-97f4-481c-ac01-2c976056de3a",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(180d) .. now())\n| summarize ActiveSessions=dcount(SessionHash), ValueSessions=dcountif(SessionHash, EventName in (\"card_generated\", \"profile_shared\", \"profile_claimed\", \"mission_completed\", \"next_action_selected\")) by Week=startofweek(EventTime)\n| where Week < startofweek(now())\n| order by Week asc",
+      "id": "c104926e-7389-407e-9712-8ba235013ddc",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now())\n| where EventName in (\"card_generated\", \"profile_shared\", \"profile_claimed\", \"mission_completed\", \"next_action_selected\")\n| summarize Events=count(), Sessions=dcount(SessionHash) by EventName\n| extend Event=strcat_array(split(EventName, \"_\"), \" \")\n| project Event, Events, Sessions\n| order by Sessions desc",
+      "id": "77cdd4bb-6029-4fb3-a3f8-9b7b4f47e6fc",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nunion\n  (E | summarize Value=count() | extend Metric=\"Tracked actions\"),\n  (E | summarize Value=dcount(SessionHash) | extend Metric=\"Active sessions\"),\n  (E | where EventName == \"profile_viewed\" | summarize Value=dcount(TargetLogin) | extend Metric=\"Profiles viewed\"),\n  (E | where isnotempty(Source) | summarize Value=dcount(SessionHash) | extend Metric=\"Attributed sessions\")\n| project Metric, Value",
+      "id": "50351041-70e4-4eb7-a69f-ef0186c39436",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(60d) .. now())\n| extend EventGroup=case(\n    EventName in (\"search_appearance\", \"profile_viewed\"), \"Discovery\",\n    EventName in (\"card_generated\", \"profile_shared\", \"profile_claimed\"), \"Identity & sharing\",\n    EventName startswith \"mission_\", \"Missions\",\n    EventName in (\"recommendation_opened\", \"next_action_selected\", \"comparison_started\"), \"Exploration\",\n    \"Other\")\n| summarize Actions=count() by Day=startofday(EventTime), EventGroup\n| order by Day asc",
+      "id": "42da2618-10fb-42dd-8aec-4da6c38099f3",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now())\n| extend AcquisitionSource=iff(isempty(Source), \"Unattributed\", Source)\n| summarize Value=dcount(SessionHash) by AcquisitionSource\n| top 10 by Value desc",
+      "id": "1f5b9b0f-1654-4152-90b7-bdb1a3a5b5bb",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now())\n| summarize Sessions=dcount(SessionHash), Actions=count() by EventName\n| extend Feature=strcat_array(split(EventName, \"_\"), \" \")\n| project Feature, Sessions, Actions\n| top 15 by Sessions desc",
+      "id": "666638ec-ecc3-4117-a6c1-66a7d33bb9c9",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now())\n| where isnotempty(Journey)\n| summarize Sessions=dcount(SessionHash), Actions=count(), ValueSessions=dcountif(SessionHash, EventName in (\"mission_completed\", \"next_action_selected\", \"profile_shared\")) by Journey\n| extend ValueRate=round(100.0 * ValueSessions / Sessions, 1)\n| project Journey, Sessions, Actions, ValueSessions, ValueRate\n| order by Sessions desc",
+      "id": "1aab62eb-db45-4949-b84e-ca6e2c95b152",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now()) and EventName == \"profile_shared\"\n| extend ShareChannel=iff(isempty(Channel), \"Unspecified\", Channel)\n| summarize Shares=count(), Sharers=dcount(SessionHash) by ShareChannel\n| order by Shares desc",
+      "id": "70e862c3-22da-490e-a5c4-5e75ff0a9123",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now()) and isnotempty(TargetLogin)\n| summarize Views=countif(EventName == \"profile_viewed\"), Cards=countif(EventName == \"card_generated\"), Shares=countif(EventName == \"profile_shared\") by TargetLogin\n| where Views + Cards + Shares > 0\n| top 20 by Views desc",
+      "id": "20866c12-9951-4da0-891b-8805385be1b7",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nlet Discovery=E | summarize Impression=minif(EventTime, EventName == \"search_appearance\"), View=minif(EventTime, EventName == \"profile_viewed\"), Card=minif(EventTime, EventName == \"card_generated\"), Share=minif(EventTime, EventName == \"profile_shared\") by SessionHash, TargetLogin;\nlet D=Discovery | summarize Impressions=countif(isnotnull(Impression)), Views=countif(isnotnull(Impression) and View >= Impression), Cards=countif(isnotnull(Impression) and View >= Impression and Card >= View), Shares=countif(isnotnull(Impression) and View >= Impression and Card >= View and Share >= Card);\nD\n| extend ViewRate=iff(Impressions == 0, 0.0, round(100.0 * Views / Impressions, 1)), CardRate=iff(Impressions == 0, 0.0, round(100.0 * Cards / Impressions, 1)), ShareRate=iff(Impressions == 0, 0.0, round(100.0 * Shares / Impressions, 1))\n| project Metric=pack_array(\"Search-to-view %\", \"Search-to-card %\", \"Search-to-share %\"), Value=pack_array(ViewRate, CardRate, ShareRate)\n| mv-expand Metric to typeof(string), Value to typeof(real)",
+      "id": "885f12be-031a-4c6c-970b-2e1773ec7847",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nlet T=E | summarize Impression=minif(EventTime, EventName == \"search_appearance\"), View=minif(EventTime, EventName == \"profile_viewed\"), Card=minif(EventTime, EventName == \"card_generated\"), Share=minif(EventTime, EventName == \"profile_shared\") by SessionHash, TargetLogin;\nunion\n  (T | summarize Sessions=countif(isnotnull(Impression)) | extend StepOrder=1, Step=\"Search appearance\"),\n  (T | summarize Sessions=countif(isnotnull(Impression) and View >= Impression) | extend StepOrder=2, Step=\"Profile viewed\"),\n  (T | summarize Sessions=countif(isnotnull(Impression) and View >= Impression and Card >= View) | extend StepOrder=3, Step=\"Card generated\"),\n  (T | summarize Sessions=countif(isnotnull(Impression) and View >= Impression and Card >= View and Share >= Card) | extend StepOrder=4, Step=\"Profile shared\")\n| order by StepOrder asc\n| project Step, Sessions",
+      "id": "b3383a24-4e32-42f9-8897-3b5d1a85dcbc",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nlet T=E | summarize Profile=minif(EventTime, EventName == \"profile_viewed\"), Recommendation=minif(EventTime, EventName == \"recommendation_opened\"), Action=minif(EventTime, EventName == \"next_action_selected\") by SessionHash;\nunion\n  (T | summarize Sessions=countif(isnotnull(Profile)) | extend StepOrder=1, Step=\"Profile viewed\"),\n  (T | summarize Sessions=countif(isnotnull(Profile) and Recommendation >= Profile) | extend StepOrder=2, Step=\"Recommendation opened\"),\n  (T | summarize Sessions=countif(isnotnull(Profile) and Recommendation >= Profile and Action >= Recommendation) | extend StepOrder=3, Step=\"Next action selected\")\n| order by StepOrder asc\n| project Step, Sessions",
+      "id": "37aa074e-ea6e-4b81-ae31-44088df50909",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(30d) .. now());\nlet T=E | summarize Viewed=minif(EventTime, EventName == \"mission_viewed\"), Accepted=minif(EventTime, EventName == \"mission_accepted\"), Completed=minif(EventTime, EventName == \"mission_completed\") by SessionHash;\nunion\n  (T | summarize Sessions=countif(isnotnull(Viewed)) | extend StepOrder=1, Step=\"Mission viewed\"),\n  (T | summarize Sessions=countif(isnotnull(Viewed) and Accepted >= Viewed) | extend StepOrder=2, Step=\"Mission accepted\"),\n  (T | summarize Sessions=countif(isnotnull(Viewed) and Accepted >= Viewed and Completed >= Accepted) | extend StepOrder=3, Step=\"Mission completed\")\n| order by StepOrder asc\n| project Step, Sessions",
+      "id": "8eb6e0ec-da6b-4194-b976-81db8bfce92f",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nlet E=Events | where EventTime between (ago(180d) .. now());\nlet FirstSeen=E | summarize FirstSeen=min(EventTime) by SessionHash;\nE\n| where EventTime between (ago(60d) .. now())\n| extend Day=startofday(EventTime)\n| join kind=leftouter FirstSeen on SessionHash\n| summarize ActiveBrowsers=dcount(SessionHash), NewBrowsers=dcountif(SessionHash, FirstSeen >= Day and FirstSeen < Day + 1d), ReturningBrowsers=dcountif(SessionHash, FirstSeen < Day) by Day\n| order by Day asc",
+      "id": "2f47d8ba-c374-4066-a880-f51560c2a46f",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now())\n| summarize EventTypes=dcount(EventName) by SessionHash\n| extend Depth=case(EventTypes == 1, \"1 event type\", EventTypes between (2 .. 3), \"2-3 event types\", \"4+ event types\")\n| summarize Value=count() by Depth",
+      "id": "33b1ae43-22ca-4554-9d55-b5480cf4f85b",
+      "usedVariables": []
+    },
+    {
+      "dataSource": {
+        "kind": "inline",
+        "dataSourceId": "81da50c0-1748-4322-bacc-29b64472b427"
+      },
+      "text": "let Events = () {\n  DevGlobeEngagementRaw\n  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))\n  | where isnotempty(EventId)\n  | summarize arg_max(IngestedAt, *) by EventId\n  | extend\n      EventTime=todatetime(Document.createdAt),\n      EventName=tostring(Document.eventName),\n      SessionHash=tostring(Document.sessionHash),\n      PrivacyHash=tostring(Document.privacyHash),\n      TargetLogin=tostring(Document.targetLogin),\n      Source=tostring(Document.properties.source),\n      Journey=tostring(Document.properties.journey),\n      Action=tostring(Document.properties.action),\n      Channel=tostring(Document.properties.channel)\n  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);\n};\nEvents\n| where EventTime between (ago(30d) .. now()) and isnotempty(Journey)\n| summarize Sessions=dcount(SessionHash), Completed=dcountif(SessionHash, EventName in (\"mission_completed\", \"next_action_selected\", \"profile_shared\")) by Journey\n| extend ConversionRate=round(100.0 * Completed / Sessions, 1)\n| project Journey, Sessions, Completed, ConversionRate\n| order by Sessions desc",
+      "id": "fc9ea4f3-46db-4f72-b858-bcfc304305b0",
+      "usedVariables": []
+    }
+  ],
+  "parameters": []
+}

--- a/dashboards/devglobe-product-adoption-workbook.json
+++ b/dashboards/devglobe-product-adoption-workbook.json
@@ -1,0 +1,316 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# DevGlobe Product Adoption\nProduct-owner view of reach, usage, acquisition, conversion, and MCP adoption. Metrics use the last 30 days of live Application Insights telemetry from `devglobe-public-api`."
+      },
+      "name": "title"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let P=pageViews | where timestamp >= ago(30d); let E=customEvents | where timestamp >= ago(30d); union (P | summarize Value=count() | extend Metric='Page views'), (P | summarize Value=dcount(user_Id) | extend Metric='Active users'), (P | summarize Value=dcount(session_Id) | extend Metric='Sessions'), (E | summarize Value=count() | extend Metric='Product actions') | project Metric, Value",
+        "size": 4,
+        "title": "30-day product health",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {
+            "columnMatch": "Metric",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "Value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            }
+          },
+          "showBorder": true
+        }
+      },
+      "name": "product-health"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "pageViews | where timestamp >= ago(30d) | summarize PageViews=count(), Users=dcount(user_Id), Sessions=dcount(session_Id) by Day=startofday(timestamp) | order by Day asc",
+        "size": 0,
+        "title": "Daily traffic and active users",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "timechart"
+      },
+      "customWidth": "70",
+      "name": "daily-traffic"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "pageViews | where timestamp >= ago(30d) | extend Page=iff(isempty(name), tostring(parse_url(url).Path), name) | summarize Views=count(), Users=dcount(user_Id), Sessions=dcount(session_Id) by Page | top 15 by Views desc",
+        "size": 0,
+        "title": "Top pages",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "customWidth": "30",
+      "name": "top-pages"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Feature adoption\nWhich intentional product actions users take after arriving."
+      },
+      "name": "usage-heading"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents | where timestamp >= ago(30d) | summarize Actions=count(), Users=dcount(user_Id), Sessions=dcount(session_Id) by Feature=name | top 15 by Sessions desc",
+        "size": 0,
+        "title": "Feature adoption by session",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "customWidth": "70",
+      "name": "feature-adoption"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "pageViews | where timestamp >= ago(30d) | extend Source=extract(@'[?&]utm_source=([^&]+)', 1, url), Campaign=extract(@'[?&]utm_campaign=([^&]+)', 1, url) | extend Source=iff(isempty(Source), 'Direct / unattributed', Source), Campaign=iff(isempty(Campaign), 'None', Campaign) | summarize Sessions=dcount(session_Id), Users=dcount(user_Id), Views=count() by Source, Campaign | top 15 by Sessions desc",
+        "size": 0,
+        "title": "Acquisition sources",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table"
+      },
+      "customWidth": "30",
+      "name": "acquisition"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Conversion funnels\nStages are ordered within the same Application Insights session. Counts are directional product signals, not identity-level attribution."
+      },
+      "name": "funnels-heading"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let E=customEvents | where timestamp >= ago(30d) and isnotempty(session_Id); let S=E | summarize Profile=minif(timestamp, name == 'profile_viewed'), Card=minif(timestamp, name == 'card_generated'), Share=minif(timestamp, name in ('identity_card_shared','agent_profile_shared')), Claim=minif(timestamp, name == 'claim_completed') by session_Id; union (S | summarize Sessions=countif(isnotnull(Profile)) | extend StepOrder=1, Stage='Profile viewed'), (S | summarize Sessions=countif(isnotnull(Profile) and Card >= Profile) | extend StepOrder=2, Stage='Card generated'), (S | summarize Sessions=countif(isnotnull(Profile) and Card >= Profile and Share >= Card) | extend StepOrder=3, Stage='Profile shared'), (S | summarize Sessions=countif(isnotnull(Profile) and Claim >= Profile) | extend StepOrder=4, Stage='Profile claimed') | order by StepOrder asc | project Stage, Sessions",
+        "size": 0,
+        "title": "Profile value funnel",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "customWidth": "50",
+      "name": "profile-funnel"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let E=customEvents | where timestamp >= ago(30d) and isnotempty(session_Id); let S=E | summarize Preview=minif(timestamp, name in ('mission_preview_requested','mission_preview_shown')), Viewed=minif(timestamp, name == 'mission_viewed'), Accepted=minif(timestamp, name == 'mission_accepted'), Completed=minif(timestamp, name == 'mission_completed') by session_Id; union (S | summarize Sessions=countif(isnotnull(Preview)) | extend StepOrder=1, Stage='Preview'), (S | summarize Sessions=countif(isnotnull(Preview) and Viewed >= Preview) | extend StepOrder=2, Stage='Viewed'), (S | summarize Sessions=countif(isnotnull(Viewed) and Accepted >= Viewed) | extend StepOrder=3, Stage='Accepted'), (S | summarize Sessions=countif(isnotnull(Accepted) and Completed >= Accepted) | extend StepOrder=4, Stage='Completed') | order by StepOrder asc | project Stage, Sessions",
+        "size": 0,
+        "title": "Daily mission funnel",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "customWidth": "50",
+      "name": "mission-funnel"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let P=pageViews | where timestamp >= ago(30d) and isnotempty(session_Id); let SessionDepth=P | summarize PageViews=count(), DistinctPages=dcount(name) by session_Id; SessionDepth | extend Depth=case(PageViews == 1, '1 view', PageViews between (2 .. 3), '2-3 views', PageViews between (4 .. 7), '4-7 views', '8+ views') | summarize Sessions=count() by Depth",
+        "size": 0,
+        "title": "Session depth",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "piechart"
+      },
+      "name": "session-depth"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## MCP adoption and reliability\nPrivacy-safe usage of the public DevGlobe MCP endpoint. Client values are bounded families; prompts, tool arguments, tokens, and raw user agents are never collected."
+      },
+      "name": "mcp-heading"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); let T=M | summarize Calls=count(), ToolCalls=countif(Method == 'tools/call'), CallerDays=dcountif(CallerHash, isnotempty(CallerHash)), Successful=countif(Outcome == 'success'), P95LatencyMs=percentile(DurationMs, 95); T | extend SuccessRate=iff(Calls == 0, 0.0, round(100.0 * Successful / Calls, 1)) | project Metric=pack_array('Requests', 'Tool calls', 'Correlated caller-days', 'Success rate %', 'P95 latency ms'), Value=pack_array(todouble(Calls), todouble(ToolCalls), todouble(CallerDays), SuccessRate, P95LatencyMs) | mv-expand Metric to typeof(string), Value to typeof(real)",
+        "size": 4,
+        "title": "MCP health - last 30 days",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {
+            "columnMatch": "Metric",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "Value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            }
+          },
+          "showBorder": true
+        }
+      },
+      "name": "mcp-health"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); M | summarize Requests=count(), Errors=countif(Outcome == 'error') by Day=startofday(Timestamp) | order by Day asc",
+        "size": 0,
+        "title": "Daily MCP requests and errors",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "timechart"
+      },
+      "customWidth": "60",
+      "name": "mcp-daily"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); M | where Method == 'tools/call' and Tool != 'none' | summarize Calls=count(), Successful=countif(Outcome == 'success'), Results=sum(ResultCount), P95LatencyMs=round(percentile(DurationMs, 95), 0) by Tool | extend SuccessRate=round(100.0 * Successful / Calls, 1) | project Tool, Calls, SuccessRate, P95LatencyMs, Results | order by Calls desc",
+        "size": 0,
+        "title": "Tool adoption",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "customWidth": "40",
+      "name": "mcp-tools"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); M | summarize Requests=count(), ToolCalls=countif(Method == 'tools/call') by Client | order by Requests desc",
+        "size": 0,
+        "title": "MCP client mix",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "piechart"
+      },
+      "customWidth": "50",
+      "name": "mcp-clients"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); M | summarize Requests=count(), Errors=countif(Outcome == 'error'), P50LatencyMs=round(percentile(DurationMs, 50), 0), P95LatencyMs=round(percentile(DurationMs, 95), 0) by Method, Tool | extend SuccessRate=round(100.0 * (Requests - Errors) / Requests, 1) | project Method, Tool, Requests, SuccessRate, P50LatencyMs, P95LatencyMs | order by Requests desc",
+        "size": 0,
+        "title": "Reliability by method and tool",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table"
+      },
+      "customWidth": "50",
+      "name": "mcp-reliability"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); let C=M | where isnotempty(CallerHash) | summarize Initialized=countif(Method == 'initialize') > 0, Listed=countif(Method == 'tools/list') > 0, Called=countif(Method == 'tools/call') > 0, Succeeded=countif(Method == 'tools/call' and Outcome == 'success') > 0 by CallerHash; union (C | summarize CallerDays=countif(Initialized) | extend StepOrder=1, Stage='Initialized'), (C | summarize CallerDays=countif(Initialized and Listed) | extend StepOrder=2, Stage='Listed tools'), (C | summarize CallerDays=countif(Initialized and Listed and Called) | extend StepOrder=3, Stage='Called a tool'), (C | summarize CallerDays=countif(Initialized and Listed and Called and Succeeded) | extend StepOrder=4, Stage='Successful tool result') | order by StepOrder asc | project Stage, CallerDays",
+        "size": 0,
+        "title": "MCP caller-day conversion",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "customWidth": "60",
+      "name": "mcp-conversion"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode); M | where Outcome == 'error' | extend ErrorCode=iff(isempty(ErrorCode), 'unclassified', ErrorCode) | summarize Errors=count(), CallerDays=dcountif(CallerHash, isnotempty(CallerHash)), LastSeen=max(Timestamp) by ErrorCode, Tool | order by Errors desc",
+        "size": 0,
+        "title": "MCP errors by code",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table"
+      },
+      "customWidth": "40",
+      "name": "mcp-errors"
+    }
+  ],
+  "fallbackResourceIds": [],
+  "fromTemplateId": null,
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/docs-site/agents/mcp.md
+++ b/docs-site/agents/mcp.md
@@ -50,8 +50,23 @@ For consent-gated introduction tools, keep the issued token in the client's secu
 |---|---|---|
 | `search_developers` | Anonymous | Searches public profiles by expertise, name, location, language, and agent availability |
 | `get_developer_profile` | Anonymous | Returns one public profile by GitHub login |
+| `find_similar_developers` | Anonymous | Finds alternatives similar to a known public profile |
+| `get_trending_developers` | Anonymous | Lists recent score gainers and new impact-tracking entries |
+| `preview_contribution_mission` | Anonymous | Previews one contribution-ready issue without reserving it |
 | `request_introduction` | Bearer token | Creates a pending request for an opted-in developer |
 | `get_introduction_status` | Same bearer token | Polls a request created by that agent |
+
+## Agent workflows
+
+Start broad discovery with `search_developers`, inspect selected results with `get_developer_profile`, and use `find_similar_developers` only when alternatives to a known profile are useful. Use `get_trending_developers` when recency matters and `preview_contribution_mission` when the user asks for a concrete open-source action.
+
+Example inputs:
+
+```json
+{"tool":"search_developers","arguments":{"query":"TypeScript maintainers","location":"Germany","availableForAgents":true,"limit":5}}
+{"tool":"get_developer_profile","arguments":{"login":"sajeetharan"}}
+{"tool":"get_trending_developers","arguments":{"days":30,"limit":10}}
+```
 
 Search limits must remain between 1 and 20. Clients should surface structured tool errors and back off when rate-limited rather than retrying aggressively.
 
@@ -82,6 +97,7 @@ Only retryable errors ever include `retryAfterSeconds`, and only when DevGlobe c
 ## Privacy-safe telemetry
 
 DevGlobe records the MCP method, known tool name, success or error outcome, latency, and aggregate result count. Raw prompts, search arguments, profile content, credentials, and private contact details are not included in usage events.
+DevGlobe records the MCP method, known tool name, success or error outcome, bounded error code, latency, aggregate result count, and a daily rotating HMAC caller hash for conversion measurement. Raw prompts, search arguments, profile content, credentials, IP addresses, raw user agents, and private contact details are not included in usage events.
 
 ## Consent lifecycle
 

--- a/docs/adx-product-adoption-dashboard.md
+++ b/docs/adx-product-adoption-dashboard.md
@@ -1,0 +1,100 @@
+# DevGlobe product adoption dashboard
+
+This Azure Data Explorer dashboard gives product owners a privacy-safe view of usage, feature adoption, conversion, and repeat engagement.
+
+## What it answers
+
+- How many browser sessions are active, engaged, and reaching a value action?
+- Which product areas, journeys, acquisition sources, and sharing channels are adopted?
+- Where do users leave the discovery, exploration, and daily-mission funnels?
+- Are new browsers returning on later days?
+- How often is the MCP endpoint used, which tools and client families are adopted, and is it reliable?
+
+The dashboard contains three pages:
+
+1. **Adoption Overview** - 30-day KPIs, daily and weekly trends, engagement rate, and value actions.
+2. **Usage & Acquisition** - product-area usage, source attribution, feature adoption, journey performance, and popular profiles.
+3. **Funnels & Retention** - ordered discovery, exploration, and mission funnels plus new-versus-returning browser trends.
+
+## Data source
+
+The dashboard expects the Cosmos DB `engagement-events` change feed in this ADX table:
+
+```kusto
+.create table DevGlobeEngagementRaw (
+    Document: dynamic,
+    CosmosTimestamp: datetime
+)
+```
+
+Create the ingestion mapping:
+
+```kusto
+.create-or-alter table DevGlobeEngagementRaw ingestion json mapping 'DevGlobeEngagementRawMapping' '[
+  {"column":"Document","path":"$","datatype":"dynamic"},
+  {"column":"CosmosTimestamp","path":"$._ts","datatype":"datetime","transform":"DateTimeFromUnixSeconds"}
+]'
+```
+
+In the ADX database **Data connections** page, connect the Cosmos DB `engagement-events` container to `DevGlobeEngagementRaw` with `DevGlobeEngagementRawMapping`. Use the ADX cluster's managed identity and grant it **Cosmos DB Built-in Data Reader** plus management-plane **Reader** at the narrowest practical scope. Do not store account keys in the dashboard or generator.
+
+Verify ingestion before importing:
+
+```kusto
+DevGlobeEngagementRaw
+| extend EventTime=todatetime(Document.createdAt), EventName=tostring(Document.eventName)
+| summarize Rows=count(), Earliest=min(EventTime), Latest=max(EventTime), EventTypes=dcount(EventName)
+```
+
+The event documents are retained for 180 days. Set the Cosmos data connection retrieval start date early enough for the desired trend window.
+
+## Generate and import
+
+From the repository root:
+
+```powershell
+npm run dashboard:adoption
+```
+
+The generator defaults to:
+
+- Cluster: `https://devlglobe.eastus2.kusto.windows.net`
+- Database: `devglobe-analytics`
+
+Confirm that this cluster exists in the target subscription before import. If it is not provisioned or uses a different name, set `ADX_CLUSTER_URI` explicitly; the dashboard cannot execute queries against a placeholder or unresolved endpoint.
+
+Override either target when needed:
+
+```powershell
+$env:ADX_CLUSTER_URI = 'https://your-cluster.region.kusto.windows.net'
+$env:ADX_DATABASE = 'your-database'
+npm run dashboard:adoption
+```
+
+Import `dashboards/devglobe-product-adoption-dashboard.json` from **Azure Data Explorer > Dashboards > New dashboard > Import dashboard**, then authenticate the `DevGlobe Product Analytics` data source.
+
+## Metric definitions
+
+- **Active session**: a privacy-safe browser session with at least one intentional event in the period.
+- **Engaged session**: an active session with at least two distinct event types.
+- **Value session**: a session containing card generation, profile sharing, profile claim, mission completion, or a next-action selection.
+- **Returning browser**: a session hash observed before the reporting day. This is directional browser retention, not authenticated-user retention.
+- **Profiles reached**: distinct public developer logins referenced by tracked events.
+
+Repeated equivalent events are deduplicated by the application in 30-minute windows. The dashboard also deduplicates change-feed rows by event ID.
+
+## Views and attribution limitations
+
+Durable engagement telemetry records intentional product actions. `profile_viewed` and `mission_viewed` are included, but generic route page views are not written to `engagement-events`. For site traffic, bounce rate, and landing-page views, use the Application Insights `AppPageViews` data documented in `docs/growth-attribution.md` or add a privacy-reviewed page-view event to the durable contract.
+
+Source, channel, journey, and action values are optional. The dashboard groups missing source values as **Unattributed** rather than inferring attribution. Session and privacy hashes are pseudonymous and must not be exported or used for individual tracking.
+
+## Azure Monitor Workbook and MCP metrics
+
+The deployed **DevGlobe Product Adoption** Azure Monitor Workbook uses the live `devglobe-public-api` Application Insights component. Rebuild its serialized definition with:
+
+```powershell
+npm run workbook:adoption
+```
+
+MCP requests emit a structured `devglobe_mcp` console record from Azure Container Apps. The Workbook queries `ContainerAppConsoleLogs_CL` in `workspace-devgloberg7P5B` and reports request and tool-call volume, known client-family count, success rate, p50/p95 latency, result volume, tool adoption, and client mix. Telemetry stores only bounded method, tool, client-family, and outcome dimensions plus numeric duration and result count. It does not store prompts, tool arguments, tokens, authorization data, client IP addresses, or raw user-agent strings.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,3 +1,4 @@
+Privacy-safe usage events include only the MCP method, known tool name, outcome, bounded error code, latency, aggregate result count, and a daily rotating caller hash; prompts and tool arguments are not recorded. The caller hash is derived with HMAC from request metadata and cannot be reversed; rotation prevents longitudinal tracking.
 # DevGlobe MCP Server
 
 DevGlobe provides a hosted Model Context Protocol server for developer discovery and consent-gated introductions. It uses stateless Streamable HTTP so agents can connect without cloning or running DevGlobe locally.

--- a/lib/devglobe-mcp-client.js
+++ b/lib/devglobe-mcp-client.js
@@ -80,12 +80,14 @@ async function readJson(response) {
 export function createDevGlobeMcpClient({
   baseUrl = process.env.DEVGLOBE_API_URL,
   publicApiBaseUrl = baseUrl,
+  appApiBaseUrl = process.env.DEVGLOBE_INTERNAL_API_URL || baseUrl,
   agentToken = process.env.DEVGLOBE_AGENT_TOKEN,
   previewIdentity,
   fetchImpl = fetch,
 } = {}) {
   const origin = normalizeBaseUrl(baseUrl);
   const publicApiOrigin = normalizeBaseUrl(publicApiBaseUrl);
+  const appApiOrigin = normalizeBaseUrl(appApiBaseUrl);
 
   return {
     async searchDevelopers({ query, location, language, opportunityType, availableForAgents = false, limit = 10 }) {
@@ -119,7 +121,7 @@ export function createDevGlobeMcpClient({
     },
 
     async getTrendingDevelopers({ days = 30, limit = 10 } = {}) {
-      const url = new URL('/api/trending', origin);
+      const url = new URL('/api/trending', appApiOrigin);
       url.searchParams.set('days', String(days));
       const trending = await readJson(await fetchImpl(url));
       const boundedLimit = Math.min(Math.max(limit, 1), 20);
@@ -137,7 +139,7 @@ export function createDevGlobeMcpClient({
     },
 
     async findSimilarDevelopers({ login, limit = 10 }) {
-      const url = new URL('/api/similar-developers', origin);
+      const url = new URL('/api/similar-developers', appApiOrigin);
       url.searchParams.set('login', login);
       url.searchParams.set('top', String(Math.min(Math.max(limit, 1), 20)));
       const similarity = await readJson(await fetchImpl(url));
@@ -151,7 +153,7 @@ export function createDevGlobeMcpClient({
     },
 
     async previewContributionMission({ login }) {
-      const url = new URL('/api/mission-preview', origin);
+      const url = new URL('/api/mission-preview', appApiOrigin);
       return readJson(await fetchImpl(url, {
         method: 'POST',
         headers: {

--- a/lib/devglobe-mcp-server.js
+++ b/lib/devglobe-mcp-server.js
@@ -110,17 +110,17 @@ export function toolError(error) {
 }
 
 export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } = {}) {
-  const server = new McpServer({ name: 'devglobe', version: '1.1.0' });
+  const server = new McpServer({ name: 'devglobe', version: '1.2.0' });
 
   server.registerTool('search_developers', {
-    description: 'Search public DevGlobe developer profiles by expertise, location, language, agent availability, and active self-declared opportunity intent.',
+    description: 'Use when the user wants to find public developers by skill, name, language, location, agent availability, or active opportunity intent. Start discovery here; no authentication is required. Example: {"query":"TypeScript maintainers","location":"Germany","availableForAgents":true,"limit":5}.',
     inputSchema: {
-      query: z.string().min(1).max(200).describe('Skills, expertise, name, or other search intent'),
-      location: z.string().max(100).optional(),
-      language: z.string().max(50).optional(),
-      opportunityType: z.enum(OPPORTUNITY_TYPES).optional(),
-      availableForAgents: z.boolean().default(false),
-      limit: z.number().int().min(1).max(20).default(10),
+      query: z.string().min(1).max(200).describe('Required natural-language public search intent, such as "TypeScript maintainers" or a developer name'),
+      location: z.string().max(100).optional().describe('Optional public location text, such as "Germany" or "Colombo"'),
+      language: z.string().max(50).optional().describe('Optional primary programming language, such as "TypeScript"'),
+      opportunityType: z.enum(OPPORTUNITY_TYPES).optional().describe('Optional active self-declared opportunity type; do not infer availability'),
+      availableForAgents: z.boolean().default(false).describe('Set true only when the user needs profiles accepting verified agent requests'),
+      limit: z.number().int().min(1).max(20).default(10).describe('Maximum results from 1 to 20'),
     },
     outputSchema: {
       results: z.array(developerSchema),
@@ -147,7 +147,7 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   });
 
   server.registerTool('get_developer_profile', {
-    description: 'Get one public DevGlobe developer profile. Private AI collaboration settings are never returned.',
+    description: 'Use when the user names a GitHub login or selects one DevGlobe search result and needs its public profile and contribution evidence. No authentication is required. Example: {"login":"sajeetharan"}.',
     inputSchema: {
       login: z.string().min(1).max(39).describe('GitHub login'),
     },
@@ -171,10 +171,10 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   });
 
   server.registerTool('find_similar_developers', {
-    description: 'Find public developer profiles with similar repository, language, location, and profile signals. Similarity supports exploration and is not a suitability judgment.',
+    description: 'Use when the user wants alternatives similar to a known GitHub login. Similarity uses public repository, language, location, and profile signals and is not a suitability judgment. Example: {"login":"sajeetharan","limit":5}.',
     inputSchema: {
       login: z.string().min(1).max(39).describe('GitHub login of the source profile'),
-      limit: z.number().int().min(1).max(20).default(10),
+      limit: z.number().int().min(1).max(20).default(10).describe('Maximum similar profiles from 1 to 20'),
     },
     outputSchema: {
       source: z.string(),
@@ -203,10 +203,10 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   });
 
   server.registerTool('get_trending_developers', {
-    description: 'List public developers whose DevGlobe score increased over a recent window, plus high-ranking profiles that are new to impact tracking.',
+    description: 'Use when recency or momentum matters. Lists public score gainers and high-ranking profiles new to impact tracking; do not use as a hiring recommendation. Example: {"days":30,"limit":10}.',
     inputSchema: {
-      days: z.number().int().min(1).max(90).default(30),
-      limit: z.number().int().min(1).max(20).default(10),
+      days: z.number().int().min(1).max(90).default(30).describe('Trend window from 1 to 90 days'),
+      limit: z.number().int().min(1).max(20).default(10).describe('Maximum gainers and new entries from 1 to 20 each'),
     },
     outputSchema: {
       windowDays: z.number().int(),
@@ -237,7 +237,7 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   });
 
   server.registerTool('preview_contribution_mission', {
-    description: 'Preview one contribution-ready public GitHub issue matched to a DevGlobe profile. The preview is read-only, does not reserve the issue, and is rate limited.',
+    description: 'Use when the user wants one concrete open-source contribution opportunity for an indexed GitHub login. Read-only, rate limited, and does not reserve the issue. Example: {"login":"sajeetharan"}.',
     inputSchema: {
       login: z.string().min(1).max(39).describe('Public GitHub login already indexed by DevGlobe'),
     },
@@ -271,11 +271,11 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   });
 
   server.registerTool('request_introduction', {
-    description: 'Request a consent-gated introduction to an opted-in developer. This creates a pending request and never returns private contact details.',
+    description: 'Use only after the user explicitly asks to contact an opted-in developer. Requires a bearer token, creates a consent-gated pending request, and never returns private contact details. Example: {"developerLogin":"octocat","reason":"We would like help maintaining our open-source React library.","project":"Example UI"}.',
     inputSchema: {
-      developerLogin: z.string().min(1).max(39),
-      reason: z.string().min(20).max(1000),
-      project: z.string().min(2).max(200),
+      developerLogin: z.string().min(1).max(39).describe('GitHub login selected by the user'),
+      reason: z.string().min(20).max(1000).describe('Specific collaboration reason of at least 20 characters'),
+      project: z.string().min(2).max(200).describe('Project or organization name'),
     },
     annotations: {
       readOnlyHint: false,
@@ -292,7 +292,7 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   });
 
   server.registerTool('get_introduction_status', {
-    description: 'Check an introduction request owned by this agent. An accepted request returns only the developer public GitHub contact route.',
+    description: 'Use after request_introduction to check a request created by the same authenticated agent. An accepted request returns only the public GitHub contact route.',
     inputSchema: {
       id: z.string().uuid(),
       developerLogin: z.string().min(1).max(39),

--- a/lib/mcp-observability.js
+++ b/lib/mcp-observability.js
@@ -1,3 +1,5 @@
+import { createHmac } from 'node:crypto';
+
 const METHODS = new Set(['initialize', 'tools/list', 'tools/call']);
 const TOOLS = new Set([
   'search_developers',
@@ -16,6 +18,15 @@ const CLIENT_PATTERNS = [
   ['openai', /openai|chatgpt/i],
   ['mcp-inspector', /mcp[ /_-]?inspector/i],
 ];
+const ERROR_CODES = new Set([
+  'authentication_required',
+  'conflict',
+  'invalid_request',
+  'not_found',
+  'rate_limited',
+  'unavailable',
+  'upstream_error',
+]);
 
 export function classifyMcpClient(...values) {
   const identity = values.filter(value => typeof value === 'string').join(' ');
@@ -29,6 +40,16 @@ export function describeMcpRequest(body, userAgent = '') {
   return { method, tool, client };
 }
 
+export function createMcpCallerHash(request, secret = process.env.ENGAGEMENT_HASH_SECRET || process.env.SESSION_SECRET, now = new Date()) {
+  if (!secret) return null;
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || '';
+  const userAgent = request.headers.get('user-agent') || '';
+  const day = now.toISOString().slice(0, 10);
+  return createHmac('sha256', secret)
+    .update(`mcp-caller:${day}:${forwardedFor}:${userAgent}`)
+    .digest('base64url');
+}
+
 export function recordMcpMetric(metric, logger = console.info) {
   logger(JSON.stringify({
     event: 'devglobe_mcp',
@@ -38,6 +59,8 @@ export function recordMcpMetric(metric, logger = console.info) {
     client: metric.client,
     outcome: metric.outcome,
     durationMs: metric.durationMs,
+    ...(metric.callerHash ? { callerHash: metric.callerHash } : {}),
+    ...(ERROR_CODES.has(metric.errorCode) ? { errorCode: metric.errorCode } : {}),
     ...(Number.isInteger(metric.resultCount) ? { resultCount: metric.resultCount } : {}),
   }));
 }

--- a/lib/remote-mcp.js
+++ b/lib/remote-mcp.js
@@ -1,7 +1,7 @@
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { createDevGlobeMcpClient } from './devglobe-mcp-client.js';
 import { createDevGlobeMcpServer } from './devglobe-mcp-server.js';
-import { describeMcpRequest, recordMcpMetric } from './mcp-observability.js';
+import { createMcpCallerHash, describeMcpRequest, recordMcpMetric } from './mcp-observability.js';
 import { createMcpPreviewIdentity } from './mcp-preview-identity.js';
 import { getSiteUrl } from './site.js';
 
@@ -41,6 +41,15 @@ function withSecurityHeaders(response, origin) {
   });
 }
 
+function readToolError(responseBody) {
+  if (!responseBody?.result?.isError) return null;
+  try {
+    return JSON.parse(responseBody.result.content?.[0]?.text || '{}')?.error || null;
+  } catch {
+    return null;
+  }
+}
+
 export function handleMcpOptions(request) {
   if (!isMcpOriginAllowed(request)) return new Response(null, { status: 403 });
   const origin = request.headers.get('origin');
@@ -59,6 +68,8 @@ export async function handleRemoteMcpRequest(request, {
   fetchImpl = fetch,
   metricRecorder = recordMcpMetric,
   apiBaseUrl = process.env.DEVGLOBE_API_URL || process.env.NEXT_PUBLIC_API_URL,
+  appApiBaseUrl = process.env.DEVGLOBE_INTERNAL_API_URL
+    || (process.env.NODE_ENV === 'production' ? `http://localhost:${process.env.PORT || 3000}` : undefined),
 } = {}) {
   if (!isMcpOriginAllowed(request)) {
     return withSecurityHeaders(new Response(JSON.stringify({
@@ -95,6 +106,7 @@ export async function handleRemoteMcpRequest(request, {
   const client = createDevGlobeMcpClient({
     baseUrl: new URL(request.url).origin,
     publicApiBaseUrl: apiBaseUrl || new URL(request.url).origin,
+    appApiBaseUrl: appApiBaseUrl || new URL(request.url).origin,
     agentToken,
     previewIdentity: createMcpPreviewIdentity(request),
     fetchImpl,
@@ -107,10 +119,13 @@ export async function handleRemoteMcpRequest(request, {
   await server.connect(transport);
   const response = await transport.handleRequest(request);
   const responseBody = await response.clone().json().catch(() => null);
+  const toolError = readToolError(responseBody);
   metricRecorder({
     ...requestDescription,
     outcome: response.status >= 400 || responseBody?.error || responseBody?.result?.isError ? 'error' : 'success',
     durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
+    callerHash: createMcpCallerHash(request),
+    errorCode: toolError?.code,
     resultCount: responseBody?.result?.structuredContent?.resultCount,
   });
   return withSecurityHeaders(response, request.headers.get('origin'));

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "docs:build": "vitepress build docs-site && node scripts/verify-docs-build.js",
     "docs:check-live": "node scripts/verify-docs-endpoints.js",
     "docs:preview": "vitepress preview docs-site",
+    "dashboard:adoption": "node scripts/build-product-adoption-dashboard.js",
+    "workbook:adoption": "node scripts/build-product-adoption-workbook.js",
     "lint": "next lint",
     "build-data": "node scripts/build-dataset.js",
     "fetch-github": "node scripts/fetch-github.js",

--- a/scripts/build-product-adoption-dashboard.js
+++ b/scripts/build-product-adoption-dashboard.js
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const outputPath = path.join(directory, '..', 'dashboards', 'devglobe-product-adoption-dashboard.json');
+const clusterUri = process.env.ADX_CLUSTER_URI || 'https://devlglobe.eastus2.kusto.windows.net';
+const database = process.env.ADX_DATABASE || 'devglobe-analytics';
+
+const dataSourceId = crypto.randomUUID();
+const dataSources = [{
+  id: dataSourceId,
+  kind: 'manual-kusto',
+  name: 'DevGlobe Product Analytics',
+  clusterUri,
+  database,
+}];
+
+const overviewPageId = crypto.randomUUID();
+const usagePageId = crypto.randomUUID();
+const funnelsPageId = crypto.randomUUID();
+const pages = [
+  { name: 'Adoption Overview', id: overviewPageId },
+  { name: 'Usage & Acquisition', id: usagePageId },
+  { name: 'Funnels & Retention', id: funnelsPageId },
+];
+
+const tiles = [];
+const queries = [];
+function uuid() { return crypto.randomUUID(); }
+function addQuery(text, dsId = dataSourceId) {
+  const id = uuid();
+  queries.push({ dataSource: { kind: 'inline', dataSourceId: dsId }, text, id, usedVariables: [] });
+  return id;
+}
+function addMarkdown(pageId, title, markdownText, y, height = 2) {
+  tiles.push({ id: uuid(), title, visualType: 'markdownCard', pageId, layout: { x: 0, y, width: 18, height }, markdownText, visualOptions: {} });
+}
+function addTile(pageId, title, type, queryId, layout, visualOptions = {}) {
+  tiles.push({ id: uuid(), title, visualType: type, pageId, layout, queryRef: { kind: 'query', queryId }, visualOptions });
+}
+function multistat(width, height = 4) {
+  return { multiStat__textSize: 'auto', multiStat__valueColumn: null, colorRulesDisabled: false, multiStat__displayOrientation: 'horizontal', multiStat__labelColumn: null, multiStat__slot: { width, height }, colorRules: [] };
+}
+function pie(kind = 'donut', location = 'bottom') {
+  return { hideLegend: false, legendLocation: location, xColumn: null, yColumns: null, seriesColumns: null, crossFilterDisabled: false, drillthroughDisabled: false, labelDisabled: false, pie__label: ['name', 'percentage'], tooltipDisabled: false, pie__tooltip: ['name', 'percentage', 'value'], pie__orderBy: 'size', pie__kind: kind, pie__topNSlices: null, seriesColors: {}, crossFilter: [], drillthrough: [] };
+}
+function chart(xColumn, yColumns, options = {}) {
+  return { multipleYAxes: { base: { id: '-1', label: options.yLabel || '', columns: [], yAxisMaximumValue: null, yAxisMinimumValue: null, yAxisScale: 'linear', horizontalLines: [] }, additional: [], showMultiplePanels: false }, hideLegend: options.hideLegend ?? yColumns.length === 1, legendLocation: options.legend || 'right', xColumnTitle: '', xColumn, yColumns, seriesColumns: options.series || null, xAxisScale: 'linear', verticalLine: '', crossFilterDisabled: false, drillthroughDisabled: false, forceAxisTicks: false, seriesColors: {}, crossFilter: [], drillthrough: [] };
+}
+function table() {
+  return { table__enableRenderLinks: false, colorRulesDisabled: true, crossFilterDisabled: false, drillthroughDisabled: false, crossFilter: [], drillthrough: [], table__renderLinks: [], colorRules: [] };
+}
+
+const events = `let Events = () {
+  DevGlobeEngagementRaw
+  | extend EventId=tostring(Document.id), IngestedAt=coalesce(CosmosTimestamp, unixtime_seconds_todatetime(tolong(Document._ts)))
+  | where isnotempty(EventId)
+  | summarize arg_max(IngestedAt, *) by EventId
+  | extend
+      EventTime=todatetime(Document.createdAt),
+      EventName=tostring(Document.eventName),
+      SessionHash=tostring(Document.sessionHash),
+      PrivacyHash=tostring(Document.privacyHash),
+      TargetLogin=tostring(Document.targetLogin),
+      Source=tostring(Document.properties.source),
+      Journey=tostring(Document.properties.journey),
+      Action=tostring(Document.properties.action),
+      Channel=tostring(Document.properties.channel)
+  | where isnotnull(EventTime) and isnotempty(EventName) and isnotempty(SessionHash);
+};`;
+
+let y = 0;
+addMarkdown(overviewPageId, 'Product Adoption Overview', '## Product adoption\nA product-owner view of reach, meaningful use, and repeat adoption. All metrics use privacy-safe browser session hashes and intentional product events.', y);
+y += 2;
+const overviewKpis = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+let S=E | summarize EventTypes=dcount(EventName), HasValue=countif(EventName in ("card_generated", "profile_shared", "profile_claimed", "mission_completed", "next_action_selected")) > 0 by SessionHash;
+union
+  (S | summarize Value=count() | extend Metric="Active sessions"),
+  (S | where EventTypes >= 2 | summarize Value=count() | extend Metric="Engaged sessions"),
+  (S | where HasValue | summarize Value=count() | extend Metric="Value sessions"),
+  (E | where EventName == "profile_viewed" | summarize Value=count() | extend Metric="Profile views"),
+  (E | summarize Value=dcount(TargetLogin) | extend Metric="Profiles reached")
+| project Metric, Value`);
+addTile(overviewPageId, 'Last 30 Days', 'multistat', overviewKpis, { x: 0, y, width: 18, height: 4 }, multistat(18));
+y += 4;
+const dailyAdoption = addQuery(`${events}
+Events
+| where EventTime between (ago(90d) .. now())
+| summarize Events=count(), EventTypes=dcount(EventName) by Day=startofday(EventTime), SessionHash
+| summarize ActiveSessions=count(), EngagedSessions=countif(EventTypes >= 2), Events=sum(Events) by Day
+| order by Day asc`);
+addTile(overviewPageId, 'Daily Active and Engaged Sessions', 'line', dailyAdoption, { x: 0, y, width: 12, height: 6 }, chart('Day', ['ActiveSessions', 'EngagedSessions'], { hideLegend: false }));
+const engagementHealth = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+let S=E | summarize EventTypes=dcount(EventName), Events=count(), HasValue=countif(EventName in ("card_generated", "profile_shared", "profile_claimed", "mission_completed", "next_action_selected")) > 0 by SessionHash;
+let Totals=S | summarize Active=count(), Engaged=countif(EventTypes >= 2), ValueSessions=countif(HasValue), AvgEvents=round(avg(Events), 2);
+Totals
+| extend EngagementRate=iff(Active == 0, 0.0, round(100.0 * Engaged / Active, 1)), ValueRate=iff(Active == 0, 0.0, round(100.0 * ValueSessions / Active, 1))
+| project Metric=pack_array("Engagement rate", "Value-session rate", "Events per session"), Value=pack_array(EngagementRate, ValueRate, AvgEvents)
+| mv-expand Metric to typeof(string), Value to typeof(real)`);
+addTile(overviewPageId, 'Adoption Health', 'multistat', engagementHealth, { x: 12, y, width: 6, height: 6 }, multistat(6, 6));
+y += 6;
+const weeklyAdoption = addQuery(`${events}
+Events
+| where EventTime between (ago(180d) .. now())
+| summarize ActiveSessions=dcount(SessionHash), ValueSessions=dcountif(SessionHash, EventName in ("card_generated", "profile_shared", "profile_claimed", "mission_completed", "next_action_selected")) by Week=startofweek(EventTime)
+| where Week < startofweek(now())
+| order by Week asc`);
+addTile(overviewPageId, 'Completed Weekly Adoption', 'column', weeklyAdoption, { x: 0, y, width: 12, height: 6 }, chart('Week', ['ActiveSessions', 'ValueSessions'], { hideLegend: false }));
+const topValueActions = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now())
+| where EventName in ("card_generated", "profile_shared", "profile_claimed", "mission_completed", "next_action_selected")
+| summarize Events=count(), Sessions=dcount(SessionHash) by EventName
+| extend Event=strcat_array(split(EventName, "_"), " ")
+| project Event, Events, Sessions
+| order by Sessions desc`);
+addTile(overviewPageId, 'Value Actions', 'table', topValueActions, { x: 12, y, width: 6, height: 6 }, table());
+
+y = 0;
+addMarkdown(usagePageId, 'Usage and Acquisition', '## Usage and acquisition\nUnderstand which experiences users adopt and which attributed sources, journeys, and channels produce meaningful sessions.', y);
+y += 2;
+const usageKpis = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+union
+  (E | summarize Value=count() | extend Metric="Tracked actions"),
+  (E | summarize Value=dcount(SessionHash) | extend Metric="Active sessions"),
+  (E | where EventName == "profile_viewed" | summarize Value=dcount(TargetLogin) | extend Metric="Profiles viewed"),
+  (E | where isnotempty(Source) | summarize Value=dcount(SessionHash) | extend Metric="Attributed sessions")
+| project Metric, Value`);
+addTile(usagePageId, 'Usage KPIs - Last 30 Days', 'multistat', usageKpis, { x: 0, y, width: 18, height: 4 }, multistat(18));
+y += 4;
+const dailyUsage = addQuery(`${events}
+Events
+| where EventTime between (ago(60d) .. now())
+| extend EventGroup=case(
+    EventName in ("search_appearance", "profile_viewed"), "Discovery",
+    EventName in ("card_generated", "profile_shared", "profile_claimed"), "Identity & sharing",
+    EventName startswith "mission_", "Missions",
+    EventName in ("recommendation_opened", "next_action_selected", "comparison_started"), "Exploration",
+    "Other")
+| summarize Actions=count() by Day=startofday(EventTime), EventGroup
+| order by Day asc`);
+addTile(usagePageId, 'Daily Usage by Product Area', 'column', dailyUsage, { x: 0, y, width: 12, height: 6 }, chart('Day', ['Actions'], { series: ['EventGroup'], hideLegend: false }));
+const sources = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now())
+| extend AcquisitionSource=iff(isempty(Source), "Unattributed", Source)
+| summarize Value=dcount(SessionHash) by AcquisitionSource
+| top 10 by Value desc`);
+addTile(usagePageId, 'Acquisition Sources', 'pie', sources, { x: 12, y, width: 6, height: 6 }, pie('donut', 'bottom'));
+y += 6;
+const featureAdoption = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now())
+| summarize Sessions=dcount(SessionHash), Actions=count() by EventName
+| extend Feature=strcat_array(split(EventName, "_"), " ")
+| project Feature, Sessions, Actions
+| top 15 by Sessions desc`);
+addTile(usagePageId, 'Feature Adoption', 'bar', featureAdoption, { x: 0, y, width: 12, height: 7 }, chart('Feature', ['Sessions'], { hideLegend: true }));
+const journeys = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now())
+| where isnotempty(Journey)
+| summarize Sessions=dcount(SessionHash), Actions=count(), ValueSessions=dcountif(SessionHash, EventName in ("mission_completed", "next_action_selected", "profile_shared")) by Journey
+| extend ValueRate=round(100.0 * ValueSessions / Sessions, 1)
+| project Journey, Sessions, Actions, ValueSessions, ValueRate
+| order by Sessions desc`);
+addTile(usagePageId, 'Journey Performance', 'table', journeys, { x: 12, y, width: 6, height: 7 }, table());
+y += 7;
+const channels = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now()) and EventName == "profile_shared"
+| extend ShareChannel=iff(isempty(Channel), "Unspecified", Channel)
+| summarize Shares=count(), Sharers=dcount(SessionHash) by ShareChannel
+| order by Shares desc`);
+addTile(usagePageId, 'Sharing Channels', 'table', channels, { x: 0, y, width: 9, height: 5 }, table());
+const topProfiles = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now()) and isnotempty(TargetLogin)
+| summarize Views=countif(EventName == "profile_viewed"), Cards=countif(EventName == "card_generated"), Shares=countif(EventName == "profile_shared") by TargetLogin
+| where Views + Cards + Shares > 0
+| top 20 by Views desc`);
+addTile(usagePageId, 'Most Viewed Profiles', 'table', topProfiles, { x: 9, y, width: 9, height: 5 }, table());
+
+y = 0;
+addMarkdown(funnelsPageId, 'Funnels and Retention', '## Funnels and retention\nConversion steps are ordered within the same privacy-safe session. Returning browsers are session hashes first seen before the reporting day; they are directional, not authenticated-user retention.', y);
+y += 2;
+const funnelKpis = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+let Discovery=E | summarize Impression=minif(EventTime, EventName == "search_appearance"), View=minif(EventTime, EventName == "profile_viewed"), Card=minif(EventTime, EventName == "card_generated"), Share=minif(EventTime, EventName == "profile_shared") by SessionHash, TargetLogin;
+let D=Discovery | summarize Impressions=countif(isnotnull(Impression)), Views=countif(isnotnull(Impression) and View >= Impression), Cards=countif(isnotnull(Impression) and View >= Impression and Card >= View), Shares=countif(isnotnull(Impression) and View >= Impression and Card >= View and Share >= Card);
+D
+| extend ViewRate=iff(Impressions == 0, 0.0, round(100.0 * Views / Impressions, 1)), CardRate=iff(Impressions == 0, 0.0, round(100.0 * Cards / Impressions, 1)), ShareRate=iff(Impressions == 0, 0.0, round(100.0 * Shares / Impressions, 1))
+| project Metric=pack_array("Search-to-view %", "Search-to-card %", "Search-to-share %"), Value=pack_array(ViewRate, CardRate, ShareRate)
+| mv-expand Metric to typeof(string), Value to typeof(real)`);
+addTile(funnelsPageId, 'Discovery Conversion - Last 30 Days', 'multistat', funnelKpis, { x: 0, y, width: 18, height: 4 }, multistat(18));
+y += 4;
+const discoveryFunnel = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+let T=E | summarize Impression=minif(EventTime, EventName == "search_appearance"), View=minif(EventTime, EventName == "profile_viewed"), Card=minif(EventTime, EventName == "card_generated"), Share=minif(EventTime, EventName == "profile_shared") by SessionHash, TargetLogin;
+union
+  (T | summarize Sessions=countif(isnotnull(Impression)) | extend StepOrder=1, Step="Search appearance"),
+  (T | summarize Sessions=countif(isnotnull(Impression) and View >= Impression) | extend StepOrder=2, Step="Profile viewed"),
+  (T | summarize Sessions=countif(isnotnull(Impression) and View >= Impression and Card >= View) | extend StepOrder=3, Step="Card generated"),
+  (T | summarize Sessions=countif(isnotnull(Impression) and View >= Impression and Card >= View and Share >= Card) | extend StepOrder=4, Step="Profile shared")
+| order by StepOrder asc
+| project Step, Sessions`);
+addTile(funnelsPageId, 'Discovery to Sharing Funnel', 'bar', discoveryFunnel, { x: 0, y, width: 9, height: 6 }, chart('Step', ['Sessions'], { hideLegend: true }));
+const explorationFunnel = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+let T=E | summarize Profile=minif(EventTime, EventName == "profile_viewed"), Recommendation=minif(EventTime, EventName == "recommendation_opened"), Action=minif(EventTime, EventName == "next_action_selected") by SessionHash;
+union
+  (T | summarize Sessions=countif(isnotnull(Profile)) | extend StepOrder=1, Step="Profile viewed"),
+  (T | summarize Sessions=countif(isnotnull(Profile) and Recommendation >= Profile) | extend StepOrder=2, Step="Recommendation opened"),
+  (T | summarize Sessions=countif(isnotnull(Profile) and Recommendation >= Profile and Action >= Recommendation) | extend StepOrder=3, Step="Next action selected")
+| order by StepOrder asc
+| project Step, Sessions`);
+addTile(funnelsPageId, 'Exploration Funnel', 'bar', explorationFunnel, { x: 9, y, width: 9, height: 6 }, chart('Step', ['Sessions'], { hideLegend: true }));
+y += 6;
+const missionFunnel = addQuery(`${events}
+let E=Events | where EventTime between (ago(30d) .. now());
+let T=E | summarize Viewed=minif(EventTime, EventName == "mission_viewed"), Accepted=minif(EventTime, EventName == "mission_accepted"), Completed=minif(EventTime, EventName == "mission_completed") by SessionHash;
+union
+  (T | summarize Sessions=countif(isnotnull(Viewed)) | extend StepOrder=1, Step="Mission viewed"),
+  (T | summarize Sessions=countif(isnotnull(Viewed) and Accepted >= Viewed) | extend StepOrder=2, Step="Mission accepted"),
+  (T | summarize Sessions=countif(isnotnull(Viewed) and Accepted >= Viewed and Completed >= Accepted) | extend StepOrder=3, Step="Mission completed")
+| order by StepOrder asc
+| project Step, Sessions`);
+addTile(funnelsPageId, 'Daily Mission Funnel', 'bar', missionFunnel, { x: 0, y, width: 9, height: 6 }, chart('Step', ['Sessions'], { hideLegend: true }));
+const returningTrend = addQuery(`${events}
+let E=Events | where EventTime between (ago(180d) .. now());
+let FirstSeen=E | summarize FirstSeen=min(EventTime) by SessionHash;
+E
+| where EventTime between (ago(60d) .. now())
+| extend Day=startofday(EventTime)
+| join kind=leftouter FirstSeen on SessionHash
+| summarize ActiveBrowsers=dcount(SessionHash), NewBrowsers=dcountif(SessionHash, FirstSeen >= Day and FirstSeen < Day + 1d), ReturningBrowsers=dcountif(SessionHash, FirstSeen < Day) by Day
+| order by Day asc`);
+addTile(funnelsPageId, 'New vs Returning Browsers', 'line', returningTrend, { x: 9, y, width: 9, height: 6 }, chart('Day', ['NewBrowsers', 'ReturningBrowsers'], { hideLegend: false }));
+y += 6;
+const depth = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now())
+| summarize EventTypes=dcount(EventName) by SessionHash
+| extend Depth=case(EventTypes == 1, "1 event type", EventTypes between (2 .. 3), "2-3 event types", "4+ event types")
+| summarize Value=count() by Depth`);
+addTile(funnelsPageId, 'Session Engagement Depth', 'pie', depth, { x: 0, y, width: 6, height: 5 }, pie('donut', 'bottom'));
+const journeyConversion = addQuery(`${events}
+Events
+| where EventTime between (ago(30d) .. now()) and isnotempty(Journey)
+| summarize Sessions=dcount(SessionHash), Completed=dcountif(SessionHash, EventName in ("mission_completed", "next_action_selected", "profile_shared")) by Journey
+| extend ConversionRate=round(100.0 * Completed / Sessions, 1)
+| project Journey, Sessions, Completed, ConversionRate
+| order by Sessions desc`);
+addTile(funnelsPageId, 'Journey Conversion', 'table', journeyConversion, { x: 6, y, width: 12, height: 5 }, table());
+
+const dashboard = {
+  $schema: 'https://dataexplorer.azure.com/static/d/schema/75/dashboard.json',
+  id: uuid(),
+  eTag: uuid(),
+  title: 'DevGlobe Product Adoption',
+  schema_version: 75,
+  tiles,
+  pages,
+  dataSources,
+  queries,
+  parameters: [],
+};
+
+let errors = 0;
+const pageIdSet = new Set(pages.map(page => page.id));
+const dataSourceIdSet = new Set(dataSources.map(dataSource => dataSource.id));
+const queryIdSet = new Set(queries.map(query => query.id));
+for (const tile of tiles) {
+  if (!pageIdSet.has(tile.pageId)) { console.error(`ERROR: Tile "${tile.title}" bad pageId`); errors++; }
+  if (tile.queryRef && !queryIdSet.has(tile.queryRef.queryId)) { console.error(`ERROR: Tile "${tile.title}" bad queryId`); errors++; }
+}
+for (const query of queries) {
+  if (!dataSourceIdSet.has(query.dataSource.dataSourceId)) { console.error(`ERROR: Query ${query.id} bad dataSourceId`); errors++; }
+}
+const tileIdSet = new Set();
+for (const tile of tiles) { if (tileIdSet.has(tile.id)) { console.error(`ERROR: Dup tile ${tile.id}`); errors++; } tileIdSet.add(tile.id); }
+const queryIdSetSeen = new Set();
+for (const query of queries) { if (queryIdSetSeen.has(query.id)) { console.error(`ERROR: Dup query ${query.id}`); errors++; } queryIdSetSeen.add(query.id); }
+for (const tile of tiles) { if (tile.visualType === 'multistat' && !tile.visualOptions?.multiStat__slot?.height) { console.error(`ERROR: Multistat "${tile.title}" missing slot.height`); errors++; } }
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(dashboard, null, 2)}\n`);
+console.log(`Generated ${path.relative(process.cwd(), outputPath)} with ${pages.length} pages, ${tiles.length} tiles, and ${queries.length} queries.`);
+console.log(errors === 0 ? 'Validation: PASSED' : `Validation: ${errors} error(s)`);
+if (errors > 0) process.exit(1);

--- a/scripts/build-product-adoption-workbook.js
+++ b/scripts/build-product-adoption-workbook.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const outputPath = path.join(directory, '..', 'dashboards', 'devglobe-product-adoption-workbook.json');
+const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+const items = [];
+
+function markdown(name, json) {
+  items.push({ type: 1, content: { json }, name });
+}
+
+function query(name, title, queryText, visualization, customWidth, options = {}) {
+  items.push({
+    type: 3,
+    content: {
+      version: 'KqlItem/1.0',
+      query: queryText,
+      size: 0,
+      title,
+      timeContext: { durationMs: thirtyDays },
+      queryType: 0,
+      resourceType: 'microsoft.insights/components',
+      visualization,
+      ...options,
+    },
+    ...(customWidth ? { customWidth } : {}),
+    name,
+  });
+}
+
+markdown('title', '# DevGlobe Product Adoption\nProduct-owner view of reach, usage, acquisition, conversion, and MCP adoption. Metrics use the last 30 days of live Application Insights telemetry from `devglobe-public-api`.');
+query('product-health', '30-day product health', "let P=pageViews | where timestamp >= ago(30d); let E=customEvents | where timestamp >= ago(30d); union (P | summarize Value=count() | extend Metric='Page views'), (P | summarize Value=dcount(user_Id) | extend Metric='Active users'), (P | summarize Value=dcount(session_Id) | extend Metric='Sessions'), (E | summarize Value=count() | extend Metric='Product actions') | project Metric, Value", 'tiles', null, {
+  size: 4,
+  tileSettings: {
+    titleContent: { columnMatch: 'Metric', formatter: 1 },
+    leftContent: { columnMatch: 'Value', formatter: 12, formatOptions: { palette: 'auto' } },
+    showBorder: true,
+  },
+});
+query('daily-traffic', 'Daily traffic and active users', "pageViews | where timestamp >= ago(30d) | summarize PageViews=count(), Users=dcount(user_Id), Sessions=dcount(session_Id) by Day=startofday(timestamp) | order by Day asc", 'timechart', '70');
+query('top-pages', 'Top pages', "pageViews | where timestamp >= ago(30d) | extend Page=iff(isempty(name), tostring(parse_url(url).Path), name) | summarize Views=count(), Users=dcount(user_Id), Sessions=dcount(session_Id) by Page | top 15 by Views desc", 'barchart', '30');
+
+markdown('usage-heading', '## Feature adoption\nWhich intentional product actions users take after arriving.');
+query('feature-adoption', 'Feature adoption by session', "customEvents | where timestamp >= ago(30d) | summarize Actions=count(), Users=dcount(user_Id), Sessions=dcount(session_Id) by Feature=name | top 15 by Sessions desc", 'barchart', '70');
+query('acquisition', 'Acquisition sources', "pageViews | where timestamp >= ago(30d) | extend Source=extract(@'[?&]utm_source=([^&]+)', 1, url), Campaign=extract(@'[?&]utm_campaign=([^&]+)', 1, url) | extend Source=iff(isempty(Source), 'Direct / unattributed', Source), Campaign=iff(isempty(Campaign), 'None', Campaign) | summarize Sessions=dcount(session_Id), Users=dcount(user_Id), Views=count() by Source, Campaign | top 15 by Sessions desc", 'table', '30');
+
+markdown('funnels-heading', '## Conversion funnels\nStages are ordered within the same Application Insights session. Counts are directional product signals, not identity-level attribution.');
+query('profile-funnel', 'Profile value funnel', "let E=customEvents | where timestamp >= ago(30d) and isnotempty(session_Id); let S=E | summarize Profile=minif(timestamp, name == 'profile_viewed'), Card=minif(timestamp, name == 'card_generated'), Share=minif(timestamp, name in ('identity_card_shared','agent_profile_shared')), Claim=minif(timestamp, name == 'claim_completed') by session_Id; union (S | summarize Sessions=countif(isnotnull(Profile)) | extend StepOrder=1, Stage='Profile viewed'), (S | summarize Sessions=countif(isnotnull(Profile) and Card >= Profile) | extend StepOrder=2, Stage='Card generated'), (S | summarize Sessions=countif(isnotnull(Profile) and Card >= Profile and Share >= Card) | extend StepOrder=3, Stage='Profile shared'), (S | summarize Sessions=countif(isnotnull(Profile) and Claim >= Profile) | extend StepOrder=4, Stage='Profile claimed') | order by StepOrder asc | project Stage, Sessions", 'barchart', '50');
+query('mission-funnel', 'Daily mission funnel', "let E=customEvents | where timestamp >= ago(30d) and isnotempty(session_Id); let S=E | summarize Preview=minif(timestamp, name in ('mission_preview_requested','mission_preview_shown')), Viewed=minif(timestamp, name == 'mission_viewed'), Accepted=minif(timestamp, name == 'mission_accepted'), Completed=minif(timestamp, name == 'mission_completed') by session_Id; union (S | summarize Sessions=countif(isnotnull(Preview)) | extend StepOrder=1, Stage='Preview'), (S | summarize Sessions=countif(isnotnull(Preview) and Viewed >= Preview) | extend StepOrder=2, Stage='Viewed'), (S | summarize Sessions=countif(isnotnull(Viewed) and Accepted >= Viewed) | extend StepOrder=3, Stage='Accepted'), (S | summarize Sessions=countif(isnotnull(Accepted) and Completed >= Accepted) | extend StepOrder=4, Stage='Completed') | order by StepOrder asc | project Stage, Sessions", 'barchart', '50');
+query('session-depth', 'Session depth', "let P=pageViews | where timestamp >= ago(30d) and isnotempty(session_Id); let SessionDepth=P | summarize PageViews=count(), DistinctPages=dcount(name) by session_Id; SessionDepth | extend Depth=case(PageViews == 1, '1 view', PageViews between (2 .. 3), '2-3 views', PageViews between (4 .. 7), '4-7 views', '8+ views') | summarize Sessions=count() by Depth", 'piechart');
+
+markdown('mcp-heading', '## MCP adoption and reliability\nPrivacy-safe usage of the public DevGlobe MCP endpoint. Client values are bounded families; prompts, tool arguments, tokens, and raw user agents are never collected.');
+const mcpEvents = "let M=workspace('c97b958c-a52f-45b5-bcc1-d7eb355850ff').ContainerAppConsoleLogs_CL | where TimeGenerated >= ago(30d) and Log_s has 'devglobe_mcp' | extend Metric=parse_json(Log_s) | where tostring(Metric.event) == 'devglobe_mcp' | extend Timestamp=TimeGenerated, Method=tostring(Metric.method), Tool=iff(isempty(tostring(Metric.tool)), 'none', tostring(Metric.tool)), Client=iff(isempty(tostring(Metric.client)), 'unknown', tostring(Metric.client)), Outcome=tostring(Metric.outcome), DurationMs=todouble(Metric.durationMs), ResultCount=todouble(Metric.resultCount), CallerHash=tostring(Metric.callerHash), ErrorCode=tostring(Metric.errorCode);";
+query('mcp-health', 'MCP health - last 30 days', `${mcpEvents} let T=M | summarize Calls=count(), ToolCalls=countif(Method == 'tools/call'), CallerDays=dcountif(CallerHash, isnotempty(CallerHash)), Successful=countif(Outcome == 'success'), P95LatencyMs=percentile(DurationMs, 95); T | extend SuccessRate=iff(Calls == 0, 0.0, round(100.0 * Successful / Calls, 1)) | project Metric=pack_array('Requests', 'Tool calls', 'Correlated caller-days', 'Success rate %', 'P95 latency ms'), Value=pack_array(todouble(Calls), todouble(ToolCalls), todouble(CallerDays), SuccessRate, P95LatencyMs) | mv-expand Metric to typeof(string), Value to typeof(real)`, 'tiles', null, {
+  size: 4,
+  tileSettings: {
+    titleContent: { columnMatch: 'Metric', formatter: 1 },
+    leftContent: { columnMatch: 'Value', formatter: 12, formatOptions: { palette: 'auto' } },
+    showBorder: true,
+  },
+});
+query('mcp-daily', 'Daily MCP requests and errors', `${mcpEvents} M | summarize Requests=count(), Errors=countif(Outcome == 'error') by Day=startofday(Timestamp) | order by Day asc`, 'timechart', '60');
+query('mcp-tools', 'Tool adoption', `${mcpEvents} M | where Method == 'tools/call' and Tool != 'none' | summarize Calls=count(), Successful=countif(Outcome == 'success'), Results=sum(ResultCount), P95LatencyMs=round(percentile(DurationMs, 95), 0) by Tool | extend SuccessRate=round(100.0 * Successful / Calls, 1) | project Tool, Calls, SuccessRate, P95LatencyMs, Results | order by Calls desc`, 'barchart', '40');
+query('mcp-clients', 'MCP client mix', `${mcpEvents} M | summarize Requests=count(), ToolCalls=countif(Method == 'tools/call') by Client | order by Requests desc`, 'piechart', '50');
+query('mcp-reliability', 'Reliability by method and tool', `${mcpEvents} M | summarize Requests=count(), Errors=countif(Outcome == 'error'), P50LatencyMs=round(percentile(DurationMs, 50), 0), P95LatencyMs=round(percentile(DurationMs, 95), 0) by Method, Tool | extend SuccessRate=round(100.0 * (Requests - Errors) / Requests, 1) | project Method, Tool, Requests, SuccessRate, P50LatencyMs, P95LatencyMs | order by Requests desc`, 'table', '50');
+query('mcp-conversion', 'MCP caller-day conversion', `${mcpEvents} let C=M | where isnotempty(CallerHash) | summarize Initialized=countif(Method == 'initialize') > 0, Listed=countif(Method == 'tools/list') > 0, Called=countif(Method == 'tools/call') > 0, Succeeded=countif(Method == 'tools/call' and Outcome == 'success') > 0 by CallerHash; union (C | summarize CallerDays=countif(Initialized) | extend StepOrder=1, Stage='Initialized'), (C | summarize CallerDays=countif(Initialized and Listed) | extend StepOrder=2, Stage='Listed tools'), (C | summarize CallerDays=countif(Initialized and Listed and Called) | extend StepOrder=3, Stage='Called a tool'), (C | summarize CallerDays=countif(Initialized and Listed and Called and Succeeded) | extend StepOrder=4, Stage='Successful tool result') | order by StepOrder asc | project Stage, CallerDays`, 'barchart', '60');
+query('mcp-errors', 'MCP errors by code', `${mcpEvents} M | where Outcome == 'error' | extend ErrorCode=iff(isempty(ErrorCode), 'unclassified', ErrorCode) | summarize Errors=count(), CallerDays=dcountif(CallerHash, isnotempty(CallerHash)), LastSeen=max(Timestamp) by ErrorCode, Tool | order by Errors desc`, 'table', '40');
+
+const workbook = { version: 'Notebook/1.0', items, fallbackResourceIds: [], fromTemplateId: null, $schema: 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json' };
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(workbook, null, 2)}\n`);
+console.log(`Generated ${path.relative(process.cwd(), outputPath)} with ${items.length} items.`);

--- a/server.json
+++ b/server.json
@@ -2,12 +2,12 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sajeetharan/devglobe",
   "title": "DevGlobe",
-  "description": "Discover public open-source developer profiles and request consent-gated introductions.",
+  "description": "Find public software developers by skill, language, location, open-source activity, agent availability, and self-declared opportunity intent. Inspect profiles, discover similar or trending developers, preview contribution issues, and request consent-gated introductions.",
   "repository": {
     "url": "https://github.com/sajeetharan/devglobe",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/remote-mcp.test.js
+++ b/tests/remote-mcp.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { handleMcpOptions, handleRemoteMcpRequest } from '../lib/remote-mcp.js';
+import { createMcpCallerHash, recordMcpMetric } from '../lib/mcp-observability.js';
 
 const MCP_HEADERS = {
   Accept: 'application/json, text/event-stream',
@@ -148,6 +149,29 @@ test('remote MCP attributes known clients without retaining raw user agents', as
   assert.doesNotMatch(JSON.stringify(metrics[0]), /SmitheryBot|smithery\.ai/);
 });
 
+test('MCP caller correlation rotates daily without retaining source identifiers', () => {
+  const request = mcpRequest({ jsonrpc: '2.0', id: 14, method: 'tools/list', params: {} }, {
+    'User-Agent': 'PrivateClient/1.0',
+    'X-Forwarded-For': '192.0.2.10',
+  });
+  const first = createMcpCallerHash(request, 'test-secret', new Date('2026-08-28T12:00:00Z'));
+  const sameDay = createMcpCallerHash(request, 'test-secret', new Date('2026-08-28T23:00:00Z'));
+  const nextDay = createMcpCallerHash(request, 'test-secret', new Date('2026-08-29T00:00:00Z'));
+
+  assert.equal(first, sameDay);
+  assert.notEqual(first, nextDay);
+  assert.doesNotMatch(first, /PrivateClient|192\.0\.2\.10/);
+});
+
+test('MCP logs retain only allow-listed error codes', () => {
+  const logs = [];
+  recordMcpMetric({ method: 'tools/call', client: 'other', outcome: 'error', durationMs: 5, errorCode: 'not_found' }, message => logs.push(JSON.parse(message)));
+  recordMcpMetric({ method: 'tools/call', client: 'other', outcome: 'error', durationMs: 5, errorCode: 'private_detail' }, message => logs.push(JSON.parse(message)));
+
+  assert.equal(logs[0].errorCode, 'not_found');
+  assert.equal('errorCode' in logs[1], false);
+});
+
 test('remote MCP performs anonymous public developer discovery', async () => {
   const fetchImpl = async url => {
     const parsed = new URL(url);
@@ -202,6 +226,24 @@ test('remote MCP uses the configured public API instead of fetching its own orig
     'https://devglobe-public-api.azurewebsites.net',
     'https://devglobe-public-api.azurewebsites.net',
   ]);
+});
+
+test('remote MCP uses the internal app origin for same-app discovery tools', async () => {
+  let requestedUrl;
+  const response = await readMcpResponse(await handleRemoteMcpRequest(mcpRequest({
+    jsonrpc: '2.0', id: 13, method: 'tools/call',
+    params: { name: 'get_trending_developers', arguments: { days: 30, limit: 5 } },
+  }), {
+    appApiBaseUrl: 'http://localhost:3000',
+    fetchImpl: async url => {
+      requestedUrl = new URL(url);
+      return Response.json({ windowDays: 30, gainers: [], newEntries: [], hasHistory: true });
+    },
+  }));
+
+  assert.equal(response.result.isError, undefined);
+  assert.equal(requestedUrl.origin, 'http://localhost:3000');
+  assert.equal(requestedUrl.pathname, '/api/trending');
 });
 
 test('remote MCP forwards bearer credentials for introduction tools', async () => {


### PR DESCRIPTION
## Summary
- fix same-app MCP backend calls by using the internal Container Apps origin
- improve all seven tool contracts, Agent Skill workflows, and agent-facing documentation
- add privacy-safe caller-day correlation and bounded error-code telemetry
- add product adoption and MCP conversion/reliability Workbook definitions
- publish MCP Registry metadata through secretless GitHub OIDC after `server.json` changes land on main

## Privacy
Telemetry excludes prompts, tool arguments, tokens, authorization data, client IPs, and raw user-agent strings. Caller correlation uses a daily rotating HMAC.

## Validation
- `npm test` (309 passed)
- `npm run build`
- `npm run docs:build`
- `git diff --check`
- focused MCP contract suite (43 passed)

## Deployment note
The generated Workbook contains 19 items, including `mcp-conversion` and `mcp-errors`. Updating the existing live Azure Workbook is pending interactive authentication to the DevGlobe tenant; no Azure resource was modified during the failed authentication attempt.