### PR TITLE
Fix MCP Registry description validation

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sajeetharan/devglobe",
   "title": "DevGlobe",
-  "description": "Find public software developers by skill, language, location, open-source activity, agent availability, and self-declared opportunity intent. Inspect profiles, discover similar or trending developers, preview contribution issues, and request consent-gated introductions.",
+  "description": "Discover public developers by skill, location, and activity, with consent-gated introductions.",
   "repository": {
     "url": "https://github.com/sajeetharan/devglobe",
     "source": "github"

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -68,6 +68,17 @@ test('describes the MCP server tools and authentication boundary', async () => {
   assert.match(auth, /introductions:write/);
 });
 
+test('publishes MCP Registry metadata within schema limits', async () => {
+  const registry = JSON.parse(await fs.readFile('server.json', 'utf8'));
+
+  assert.ok(registry.description.length > 0);
+  assert.ok(registry.description.length <= 100);
+  assert.deepEqual(registry.remotes, [{
+    type: 'streamable-http',
+    url: 'https://www.devglobe.dev/mcp',
+  }]);
+});
+
 test('publishes RFC 9728 protected-resource scopes without claiming an authorization server', async () => {
   const response = getProtectedResource();
   const metadata = await response.json();


### PR DESCRIPTION
## Root cause
The MCP Registry rejected version 1.2.0 with HTTP 422 because `server.json.description` was 249 characters; the Registry schema permits at most 100.

## Fix
- shorten the description to 94 characters while retaining developer discovery and consent-gated introductions
- add a contract test enforcing the Registry limit and production remote endpoint

## Validation
- 25 agent-readiness and remote-MCP tests passed
- `server.json` parses with version 1.2.0 and a 94-character description
- `git diff --check`

Merging this PR changes `server.json` on `main`, which automatically retries the MCP Registry publication workflow.