### PR TITLE
Fix MCP Registry workflow npm version

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -23,6 +23,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Use repository npm version
+        run: npm install --global npm@11.14.1
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Root cause
The MCP Registry workflow ran `npm ci` with the Node 22 runner's bundled npm 10.9.8, while this repository declares and locks dependencies with npm 11.14.1. npm 10 rejected the otherwise valid lockfile with false missing React 18 peer entries.

## Fix
Install the repository-declared npm 11.14.1 before `npm ci`, matching the existing Documentation workflow.

## Validation
- `npm ci --dry-run --ignore-scripts`
- 43 focused MCP contract tests passed
- workflow YAML diagnostics clean
- `git diff --check`