### PR TITLE
Add private developer shortlists

### DIFF
--- a/app/api/shortlists/route.js
+++ b/app/api/shortlists/route.js
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server.js';
+import { getSession } from '../../../lib/auth.js';
+import { getWatchlist, mutateShortlists } from '../../../lib/watchlist-store.js';
+import {
+  createShortlist,
+  deleteShortlist,
+  ownerShortlistView,
+  updateShortlist,
+} from '../../../lib/shortlists.js';
+
+const VALIDATION_ERROR = /must be|limit|already|not found|Invalid GitHub login|Unsupported shortlist action|not in this shortlist/;
+
+export function createShortlistHandlers({
+  getAuthenticatedSession = getSession,
+  loadWatchlist = getWatchlist,
+  mutate = mutateShortlists,
+} = {}) {
+  async function requireOwner() {
+    const session = await getAuthenticatedSession();
+    return session?.login || null;
+  }
+
+  async function GET() {
+    const login = await requireOwner();
+    if (!login) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    try {
+      const watchlist = await loadWatchlist(login);
+      return NextResponse.json({ shortlists: ownerShortlistView(watchlist.shortlists) }, { headers: { 'Cache-Control': 'private, no-store' } });
+    } catch (error) {
+      console.error('Shortlist query failed:', error.message);
+      return NextResponse.json({ error: 'Unable to load shortlists' }, { status: 503 });
+    }
+  }
+
+  async function POST(request) {
+    const login = await requireOwner();
+    if (!login) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    try {
+      const body = await request.json();
+      const { watchlist } = await mutate(login, shortlists => ({ shortlists: createShortlist(shortlists, body) }));
+      return NextResponse.json({ shortlists: ownerShortlistView(watchlist.shortlists) }, { status: 201 });
+    } catch (error) {
+      const validation = VALIDATION_ERROR.test(error.message);
+      if (!validation) console.error('Shortlist creation failed:', error.message);
+      return NextResponse.json({ error: validation ? error.message : 'Unable to create shortlist' }, { status: validation ? 400 : 500 });
+    }
+  }
+
+  async function PATCH(request) {
+    const login = await requireOwner();
+    if (!login) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    try {
+      const body = await request.json();
+      let shareToken;
+      const { watchlist } = await mutate(login, shortlists => {
+        const result = updateShortlist(shortlists, body);
+        shareToken = result.shareToken;
+        return result;
+      });
+      return NextResponse.json({ shortlists: ownerShortlistView(watchlist.shortlists), shareToken });
+    } catch (error) {
+      const validation = VALIDATION_ERROR.test(error.message);
+      if (!validation) console.error('Shortlist update failed:', error.message);
+      return NextResponse.json({ error: validation ? error.message : 'Unable to update shortlist' }, { status: validation ? 400 : 500 });
+    }
+  }
+
+  async function DELETE(request) {
+    const login = await requireOwner();
+    if (!login) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    try {
+      const { id } = await request.json();
+      const { watchlist } = await mutate(login, shortlists => ({ shortlists: deleteShortlist(shortlists, id) }));
+      return NextResponse.json({ shortlists: ownerShortlistView(watchlist.shortlists) });
+    } catch (error) {
+      const validation = VALIDATION_ERROR.test(error.message);
+      if (!validation) console.error('Shortlist deletion failed:', error.message);
+      return NextResponse.json({ error: validation ? error.message : 'Unable to delete shortlist' }, { status: validation ? 400 : 500 });
+    }
+  }
+
+  return { GET, POST, PATCH, DELETE };
+}
+
+export const { GET, POST, PATCH, DELETE } = createShortlistHandlers();

--- a/app/api/shortlists/shared/route.js
+++ b/app/api/shortlists/shared/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server.js';
+import { getWatchlist, normalizeDeveloperFollow } from '../../../../lib/watchlist-store.js';
+import { findSharedShortlist } from '../../../../lib/shortlists.js';
+
+export function createSharedShortlistHandler({ loadWatchlist = getWatchlist } = {}) {
+  return async function GET(request) {
+    try {
+      const url = new URL(request.url);
+      const owner = normalizeDeveloperFollow(url.searchParams.get('owner'));
+      const token = url.searchParams.get('token') || '';
+      if (token.length < 24 || token.length > 200) throw new Error('Invalid share link');
+      const watchlist = await loadWatchlist(owner);
+      const shortlist = findSharedShortlist(watchlist.shortlists, token);
+      if (!shortlist) return NextResponse.json({ error: 'Shared shortlist not found' }, { status: 404 });
+      return NextResponse.json({ owner, shortlist }, { headers: { 'Cache-Control': 'private, no-store' } });
+    } catch (error) {
+      if (/Invalid GitHub login|Invalid share link/.test(error.message)) {
+        return NextResponse.json({ error: 'Shared shortlist not found' }, { status: 404 });
+      }
+      console.error('Shared shortlist query failed:', error.message);
+      return NextResponse.json({ error: 'Unable to load shared shortlist' }, { status: 503 });
+    }
+  };
+}
+
+export const GET = createSharedShortlistHandler();

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -12,6 +12,7 @@ import AddMeModal from '../components/AddMeModal.jsx';
 import ClaimStatusModal from '../components/ClaimStatusModal.jsx';
 import AiProfileModal from '../components/AiProfileModal.jsx';
 import IntroductionInboxModal from '../components/IntroductionInboxModal.jsx';
+import ShortlistManagerModal from '../components/ShortlistManagerModal.jsx';
 import ContributionOpportunitiesModal from '../components/ContributionOpportunitiesModal.jsx';
 import SimilarDevelopersModal from '../components/SimilarDevelopersModal.jsx';
 import QuickTour from '../components/QuickTour.jsx';
@@ -60,6 +61,8 @@ export default function Home() {
   const [showClaimPending, setShowClaimPending] = useState(false);
   const [showAiProfile, setShowAiProfile] = useState(false);
   const [showIntroductions, setShowIntroductions] = useState(false);
+  const [shortlistLogin, setShortlistLogin] = useState('');
+  const [showShortlists, setShowShortlists] = useState(false);
   const [showContributions, setShowContributions] = useState(false);
   const [similarLogin, setSimilarLogin] = useState('');
   const [completionVersion, setCompletionVersion] = useState(0);
@@ -778,6 +781,7 @@ export default function Home() {
         onClaim={handleClaim}
         onEditAiProfile={() => setShowAiProfile(true)}
         onOpenIntroductions={() => setShowIntroductions(true)}
+        onOpenShortlists={() => { setShortlistLogin(''); setShowShortlists(true); }}
         onOpenContributions={() => setShowContributions(true)}
         onOpenSimilar={handleOpenSimilar}
         onOpenProfile={handleOpenOwnProfile}
@@ -877,6 +881,7 @@ export default function Home() {
             onCardGenerated={targetLogin => recordPlatformActivity('generated_card', targetLogin)}
             onReadmeGenerated={targetLogin => recordPlatformActivity('generated_readme', targetLogin)}
             onOpenSimilar={handleOpenSimilar}
+            onAddToShortlist={login => { setShortlistLogin(login); setShowShortlists(true); }}
             claimedLogins={claimedLogins}
             user={user}
             onClaim={handleClaim}
@@ -910,6 +915,17 @@ export default function Home() {
             onEditPreferences={() => {
               setShowIntroductions(false);
               setShowAiProfile(true);
+            }}
+          />
+        )}
+        {showShortlists && (
+          <ShortlistManagerModal
+            ownerLogin={user.login}
+            initialLogin={shortlistLogin}
+            onClose={() => setShowShortlists(false)}
+            onCompare={profiles => {
+              setShowShortlists(false);
+              setCompareDevs(profiles);
             }}
           />
         )}

--- a/app/shortlists/shared/layout.js
+++ b/app/shortlists/shared/layout.js
@@ -1,0 +1,8 @@
+export const metadata = {
+  title: 'Shared developer shortlist | DevGlobe',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function SharedShortlistLayout({ children }) {
+  return children;
+}

--- a/app/shortlists/shared/page.jsx
+++ b/app/shortlists/shared/page.jsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { formatNum } from '../../../lib/format.js';
+
+export default function SharedShortlistPage() {
+  const [data, setData] = useState(null);
+  const [profiles, setProfiles] = useState({});
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    const params = new URLSearchParams(window.location.search);
+    const owner = params.get('owner');
+    const token = params.get('token');
+    fetch(`/api/shortlists/shared?owner=${encodeURIComponent(owner || '')}&token=${encodeURIComponent(token || '')}`, { cache: 'no-store' })
+      .then(async response => {
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error || 'Unable to load shared shortlist');
+        return body;
+      })
+      .then(async body => {
+        if (cancelled) return;
+        setData(body);
+        const results = await Promise.all(body.shortlist.entries.map(async entry => {
+          const response = await fetch(`/api/developer?id=${encodeURIComponent(entry.login)}`, { cache: 'no-store' });
+          return [entry.login, response.ok ? await response.json() : null];
+        }));
+        if (!cancelled) setProfiles(Object.fromEntries(results));
+      })
+      .catch(loadError => { if (!cancelled) setError(loadError.message); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <main className="shared-shortlist-page">
+      <header className="shared-shortlist-header">
+        <Link href="/" referrerPolicy="no-referrer" aria-label="Return to DevGlobe"><img src="/devglobe.png" alt="" />DevGlobe</Link>
+        <span>READ-ONLY SHORTLIST</span>
+      </header>
+      {!data && !error && <p className="shared-shortlist-state">Loading shared shortlist...</p>}
+      {error && (
+        <section className="shared-shortlist-state">
+          <h1>Link unavailable</h1>
+          <p>This shortlist was revoked, deleted, or the link is invalid.</p>
+          <Link href="/">Explore developers</Link>
+        </section>
+      )}
+      {data && (
+        <section className="shared-shortlist-content">
+          <div className="shared-shortlist-title">
+            <div><span>SHARED BY @{data.owner}</span><h1>{data.shortlist.name}</h1></div>
+            <strong>{data.shortlist.entries.length} developers</strong>
+          </div>
+          <p className="shared-shortlist-notice">This snapshot is read-only. The owner chose to include the notes shown here; only they can change entries or revoke access.</p>
+          <div className="shared-shortlist-table" role="table" aria-label={`${data.shortlist.name} developer comparison`}>
+            <div className="shared-shortlist-row shared-shortlist-row--header" role="row">
+              <span role="columnheader">Developer</span><span role="columnheader">Language</span><span role="columnheader">Score</span><span role="columnheader">Stars</span><span role="columnheader">Private note shared by owner</span>
+            </div>
+            {data.shortlist.entries.map(entry => {
+              const profile = profiles[entry.login];
+              return (
+                <div className="shared-shortlist-row" role="row" key={entry.login}>
+                  <span role="cell"><Link href={`/developer/${encodeURIComponent(entry.login)}`} referrerPolicy="no-referrer">@{entry.login}</Link><small>{profile?.name || 'Public profile'}</small></span>
+                  <span role="cell" data-label="Language">{profile?.topLanguage || '—'}</span>
+                  <span role="cell" data-label="Score">{profile?.score ?? '—'}</span>
+                  <span role="cell" data-label="Stars">{profile ? formatNum(profile.totalStars || 0) : '—'}</span>
+                  <span role="cell" data-label="Note">{entry.note || 'No note'}</span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -15,7 +15,7 @@ import { identityCardShareUrl } from '../lib/share-attribution.js';
 import SpecialTags from './SpecialTags.jsx';
 import ReadmeGeneratorModal from './ReadmeGeneratorModal.jsx';
 
-export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGenerated, onOpenSimilar, claimedLogins, user, onClaim, readmeRequest = 0, openCardOnMount = false, claimSuccess = false }) {
+export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGenerated, onOpenSimilar, onAddToShortlist, claimedLogins, user, onClaim, readmeRequest = 0, openCardOnMount = false, claimSuccess = false }) {
   const [fullData, setFullData] = useState(null);
   const [showCard, setShowCard] = useState(false);
   const [showReadmeGenerator, setShowReadmeGenerator] = useState(false);
@@ -228,18 +228,24 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
                 Similar developers
               </button>
               {user?.login.toLowerCase() !== dev.login.toLowerCase() && (
-                <button
-                  type="button"
-                  className={`profile-action${followState === 'following' ? ' profile-action--active' : ''}`}
-                  onClick={handleFollow}
-                  disabled={followState === 'loading' || followState === 'saving'}
-                  aria-pressed={followState === 'following'}
-                >
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    {followState === 'following' ? <path d="m5 12 4 4L19 6" /> : <><path d="M15 19a6 6 0 00-12 0" /><circle cx="9" cy="7" r="4" /><path d="M19 8v6M22 11h-6" /></>}
-                  </svg>
-                  {followState === 'following' ? 'Following' : followState === 'saving' ? 'Saving...' : 'Follow'}
-                </button>
+                <>
+                  <button
+                    type="button"
+                    className={`profile-action${followState === 'following' ? ' profile-action--active' : ''}`}
+                    onClick={handleFollow}
+                    disabled={followState === 'loading' || followState === 'saving'}
+                    aria-pressed={followState === 'following'}
+                  >
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      {followState === 'following' ? <path d="m5 12 4 4L19 6" /> : <><path d="M15 19a6 6 0 00-12 0" /><circle cx="9" cy="7" r="4" /><path d="M19 8v6M22 11h-6" /></>}
+                    </svg>
+                    {followState === 'following' ? 'Following' : followState === 'saving' ? 'Saving...' : 'Follow'}
+                  </button>
+                  <button type="button" className="profile-action" onClick={() => onAddToShortlist(dev.login)}>
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M4 6h16M4 12h10M4 18h8M18 15v6M15 18h6" /></svg>
+                    Add to shortlist
+                  </button>
+                </>
               )}
               <a className="profile-action" href={merged.githubUrl || `https://github.com/${dev.login}`} target="_blank" rel="noopener noreferrer">GitHub <ExternalLinkIcon /></a>
               {merged.soUserId && (

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -6,7 +6,7 @@ import UserMenu from './UserMenu.jsx';
 
 const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
 
-export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
+export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
   return (
     <header className="header">
       <div className="header__brand" onClick={onHome} style={{ cursor: 'pointer' }}>
@@ -129,7 +129,7 @@ export default function Header({ onHome, theme, onToggleTheme, user, onLogout, o
           </svg>
           <span className="btn__label">Sponsor</span>
         </a>
-        <UserMenu user={user} onLogout={onLogout} onClaim={onClaim} onEditAiProfile={onEditAiProfile} onOpenIntroductions={onOpenIntroductions} onOpenContributions={onOpenContributions} onOpenSimilar={onOpenSimilar} onOpenProfile={onOpenProfile} onGenerateCard={onGenerateCard} completionVersion={completionVersion} claimStatus={claimStatus} />
+        <UserMenu user={user} onLogout={onLogout} onClaim={onClaim} onEditAiProfile={onEditAiProfile} onOpenIntroductions={onOpenIntroductions} onOpenShortlists={onOpenShortlists} onOpenContributions={onOpenContributions} onOpenSimilar={onOpenSimilar} onOpenProfile={onOpenProfile} onGenerateCard={onGenerateCard} completionVersion={completionVersion} claimStatus={claimStatus} />
       </div>
     </header>
   );

--- a/components/ShortlistManagerModal.jsx
+++ b/components/ShortlistManagerModal.jsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+async function readResponse(response) {
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.error || 'Unable to update shortlists');
+  return data;
+}
+
+function ShortlistEntry({ entry, selected, onSelect, onSaveNote, onRemove }) {
+  const [note, setNote] = useState(entry.note || '');
+  return (
+    <article className="shortlist-entry">
+      <label className="shortlist-entry__identity">
+        <input type="checkbox" checked={selected} onChange={onSelect} aria-label={`Select ${entry.login} for comparison`} />
+        <span>@{entry.login}</span>
+      </label>
+      <textarea value={note} maxLength={500} onChange={event => setNote(event.target.value)} aria-label={`Private note for ${entry.login}`} placeholder="Private note" />
+      <div className="shortlist-entry__actions">
+        <button type="button" onClick={() => onSaveNote(note)}>Save note</button>
+        <button type="button" className="shortlist-action--danger" onClick={onRemove}>Remove</button>
+      </div>
+    </article>
+  );
+}
+
+export default function ShortlistManagerModal({ ownerLogin, initialLogin = '', onClose, onCompare }) {
+  const [shortlists, setShortlists] = useState([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [newName, setNewName] = useState('');
+  const [login, setLogin] = useState(initialLogin);
+  const [note, setNote] = useState('');
+  const [compareLogins, setCompareLogins] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/shortlists', { cache: 'no-store' })
+      .then(readResponse)
+      .then(data => {
+        if (cancelled) return;
+        setShortlists(data.shortlists);
+        setSelectedId(data.shortlists[0]?.id || '');
+      })
+      .catch(loadError => { if (!cancelled) setError(loadError.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const selected = shortlists.find(shortlist => shortlist.id === selectedId);
+
+  const mutate = async (method, body) => {
+    setSaving(true);
+    setError('');
+    setMessage('');
+    try {
+      const data = await readResponse(await fetch('/api/shortlists', {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }));
+      setShortlists(data.shortlists);
+      return data;
+    } catch (mutationError) {
+      setError(mutationError.message);
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const create = async event => {
+    event.preventDefault();
+    const data = await mutate('POST', { name: newName });
+    if (!data) return;
+    const created = data.shortlists.find(shortlist => !shortlists.some(existing => existing.id === shortlist.id));
+    setSelectedId(created?.id || data.shortlists.at(-1)?.id || '');
+    setNewName('');
+  };
+
+  const addDeveloper = async event => {
+    event.preventDefault();
+    const data = await mutate('PATCH', { id: selectedId, action: 'add', login, note });
+    if (!data) return;
+    setLogin('');
+    setNote('');
+  };
+
+  const share = async () => {
+    if (!window.confirm('Create a read-only link? Anyone with it can see this shortlist, including its notes.')) return;
+    const data = await mutate('PATCH', { id: selectedId, action: 'share' });
+    if (!data?.shareToken) return;
+    const url = `${window.location.origin}/shortlists/shared?owner=${encodeURIComponent(ownerLogin)}&token=${encodeURIComponent(data.shareToken)}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setMessage('Read-only link copied. Creating another link revokes this one.');
+    } catch {
+      setMessage(url);
+    }
+  };
+
+  const removeList = async () => {
+    if (!selected || !window.confirm(`Delete “${selected.name}” and all of its private notes?`)) return;
+    const data = await mutate('DELETE', { id: selected.id });
+    if (data) {
+      setSelectedId(data.shortlists[0]?.id || '');
+      setCompareLogins([]);
+    }
+  };
+
+  const renameList = async () => {
+    const name = window.prompt('Shortlist name', selected?.name || '');
+    if (!name || name.trim() === selected?.name) return;
+    await mutate('PATCH', { id: selected.id, action: 'rename', name });
+  };
+
+  const compare = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const profiles = await Promise.all(compareLogins.map(async developerLogin => {
+        const response = await fetch(`/api/developer?id=${encodeURIComponent(developerLogin)}`, { cache: 'no-store' });
+        if (!response.ok) throw new Error(`Unable to load @${developerLogin}`);
+        return response.json();
+      }));
+      onCompare(profiles);
+    } catch (compareError) {
+      setError(compareError.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="shortlist-modal__backdrop" role="presentation" onMouseDown={event => event.target === event.currentTarget && onClose()}>
+      <section className="shortlist-modal" role="dialog" aria-modal="true" aria-labelledby="shortlist-title">
+        <header className="shortlist-modal__header">
+          <div><span>PRIVATE WORKSPACE</span><h2 id="shortlist-title">Developer shortlists</h2></div>
+          <button type="button" className="shortlist-modal__close" onClick={onClose} aria-label="Close shortlists">&times;</button>
+        </header>
+        <p className="shortlist-modal__intro">Organize candidates and collaborators. Lists and notes stay private unless you create a read-only link.</p>
+
+        <form className="shortlist-create" onSubmit={create}>
+          <label htmlFor="shortlist-name">New shortlist</label>
+          <div><input id="shortlist-name" value={newName} maxLength={80} onChange={event => setNewName(event.target.value)} placeholder="e.g. Rust maintainers" required /><button disabled={saving}>Create</button></div>
+        </form>
+
+        {loading && <p className="shortlist-modal__state">Loading shortlists...</p>}
+        {error && <p className="shortlist-modal__error" role="alert">{error}</p>}
+        {message && <p className="shortlist-modal__message" role="status">{message}</p>}
+
+        {!loading && shortlists.length === 0 && <p className="shortlist-modal__state">Create a named shortlist to start organizing developers.</p>}
+        {shortlists.length > 0 && (
+          <div className="shortlist-workspace">
+            <nav className="shortlist-tabs" aria-label="Your shortlists">
+              {shortlists.map(shortlist => (
+                <button type="button" aria-pressed={selectedId === shortlist.id} onClick={() => { setSelectedId(shortlist.id); setCompareLogins([]); }} key={shortlist.id}>
+                  <span>{shortlist.name}</span><small>{shortlist.entries.length}</small>
+                </button>
+              ))}
+            </nav>
+
+            {selected && (
+              <section className="shortlist-detail" aria-label={selected.name}>
+                <div className="shortlist-detail__toolbar">
+                  <div><strong>{selected.name}</strong><span>{selected.entries.length} of 50 developers</span></div>
+                  <div>
+                    <button type="button" disabled={saving} onClick={renameList}>Rename</button>
+                    <button type="button" disabled={saving || compareLogins.length !== 2} onClick={compare}>Compare {compareLogins.length}/2</button>
+                    <button type="button" disabled={saving} onClick={share}>{selected.shared ? 'Replace share link' : 'Share read-only'}</button>
+                    {selected.shared && <button type="button" disabled={saving} onClick={() => mutate('PATCH', { id: selected.id, action: 'unshare' })}>Revoke</button>}
+                    <button type="button" className="shortlist-action--danger" disabled={saving} onClick={removeList}>Delete</button>
+                  </div>
+                </div>
+
+                <form className="shortlist-add" onSubmit={addDeveloper}>
+                  <label htmlFor="shortlist-login">Add developer</label>
+                  <div><input id="shortlist-login" value={login} onChange={event => setLogin(event.target.value)} placeholder="GitHub login" required /><input value={note} maxLength={500} onChange={event => setNote(event.target.value)} placeholder="Private note (optional)" /><button disabled={saving}>Add</button></div>
+                </form>
+
+                <div className="shortlist-entries">
+                  {selected.entries.length === 0 && <p className="shortlist-modal__state">No developers in this shortlist yet.</p>}
+                  {selected.entries.map(entry => (
+                    <ShortlistEntry
+                      entry={entry}
+                      selected={compareLogins.includes(entry.login)}
+                      onSelect={() => setCompareLogins(current => current.includes(entry.login) ? current.filter(loginValue => loginValue !== entry.login) : current.length < 2 ? [...current, entry.login] : current)}
+                      onSaveNote={entryNote => mutate('PATCH', { id: selected.id, action: 'note', login: entry.login, note: entryNote })}
+                      onRemove={() => mutate('PATCH', { id: selected.id, action: 'remove', login: entry.login })}
+                      key={entry.login}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/UserMenu.jsx
+++ b/components/UserMenu.jsx
@@ -6,7 +6,7 @@ import { developerInviteUrl } from '../lib/share-attribution.js';
 import ProfileCompletionChecklist from './ProfileCompletionChecklist.jsx';
 import ProfileInsights from './ProfileInsights.jsx';
 
-export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, claimStatus }) {
+export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, claimStatus }) {
   const [open, setOpen] = useState(false);
   const [verificationStatus, setVerificationStatus] = useState('idle');
   const [digestPreference, setDigestPreference] = useState(null);
@@ -194,6 +194,12 @@ export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onO
                   <path d="M21 15a4 4 0 01-4 4H8l-5 3V7a4 4 0 014-4h10a4 4 0 014 4z" />
                 </svg>
                 Agent requests
+              </button>
+              <button className="user-menu__item" onClick={() => { onOpenShortlists(); setOpen(false); }}>
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M4 6h16M4 12h10M4 18h8M18 15v6M15 18h6" />
+                </svg>
+                Developer shortlists
               </button>
               <button className="user-menu__item" onClick={inviteDeveloper}>
                 <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/lib/shortlists.js
+++ b/lib/shortlists.js
@@ -1,0 +1,101 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { normalizeDeveloperFollow } from './watchlist-store.js';
+
+export const MAX_SHORTLISTS = 20;
+export const MAX_SHORTLIST_ENTRIES = 50;
+
+function requiredText(value, label, maximum) {
+  const text = String(value || '').trim();
+  if (!text || text.length > maximum) throw new Error(`${label} must be between 1 and ${maximum} characters`);
+  return text;
+}
+
+function shortlistIndex(shortlists, id) {
+  const index = (shortlists || []).findIndex(shortlist => shortlist.id === id);
+  if (index < 0) throw new Error('Shortlist not found');
+  return index;
+}
+
+export function hashShortlistShareToken(token) {
+  return createHash('sha256').update(String(token || '')).digest('hex');
+}
+
+export function createShortlist(shortlists, input, {
+  id = randomUUID(),
+  now = new Date().toISOString(),
+} = {}) {
+  const current = Array.isArray(shortlists) ? shortlists : [];
+  if (current.length >= MAX_SHORTLISTS) throw new Error(`Shortlist limit is ${MAX_SHORTLISTS}`);
+  const name = requiredText(input?.name, 'Shortlist name', 80);
+  if (current.some(shortlist => shortlist.name.toLowerCase() === name.toLowerCase())) {
+    throw new Error('A shortlist with that name already exists');
+  }
+  return [...current, { id, name, entries: [], createdAt: now, updatedAt: now }];
+}
+
+export function updateShortlist(shortlists, input, {
+  now = new Date().toISOString(),
+  createShareToken = () => randomBytes(24).toString('base64url'),
+} = {}) {
+  const index = shortlistIndex(shortlists, input?.id);
+  const shortlist = structuredClone(shortlists[index]);
+  const action = input?.action;
+  let shareToken;
+
+  if (action === 'rename') {
+    const name = requiredText(input.name, 'Shortlist name', 80);
+    if (shortlists.some((entry, entryIndex) => entryIndex !== index && entry.name.toLowerCase() === name.toLowerCase())) {
+      throw new Error('A shortlist with that name already exists');
+    }
+    shortlist.name = name;
+  } else if (action === 'add') {
+    const login = normalizeDeveloperFollow(input.login);
+    if (shortlist.entries.some(entry => entry.login === login)) throw new Error('Developer is already in this shortlist');
+    if (shortlist.entries.length >= MAX_SHORTLIST_ENTRIES) throw new Error(`Shortlist developer limit is ${MAX_SHORTLIST_ENTRIES}`);
+    shortlist.entries.push({ login, note: String(input.note || '').trim().slice(0, 500), addedAt: now });
+  } else if (action === 'note') {
+    const login = normalizeDeveloperFollow(input.login);
+    const entry = shortlist.entries.find(candidate => candidate.login === login);
+    if (!entry) throw new Error('Developer is not in this shortlist');
+    entry.note = String(input.note || '').trim().slice(0, 500);
+  } else if (action === 'remove') {
+    const login = normalizeDeveloperFollow(input.login);
+    shortlist.entries = shortlist.entries.filter(entry => entry.login !== login);
+  } else if (action === 'share') {
+    shareToken = createShareToken();
+    shortlist.share = { tokenHash: hashShortlistShareToken(shareToken), createdAt: now };
+  } else if (action === 'unshare') {
+    delete shortlist.share;
+  } else {
+    throw new Error('Unsupported shortlist action');
+  }
+
+  shortlist.updatedAt = now;
+  const updated = [...shortlists];
+  updated[index] = shortlist;
+  return { shortlists: updated, shareToken };
+}
+
+export function deleteShortlist(shortlists, id) {
+  shortlistIndex(shortlists, id);
+  return shortlists.filter(shortlist => shortlist.id !== id);
+}
+
+export function ownerShortlistView(shortlists) {
+  return (shortlists || []).map(({ share, ...shortlist }) => ({
+    ...shortlist,
+    shared: Boolean(share?.tokenHash),
+  }));
+}
+
+export function findSharedShortlist(shortlists, token) {
+  const tokenHash = hashShortlistShareToken(token);
+  const candidateHash = Buffer.from(tokenHash, 'hex');
+  const shortlist = (shortlists || []).find(candidate => {
+    if (!/^[a-f\d]{64}$/i.test(candidate.share?.tokenHash || '')) return false;
+    return timingSafeEqual(Buffer.from(candidate.share.tokenHash, 'hex'), candidateHash);
+  });
+  if (!shortlist) return null;
+  const { share, ...publicShortlist } = shortlist;
+  return publicShortlist;
+}

--- a/lib/watchlist-store.js
+++ b/lib/watchlist-store.js
@@ -37,10 +37,11 @@ function emptyWatchlist(login) {
     id: login,
     login,
     documentType: 'watchlist',
-    schemaVersion: 1,
+    schemaVersion: 2,
     follows: { developers: [], projects: [], languages: [], countries: [] },
     mutes: { entities: [], eventTypes: [] },
     readState: { readThrough: null, readIds: [] },
+    shortlists: [],
     updatedAt: new Date(0).toISOString(),
   };
 }
@@ -63,7 +64,7 @@ export async function getWatchlist(login) {
 }
 
 async function saveWatchlist(watchlist) {
-  const document = { ...watchlist, schemaVersion: 1, updatedAt: new Date().toISOString() };
+  const document = { ...watchlist, schemaVersion: 2, updatedAt: new Date().toISOString() };
   const container = getWatchlistContainer();
   if (!container) {
     memoryWatchlists.set(document.login, document);
@@ -81,6 +82,26 @@ async function saveWatchlist(watchlist) {
   }
   const { resource } = await container.items.upsert(document);
   return resource;
+}
+
+export async function mutateShortlists(login, mutation, {
+  attempts = 3,
+  load = getWatchlist,
+  save = saveWatchlist,
+} = {}) {
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const watchlist = await load(login);
+    const result = mutation(watchlist.shortlists || []);
+    watchlist.shortlists = result.shortlists;
+    try {
+      return { watchlist: await save(watchlist), result };
+    } catch (error) {
+      if (error.code !== 412) throw error;
+      lastError = error;
+    }
+  }
+  throw lastError;
 }
 
 export async function followEntity(login, category, value) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -8126,6 +8126,141 @@ body {
   opacity: 0.6;
 }
 
+.shortlist-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 530;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.shortlist-modal {
+  width: min(920px, 100%);
+  max-height: calc(100dvh - 36px);
+  overflow-y: auto;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  box-shadow: var(--shadow-strong);
+}
+
+.shortlist-modal__header,
+.shortlist-detail__toolbar,
+.shortlist-entry__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.shortlist-modal__header span,
+.shortlist-detail__toolbar span,
+.shortlist-create label,
+.shortlist-add label {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.shortlist-modal__header h2 { margin: 3px 0 0; color: var(--text-primary); font-size: 20px; }
+.shortlist-modal__close { width: 44px; height: 44px; border: 0; background: transparent; color: var(--text-secondary); font-size: 26px; cursor: pointer; }
+.shortlist-modal__intro { margin: 7px 0 18px; color: var(--text-secondary); font-size: 12px; line-height: 1.5; }
+
+.shortlist-create,
+.shortlist-add { display: grid; gap: 6px; }
+.shortlist-create > div { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
+.shortlist-add > div { display: grid; grid-template-columns: minmax(130px, 0.7fr) minmax(180px, 1.3fr) auto; gap: 8px; }
+.shortlist-modal input,
+.shortlist-modal textarea { min-width: 0; border: 1px solid var(--border); border-radius: 5px; background: var(--bg-primary); color: var(--text-primary); font: inherit; font-size: 12px; }
+.shortlist-modal input { min-height: 38px; padding: 8px 10px; }
+.shortlist-modal textarea { min-height: 58px; padding: 8px; resize: vertical; line-height: 1.4; }
+.shortlist-modal button { border: 1px solid var(--border); border-radius: 5px; background: transparent; color: var(--text-secondary); font: inherit; font-size: 11px; cursor: pointer; }
+.shortlist-create button,
+.shortlist-add button { min-height: 38px; padding: 7px 13px; border-color: #0891b2; background: #0891b2; color: #fff; }
+.shortlist-modal button:disabled { cursor: wait; opacity: 0.55; }
+.shortlist-modal button:focus-visible,
+.shortlist-modal input:focus-visible,
+.shortlist-modal textarea:focus-visible { outline: 2px solid #22d3ee; outline-offset: 2px; }
+.shortlist-action--danger { color: #f87171 !important; }
+.shortlist-modal__state,
+.shortlist-modal__error,
+.shortlist-modal__message { margin: 15px 0 0; color: var(--text-muted); font-size: 11px; }
+.shortlist-modal__error { color: #f87171; }
+.shortlist-modal__message { color: #2ea44f; overflow-wrap: anywhere; }
+
+.shortlist-workspace { display: grid; grid-template-columns: 190px minmax(0, 1fr); gap: 14px; margin-top: 16px; }
+.shortlist-tabs { display: grid; align-content: start; gap: 5px; }
+.shortlist-tabs button { display: flex; min-height: 40px; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 10px; text-align: left; }
+.shortlist-tabs button[aria-pressed='true'] { border-color: #0891b2; background: rgba(8, 145, 178, 0.12); color: var(--text-primary); }
+.shortlist-tabs button span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shortlist-tabs button small { min-width: 20px; padding: 2px 5px; border-radius: 4px; background: var(--overlay-subtle); text-align: center; }
+.shortlist-detail { min-width: 0; padding-left: 14px; border-left: 1px solid var(--border); }
+.shortlist-detail__toolbar { align-items: flex-start; margin-bottom: 14px; }
+.shortlist-detail__toolbar > div:first-child { display: grid; gap: 3px; }
+.shortlist-detail__toolbar strong { color: var(--text-primary); font-size: 14px; }
+.shortlist-detail__toolbar > div:last-child { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+.shortlist-detail__toolbar button,
+.shortlist-entry__actions button { min-height: 34px; padding: 6px 9px; }
+.shortlist-entries { display: grid; gap: 8px; margin-top: 12px; }
+.shortlist-entry { display: grid; grid-template-columns: minmax(130px, 0.55fr) minmax(180px, 1fr) auto; align-items: center; gap: 10px; padding: 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--overlay-subtle); }
+.shortlist-entry__identity { display: flex; align-items: center; gap: 8px; color: var(--text-primary); font-size: 12px; font-weight: 700; }
+.shortlist-entry__identity input { width: 18px; min-height: 18px; }
+.shortlist-entry__actions { justify-content: flex-end; gap: 8px; }
+
+.shared-shortlist-page { min-height: 100vh; padding: 0 24px 48px; background: var(--bg-primary); color: var(--text-primary); }
+.shared-shortlist-header { display: flex; max-width: 1100px; min-height: 64px; align-items: center; justify-content: space-between; margin: 0 auto; border-bottom: 1px solid var(--border); }
+.shared-shortlist-header a { display: flex; align-items: center; gap: 8px; color: var(--text-primary); font-weight: 800; text-decoration: none; }
+.shared-shortlist-header img { width: 28px; height: 28px; }
+.shared-shortlist-header > span,
+.shared-shortlist-title span { color: #22d3ee; font-size: 10px; font-weight: 700; }
+.shared-shortlist-content,
+.shared-shortlist-state { max-width: 1100px; margin: 44px auto 0; }
+.shared-shortlist-state { color: var(--text-secondary); }
+.shared-shortlist-state h1 { color: var(--text-primary); }
+.shared-shortlist-state a { color: #22d3ee; }
+.shared-shortlist-title { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; }
+.shared-shortlist-title h1 { margin: 6px 0 0; font-size: 30px; }
+.shared-shortlist-title strong { color: var(--text-secondary); font-size: 12px; }
+.shared-shortlist-notice { margin: 18px 0; padding: 10px 12px; border-left: 3px solid #0891b2; background: var(--overlay-subtle); color: var(--text-secondary); font-size: 11px; }
+.shared-shortlist-table { border: 1px solid var(--border); border-radius: 7px; overflow: hidden; }
+.shared-shortlist-row { display: grid; grid-template-columns: 1.25fr 0.7fr 0.45fr 0.55fr 1.5fr; gap: 12px; align-items: center; min-height: 64px; padding: 10px 14px; border-bottom: 1px solid var(--border); color: var(--text-secondary); font-size: 12px; }
+.shared-shortlist-row:last-child { border-bottom: 0; }
+.shared-shortlist-row--header { min-height: 38px; background: var(--overlay-subtle); color: var(--text-muted); font-size: 9px; font-weight: 700; text-transform: uppercase; }
+.shared-shortlist-row a { color: var(--text-primary); font-weight: 700; text-decoration: none; }
+.shared-shortlist-row small { display: block; margin-top: 3px; color: var(--text-muted); font-weight: 400; }
+
+@media (max-width: 720px) {
+  .shortlist-modal__backdrop { align-items: flex-end; padding: 0; }
+  .shortlist-modal { width: 100%; max-height: 94dvh; padding: 18px 14px max(18px, env(safe-area-inset-bottom)); border-right: 0; border-bottom: 0; border-left: 0; border-radius: 8px 8px 0 0; }
+  .shortlist-create > div,
+  .shortlist-add > div,
+  .shortlist-workspace,
+  .shortlist-entry { grid-template-columns: 1fr; }
+  .shortlist-tabs { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .shortlist-detail { padding: 14px 0 0; border-top: 1px solid var(--border); border-left: 0; }
+  .shortlist-detail__toolbar { align-items: stretch; flex-direction: column; }
+  .shortlist-detail__toolbar > div:last-child { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .shortlist-modal button,
+  .shortlist-modal input { min-height: 44px; }
+  .shortlist-entry__actions button { flex: 1; }
+  .shared-shortlist-page { padding: 0 14px 32px; }
+  .shared-shortlist-content { margin-top: 28px; }
+  .shared-shortlist-title { align-items: flex-start; flex-direction: column; }
+  .shared-shortlist-title h1 { font-size: 24px; }
+  .shared-shortlist-row--header { display: none; }
+  .shared-shortlist-table { border: 0; overflow: visible; }
+  .shared-shortlist-row { grid-template-columns: 1fr 1fr; margin-bottom: 10px; padding: 14px; border: 1px solid var(--border); border-radius: 6px; }
+  .shared-shortlist-row span:first-child,
+  .shared-shortlist-row span:last-child { grid-column: 1 / -1; }
+  .shared-shortlist-row [data-label]::before { display: block; margin-bottom: 3px; color: var(--text-muted); content: attr(data-label); font-size: 9px; font-weight: 700; text-transform: uppercase; }
+}
+
 @media (max-width: 620px) {
   .ai-profile-modal {
     padding: 22px 16px;

--- a/tests/shortlists-api.test.js
+++ b/tests/shortlists-api.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createShortlistHandlers } from '../app/api/shortlists/route.js';
+import { createSharedShortlistHandler } from '../app/api/shortlists/shared/route.js';
+import { hashShortlistShareToken } from '../lib/shortlists.js';
+
+const ID = '26ec6492-8057-40b1-b53c-9fb6d14fffa7';
+const TOKEN = 'trusted-read-only-token-123456789';
+
+function request(method, body) {
+  return new Request('https://www.devglobe.dev/api/shortlists', {
+    method,
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+test('shortlist owner routes reject unauthenticated access before storage', async () => {
+  let accessed = false;
+  const handlers = createShortlistHandlers({
+    getAuthenticatedSession: async () => null,
+    loadWatchlist: async () => { accessed = true; },
+    mutate: async () => { accessed = true; },
+  });
+  assert.equal((await handlers.GET()).status, 401);
+  assert.equal((await handlers.POST(request('POST', { name: 'Private' }))).status, 401);
+  assert.equal(accessed, false);
+});
+
+test('shortlist mutations are always scoped to the authenticated login', async () => {
+  let mutatedLogin;
+  const handlers = createShortlistHandlers({
+    getAuthenticatedSession: async () => ({ login: 'octocat' }),
+    mutate: async (login, mutation) => {
+      mutatedLogin = login;
+      const result = mutation([]);
+      return { watchlist: { shortlists: result.shortlists }, result };
+    },
+  });
+  const response = await handlers.POST(request('POST', { name: 'Maintainers', owner: 'someone-else' }));
+  assert.equal(response.status, 201);
+  assert.equal(mutatedLogin, 'octocat');
+});
+
+test('owner projection exposes shared state but never token hashes', async () => {
+  const handlers = createShortlistHandlers({
+    getAuthenticatedSession: async () => ({ login: 'octocat' }),
+    loadWatchlist: async login => ({ login, shortlists: [{ id: ID, name: 'Private', entries: [], share: { tokenHash: 'secret' } }] }),
+  });
+  const response = await handlers.GET();
+  const body = await response.json();
+  assert.equal(body.shortlists[0].shared, true);
+  assert.equal(JSON.stringify(body).includes('tokenHash'), false);
+  assert.equal(JSON.stringify(body).includes('secret'), false);
+});
+
+test('shared reads require the matching owner and token and remain read-only projections', async () => {
+  const GET = createSharedShortlistHandler({
+    loadWatchlist: async owner => ({ login: owner, follows: { developers: ['private-follow'] }, shortlists: [{
+      id: ID,
+      name: 'Trusted review',
+      entries: [{ login: 'torvalds', note: 'Kernel work', addedAt: '2026-08-30T12:00:00.000Z' }],
+      share: { tokenHash: hashShortlistShareToken(TOKEN), createdAt: '2026-08-30T12:00:00.000Z' },
+    }] }),
+  });
+  const response = await GET(new Request(`https://www.devglobe.dev/api/shortlists/shared?owner=OctoCat&token=${TOKEN}`));
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(body.owner, 'octocat');
+  assert.equal(body.shortlist.entries[0].login, 'torvalds');
+  assert.equal(JSON.stringify(body).includes('private-follow'), false);
+  assert.equal(JSON.stringify(body).includes('tokenHash'), false);
+  assert.equal((await GET(new Request('https://www.devglobe.dev/api/shortlists/shared?owner=octocat&token=wrong-but-long-enough-token'))).status, 404);
+});

--- a/tests/shortlists.test.js
+++ b/tests/shortlists.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MAX_SHORTLISTS,
+  createShortlist,
+  deleteShortlist,
+  findSharedShortlist,
+  hashShortlistShareToken,
+  ownerShortlistView,
+  updateShortlist,
+} from '../lib/shortlists.js';
+
+const NOW = '2026-08-30T12:00:00.000Z';
+const ID = '26ec6492-8057-40b1-b53c-9fb6d14fffa7';
+
+function shortlist(overrides = {}) {
+  return { id: ID, name: 'Core maintainers', entries: [], createdAt: NOW, updatedAt: NOW, ...overrides };
+}
+
+test('creates bounded, uniquely named private shortlists', () => {
+  const result = createShortlist([], { name: ' Core maintainers ' }, { id: ID, now: NOW });
+  assert.deepEqual(result, [shortlist()]);
+  assert.throws(() => createShortlist([shortlist()], { name: 'core MAINTAINERS' }), /already exists/);
+  assert.throws(() => createShortlist(Array.from({ length: MAX_SHORTLISTS }, (_, index) => shortlist({ id: String(index), name: String(index) })), { name: 'More' }), /limit/);
+});
+
+test('adds, annotates, and removes normalized developers without duplicates', () => {
+  let result = updateShortlist([shortlist()], { id: ID, action: 'add', login: '@OctoCat', note: ' Strong docs ' }, { now: NOW }).shortlists;
+  assert.deepEqual(result[0].entries, [{ login: 'octocat', note: 'Strong docs', addedAt: NOW }]);
+  assert.throws(() => updateShortlist(result, { id: ID, action: 'add', login: 'OCTOCAT' }), /already/);
+  result = updateShortlist(result, { id: ID, action: 'note', login: 'octocat', note: 'Maintainer' }, { now: NOW }).shortlists;
+  assert.equal(result[0].entries[0].note, 'Maintainer');
+  result = updateShortlist(result, { id: ID, action: 'remove', login: 'octocat' }, { now: NOW }).shortlists;
+  assert.deepEqual(result[0].entries, []);
+});
+
+test('shares with a stored hash and never exposes it to the owner projection', () => {
+  const token = 'trusted-read-only-token';
+  const result = updateShortlist([shortlist()], { id: ID, action: 'share' }, { now: NOW, createShareToken: () => token });
+  assert.equal(result.shareToken, token);
+  assert.equal(result.shortlists[0].share.tokenHash, hashShortlistShareToken(token));
+  assert.deepEqual(ownerShortlistView(result.shortlists), [{ ...shortlist(), shared: true }]);
+  assert.deepEqual(findSharedShortlist(result.shortlists, token), shortlist());
+  assert.equal(findSharedShortlist(result.shortlists, 'wrong-token'), null);
+});
+
+test('unsharing revokes access and deleting removes the full list', () => {
+  const shared = updateShortlist([shortlist()], { id: ID, action: 'share' }, { createShareToken: () => 'token' }).shortlists;
+  const unshared = updateShortlist(shared, { id: ID, action: 'unshare' }, { now: NOW }).shortlists;
+  assert.equal(findSharedShortlist(unshared, 'token'), null);
+  assert.deepEqual(deleteShortlist(unshared, ID), []);
+  assert.throws(() => deleteShortlist([], ID), /not found/);
+});
+
+test('renames a shortlist while preserving unique names', () => {
+  const other = shortlist({ id: 'other', name: 'Other list' });
+  const renamed = updateShortlist([shortlist(), other], { id: ID, action: 'rename', name: 'Review queue' }, { now: NOW }).shortlists;
+  assert.equal(renamed[0].name, 'Review queue');
+  assert.throws(() => updateShortlist(renamed, { id: ID, action: 'rename', name: 'other LIST' }), /already exists/);
+});

--- a/tests/watchlist-store.test.js
+++ b/tests/watchlist-store.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   MAX_DEVELOPER_FOLLOWS,
+  mutateShortlists,
   normalizeDeveloperFollow,
   updateDeveloperFollows,
 } from '../lib/watchlist-store.js';
@@ -23,4 +24,26 @@ test('removes follows and enforces the developer follow limit', () => {
   assert.deepEqual(updateDeveloperFollows(['octocat'], 'OCTOCAT', { remove: true }), []);
   const follows = Array.from({ length: MAX_DEVELOPER_FOLLOWS }, (_, index) => `dev-${index}`);
   assert.throws(() => updateDeveloperFollows(follows, 'one-more'), /follow limit/);
+});
+
+test('shortlist mutations reload and retry after an ETag conflict', async () => {
+  let loads = 0;
+  let saves = 0;
+  const result = await mutateShortlists('viewer', shortlists => ({
+    shortlists: [...shortlists, { id: 'new' }],
+  }), {
+    load: async () => ({
+      id: 'viewer',
+      login: 'viewer',
+      shortlists: loads++ === 0 ? [] : [{ id: 'concurrent' }],
+    }),
+    save: async watchlist => {
+      saves += 1;
+      if (saves === 1) throw Object.assign(new Error('conflict'), { code: 412 });
+      return watchlist;
+    },
+  });
+  assert.equal(loads, 2);
+  assert.equal(saves, 2);
+  assert.deepEqual(result.watchlist.shortlists, [{ id: 'concurrent' }, { id: 'new' }]);
 });


### PR DESCRIPTION
Adds owner-scoped private developer shortlists with named lists, notes and member management, in-app comparison, and tokenized read-only sharing with revocation controls. Includes privacy protections, ETag conflict retries, responsive UI, and access validation.

Closes #327
