### PR TITLE
Improve activation with repository agent signals

### DIFF
--- a/app/api/repository-agent-signals/route.js
+++ b/app/api/repository-agent-signals/route.js
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server.js';
+import { apiError } from '../../../lib/api-error.js';
+import {
+  detectRepositoryAgentSignals,
+  isValidGitHubLogin,
+  MAX_AGENT_SIGNAL_REPOSITORIES,
+} from '../../../lib/repository-agent-signals.js';
+
+const GITHUB_API = 'https://api.github.com';
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 250;
+
+function githubHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'devglobe-agent-signal-detector',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function fetchRepositorySignals(fetchImpl, login, token) {
+  const response = await fetchImpl(`${GITHUB_API}/users/${encodeURIComponent(login)}/repos?type=owner&sort=updated&direction=desc&per_page=30`, {
+    headers: githubHeaders(token),
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`GitHub repository lookup returned ${response.status}`);
+  const payload = await response.json();
+  const repositories = (Array.isArray(payload) ? payload : [])
+    .filter(repository => !repository.private && !repository.fork && !repository.archived && repository.default_branch)
+    .slice(0, MAX_AGENT_SIGNAL_REPOSITORIES);
+
+  const trees = await Promise.all(repositories.map(async repository => {
+    const treeResponse = await fetchImpl(`${GITHUB_API}/repos/${repository.full_name}/git/trees/${encodeURIComponent(repository.default_branch)}?recursive=1`, {
+      headers: githubHeaders(token),
+    });
+    if (!treeResponse.ok) return null;
+    const tree = await treeResponse.json();
+    return {
+      fullName: repository.full_name,
+      paths: Array.isArray(tree.tree)
+        ? tree.tree.filter(entry => entry.type === 'blob').map(entry => entry.path)
+        : [],
+    };
+  }));
+  const scanned = trees.filter(Boolean);
+
+  return {
+    login: login.toLowerCase(),
+    scannedRepositories: scanned.length,
+    signals: detectRepositoryAgentSignals(scanned),
+  };
+}
+
+export function createRepositoryAgentSignalsHandler({
+  fetchImpl = fetch,
+  token = process.env.GITHUB_TOKEN,
+  cache = new Map(),
+  now = () => Date.now(),
+} = {}) {
+  return async function getRepositoryAgentSignals(request) {
+    const login = new URL(request.url).searchParams.get('login')?.trim();
+    if (!isValidGitHubLogin(login)) {
+      return apiError(400, 'invalid_login', 'A valid GitHub username is required.', 'Use login=octocat.');
+    }
+
+    const cacheKey = login.toLowerCase();
+    const cached = cache.get(cacheKey);
+    if (cached?.expiresAt > now()) return NextResponse.json(cached.result, {
+      headers: { 'Cache-Control': 'public, s-maxage=604800, stale-while-revalidate=86400' },
+    });
+
+    try {
+      const result = await fetchRepositorySignals(fetchImpl, login, token);
+      if (!result) return apiError(404, 'github_user_not_found', 'GitHub user not found.', 'Check the username.');
+      if (cache.size >= MAX_CACHE_ENTRIES) cache.delete(cache.keys().next().value);
+      cache.set(cacheKey, { result, expiresAt: now() + CACHE_TTL_MS });
+      return NextResponse.json(result, {
+        headers: { 'Cache-Control': 'public, s-maxage=604800, stale-while-revalidate=86400' },
+      });
+    } catch (error) {
+      console.error('Repository agent signal detection failed:', error.message);
+      return apiError(503, 'agent_signal_detection_unavailable', 'Repository agent detection is temporarily unavailable.', 'Retry later.');
+    }
+  };
+}
+
+export const GET = createRepositoryAgentSignalsHandler();

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -89,12 +89,6 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    try {
-      if (!localStorage.getItem('devglobe-tour-complete')) setTourStep('search');
-    } catch { /* localStorage unavailable; leave the tour closed */ }
-  }, []);
-
-  useEffect(() => {
     const referrer = new URLSearchParams(window.location.search).get('ref')?.trim();
     if (!referrer || !/^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(referrer)) return;
     const key = `devglobe-referral-${referrer.toLowerCase()}`;
@@ -809,8 +803,10 @@ export default function Home() {
         onOpenCompareFeature={handleOpenCompareFeature}
         compareCount={compareDevs.length}
         signedIn={Boolean(user)}
+        currentUsername={user?.login || ''}
+        onOpenOwnProfile={handleOpenOwnProfile}
         onOpenActivity={handleOpenActivity}
-        showMissionPreview={!tourStep}
+        showMissionPreview={false}
       />
       <QuickTour
         step={tourStep}

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -14,6 +14,7 @@ import { resolveReadmeAccess } from '../lib/profile-readme.js';
 import { identityCardShareUrl } from '../lib/share-attribution.js';
 import SpecialTags from './SpecialTags.jsx';
 import ReadmeGeneratorModal from './ReadmeGeneratorModal.jsx';
+import RepositoryAgentSignals from './RepositoryAgentSignals.jsx';
 
 export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGenerated, onOpenSimilar, onAddToShortlist, claimedLogins, user, onClaim, readmeRequest = 0, openCardOnMount = false, claimSuccess = false }) {
   const [fullData, setFullData] = useState(null);
@@ -298,6 +299,7 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
       </div>
 
       {merged.aiProfile && <AiCollaborationProfile dev={merged} profile={merged.aiProfile} />}
+      <RepositoryAgentSignals login={dev.login} />
 
       {/* Stats */}
       <div className="detail-panel__stats">

--- a/components/RepositoryAgentSignals.jsx
+++ b/components/RepositoryAgentSignals.jsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { track } from '../lib/analytics.js';
+
+export default function RepositoryAgentSignals({ login }) {
+  const [result, setResult] = useState(null);
+  const [status, setStatus] = useState('loading');
+  const [requestVersion, setRequestVersion] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setStatus('loading');
+    fetch(`/api/repository-agent-signals?login=${encodeURIComponent(login)}`, { signal: controller.signal })
+      .then(async response => {
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error || 'Repository signals are unavailable.');
+        setResult(body);
+        setStatus('ready');
+        track('repository_agent_signals_viewed', {
+          outcome: body.signals.length > 0 ? 'found' : 'empty',
+          source: 'public_repositories',
+        });
+      })
+      .catch(error => {
+        if (error.name !== 'AbortError') setStatus('error');
+      });
+    return () => controller.abort();
+  }, [login, requestVersion]);
+
+  return (
+    <section className="repository-agents" aria-labelledby="repository-agents-title">
+      <div className="repository-agents__heading">
+        <div>
+          <span>PUBLIC REPOSITORY SIGNALS</span>
+          <h3 id="repository-agents-title">Agent configurations</h3>
+        </div>
+        {status === 'ready' && <strong>{result.signals.length} detected</strong>}
+      </div>
+
+      {status === 'loading' && <p className="repository-agents__status" role="status">Checking recent public repositories...</p>}
+      {status === 'error' && (
+        <div className="repository-agents__error" role="status">
+          <span>Repository evidence is temporarily unavailable.</span>
+          <button type="button" onClick={() => setRequestVersion(version => version + 1)}>Retry</button>
+        </div>
+      )}
+      {status === 'ready' && result.signals.length === 0 && (
+        <p className="repository-agents__status">No recognized agent configuration files found in {result.scannedRepositories} recent public repositories.</p>
+      )}
+      {status === 'ready' && result.signals.length > 0 && (
+        <div className="repository-agents__signals">
+          {result.signals.map(signal => (
+            <details
+              key={signal.id}
+              onToggle={event => {
+                if (event.currentTarget.open) track('repository_agent_signal_opened', { action: signal.id, source: 'public_repositories' });
+              }}
+            >
+              <summary>
+                <span>{signal.name}</span>
+                <small>{signal.repositories.length} {signal.repositories.length === 1 ? 'repository' : 'repositories'}</small>
+              </summary>
+              <ul>
+                {signal.repositories.map(repository => (
+                  <li key={repository.name}>
+                    <a href={repository.url} target="_blank" rel="noopener noreferrer">{repository.name}</a>
+                    <span>{repository.paths.join(' · ')}</span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ))}
+        </div>
+      )}
+      <p className="repository-agents__note">Detected from filenames only. This does not confirm personal usage.</p>
+    </section>
+  );
+}

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -28,7 +28,7 @@ const SAMPLES_BY_MODE = {
   ],
 };
 
-export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0, signedIn = false, onOpenActivity, showMissionPreview = true }) {
+export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0, signedIn = false, currentUsername = '', onOpenOwnProfile, onOpenActivity, showMissionPreview = true }) {
   const [query, setQuery] = useState('');
   const [mode, setMode] = useState('text');
   const [topN, setTopN] = useState(20);
@@ -137,6 +137,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
   const handleKeyDown = (e) => {
     if (e.key === 'Enter') {
       clearTimeout(timerRef.current);
+      if (query.trim()) track('activation_started', { journey: 'username_profile', source: 'search_enter' });
       doSearch(query, mode);
     }
     if (e.key === 'Escape') {
@@ -179,6 +180,22 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
   };
 
   const handleSelectResult = (developer) => {
+    track('personalized_profile_viewed', {
+      login: developer.login,
+      journey: 'username_profile',
+      source: mode,
+    });
+    track('activation_action_selected', {
+      action: 'open_profile',
+      journey: 'username_profile',
+      source: mode,
+    });
+    track('activation_completed', {
+      login: developer.login,
+      journey: 'username_profile',
+      outcome: 'profile_opened',
+      source: mode,
+    });
     track('next_action_selected', {
       action: 'open_search_result',
       journey: 'developer_discovery',
@@ -189,6 +206,31 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
 
   return (
     <div className="search-bar" id="search-bar">
+      {!query && resultCount === null && (
+        <div className="search-bar__activation">
+          <span className="search-bar__eyebrow">Your open-source snapshot</span>
+          <h2>{signedIn ? `Welcome back, @${currentUsername}` : 'See your open-source impact'}</h2>
+          <p>Discover your ranking, recent activity, and one useful next step.</p>
+          {signedIn && (
+            <button
+              type="button"
+              className="search-bar__own-profile"
+              onClick={() => {
+                track('activation_started', { journey: 'username_profile', source: 'signed_in_cta' });
+                track('activation_action_selected', { action: 'open_own_profile', journey: 'username_profile', source: 'signed_in_cta' });
+                track('personalized_profile_viewed', { login: currentUsername, journey: 'username_profile', source: 'signed_in_cta' });
+                track('activation_completed', { login: currentUsername, journey: 'username_profile', outcome: 'profile_opened', source: 'signed_in_cta' });
+                onOpenOwnProfile?.();
+              }}
+            >
+              Open my profile
+              <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <path d="M4 10h12M11 5l5 5-5 5" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
       <div className="search-bar__inner">
         {searching ? (
           <div className="search-bar__spinner" />
@@ -200,7 +242,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
         <input
           ref={inputRef}
           type="text"
-          placeholder={mode === 'text' ? 'Find a developer by name, username, or location...' : mode === 'vector' ? 'Describe your ideal developer or agent collaborator...' : 'Combine skills, interests, and location...'}
+          placeholder={mode === 'text' ? 'Enter your GitHub username' : mode === 'vector' ? 'Describe your ideal developer or agent collaborator...' : 'Combine skills, interests, and location...'}
           autoComplete="off"
           value={query}
           onChange={handleInput}
@@ -213,6 +255,18 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
             </svg>
           </button>
         )}
+        <button
+          type="button"
+          className="search-bar__submit"
+          disabled={!query.trim() || searching}
+          onClick={() => {
+            clearTimeout(timerRef.current);
+            track('activation_started', { journey: 'username_profile', source: 'search_button' });
+            doSearch(query, mode);
+          }}
+        >
+          {mode === 'text' ? 'Find profile' : 'Search'}
+        </button>
         <select value={mode} onChange={handleModeChange} title="Search mode">
           <option value="text">Text</option>
           <option value="vector">Vector (AI)</option>

--- a/dashboards/devglobe-product-adoption-workbook.json
+++ b/dashboards/devglobe-product-adoption-workbook.json
@@ -310,7 +310,9 @@
       "name": "mcp-errors"
     }
   ],
-  "fallbackResourceIds": [],
+  "fallbackResourceIds": [
+    "/subscriptions/0caf9c40-8ea2-43b1-a54f-38c656a8e1f0/resourceGroups/devglobe-rg/providers/microsoft.insights/components/devglobe-public-api"
+  ],
   "fromTemplateId": null,
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/docs/adx-product-adoption-dashboard.md
+++ b/docs/adx-product-adoption-dashboard.md
@@ -91,10 +91,10 @@ Source, channel, journey, and action values are optional. The dashboard groups m
 
 ## Azure Monitor Workbook and MCP metrics
 
-The deployed **DevGlobe Product Adoption** Azure Monitor Workbook uses the live `devglobe-public-api` Application Insights component. Rebuild its serialized definition with:
+The deployed **DevGlobe Product Adoption** Azure Monitor Workbook is pinned to the live `devglobe-public-api` Application Insights component in subscription `0caf9c40-8ea2-43b1-a54f-38c656a8e1f0` and resource group `devglobe-rg`. Its browser telemetry is stored in the component's linked `DefaultWorkspace-0caf9c40-8ea2-43b1-a54f-38c656a8e1f0-EUS` workspace. Rebuild its serialized definition with:
 
 ```powershell
 npm run workbook:adoption
 ```
 
-MCP requests emit a structured `devglobe_mcp` console record from Azure Container Apps. The Workbook queries `ContainerAppConsoleLogs_CL` in `workspace-devgloberg7P5B` and reports request and tool-call volume, known client-family count, success rate, p50/p95 latency, result volume, tool adoption, and client mix. Telemetry stores only bounded method, tool, client-family, and outcome dimensions plus numeric duration and result count. It does not store prompts, tool arguments, tokens, authorization data, client IP addresses, or raw user-agent strings.
+MCP requests emit a structured `devglobe_mcp` console record from Azure Container Apps. The Workbook uses a cross-workspace query against `ContainerAppConsoleLogs_CL` in `workspace-devgloberg7P5B` and reports request and tool-call volume, known client-family count, success rate, p50/p95 latency, result volume, tool adoption, and client mix. Telemetry stores only bounded method, tool, client-family, and outcome dimensions plus numeric duration and result count. It does not store prompts, tool arguments, tokens, authorization data, client IP addresses, or raw user-agent strings.

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,4 +1,7 @@
 const ENGAGEMENT_EVENT_MAP = {
+	activation_action_selected: 'activation_action_selected',
+	activation_completed: 'activation_completed',
+	activation_started: 'activation_started',
 	agent_profile_shared: 'profile_shared',
 	card_generated: 'card_generated',
 	claim_completed: 'profile_claimed',
@@ -16,6 +19,7 @@ const ENGAGEMENT_EVENT_MAP = {
 	mission_viewed: 'mission_viewed',
 	next_action_selected: 'next_action_selected',
 	profile_viewed: 'profile_viewed',
+	personalized_profile_viewed: 'personalized_profile_viewed',
 	recommendation_opened: 'recommendation_opened',
 	session_restored: 'session_restored',
 };

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -1,6 +1,9 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
 export const ENGAGEMENT_EVENTS = new Set([
+  'activation_action_selected',
+  'activation_completed',
+  'activation_started',
   'card_generated',
   'comparison_started',
   'mission_accepted',
@@ -17,6 +20,7 @@ export const ENGAGEMENT_EVENTS = new Set([
   'profile_shared',
   'profile_claimed',
   'profile_viewed',
+  'personalized_profile_viewed',
   'recommendation_opened',
   'search_appearance',
   'session_restored',
@@ -61,7 +65,7 @@ export function normalizeEngagementEvent(input) {
   const eventName = String(input?.eventName || '').trim();
   if (!ENGAGEMENT_EVENTS.has(eventName)) throw new EngagementValidationError('Unsupported engagement event');
   const targetLogin = normalizeTargetLogin(input.targetLogin);
-  if (['card_generated', 'profile_claimed', 'profile_shared', 'profile_viewed', 'search_appearance'].includes(eventName) && !targetLogin) {
+  if (['activation_completed', 'card_generated', 'personalized_profile_viewed', 'profile_claimed', 'profile_shared', 'profile_viewed', 'search_appearance'].includes(eventName) && !targetLogin) {
     throw new EngagementValidationError('Target login is required');
   }
   return { eventName, targetLogin, properties: normalizeProperties(input.properties) };

--- a/lib/repository-agent-signals.js
+++ b/lib/repository-agent-signals.js
@@ -1,0 +1,62 @@
+import { AI_TOOLS } from './ai-profile.js';
+
+export const MAX_AGENT_SIGNAL_REPOSITORIES = 8;
+export const MAX_AGENT_SIGNAL_PATHS = 5;
+
+const TOOL_NAMES = new Map(AI_TOOLS.map(tool => [tool.id, tool.name]));
+const SIGNAL_RULES = [
+  { id: 'github-copilot', matches: path => path === '.github/copilot-instructions.md' || /^\.github\/instructions\/.+\.instructions\.md$/.test(path) || /^\.github\/agents\/.+\.agent\.md$/.test(path) },
+  { id: 'claude-code', matches: path => path === 'claude.md' || path.startsWith('.claude/') },
+  { id: 'cursor', matches: path => path === '.cursorrules' || path.startsWith('.cursor/rules/') },
+  { id: 'openai-codex', matches: path => path === '.codex/config.toml' },
+  { id: 'gemini-cli', matches: path => path === 'gemini.md' || path.startsWith('.gemini/') },
+  { id: 'windsurf', matches: path => path === '.windsurfrules' || path.startsWith('.windsurf/rules/') },
+  { id: 'custom-agent', matches: path => path === 'agents.md' || path.endsWith('/agents.md') },
+];
+
+function normalizePath(value) {
+  return String(value || '').trim().replaceAll('\\', '/').replace(/^\.\//, '').toLowerCase();
+}
+
+export function detectRepositoryAgentSignals(repositories) {
+  const signals = new Map();
+
+  for (const repository of repositories.slice(0, MAX_AGENT_SIGNAL_REPOSITORIES)) {
+    const repositoryName = String(repository?.fullName || '').trim();
+    if (!repositoryName || !Array.isArray(repository.paths)) continue;
+    const matchesByTool = new Map();
+
+    for (const rawPath of repository.paths) {
+      const path = normalizePath(rawPath);
+      if (!path) continue;
+      for (const rule of SIGNAL_RULES) {
+        if (!rule.matches(path)) continue;
+        const paths = matchesByTool.get(rule.id) || [];
+        if (paths.length < MAX_AGENT_SIGNAL_PATHS && !paths.includes(path)) paths.push(path);
+        matchesByTool.set(rule.id, paths);
+      }
+    }
+
+    for (const [id, paths] of matchesByTool) {
+      const signal = signals.get(id) || {
+        id,
+        name: TOOL_NAMES.get(id) || 'Agent instructions',
+        source: 'public-repository',
+        repositories: [],
+      };
+      signal.repositories.push({
+        name: repositoryName,
+        url: `https://github.com/${repositoryName}`,
+        paths,
+      });
+      signals.set(id, signal);
+    }
+  }
+
+  return [...signals.values()].sort((first, second) =>
+    second.repositories.length - first.repositories.length || first.name.localeCompare(second.name));
+}
+
+export function isValidGitHubLogin(value) {
+  return /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(String(value || '').trim());
+}

--- a/scripts/build-product-adoption-workbook.js
+++ b/scripts/build-product-adoption-workbook.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const directory = path.dirname(fileURLToPath(import.meta.url));
 const outputPath = path.join(directory, '..', 'dashboards', 'devglobe-product-adoption-workbook.json');
+const applicationInsightsResourceId = '/subscriptions/0caf9c40-8ea2-43b1-a54f-38c656a8e1f0/resourceGroups/devglobe-rg/providers/microsoft.insights/components/devglobe-public-api';
 const thirtyDays = 30 * 24 * 60 * 60 * 1000;
 const items = [];
 
@@ -69,7 +70,7 @@ query('mcp-reliability', 'Reliability by method and operation', `${mcpEvents} M 
 query('mcp-conversion', 'MCP caller-day conversion', `${mcpEvents} let C=M | where isnotempty(CallerHash) | summarize Initialized=countif(Method == 'initialize') > 0, Listed=countif(Method == 'tools/list') > 0, ListedPrompts=countif(Method == 'prompts/list') > 0, OpenedPrompt=countif(Method == 'prompts/get') > 0, Called=countif(Method == 'tools/call') > 0, Succeeded=countif(Method == 'tools/call' and Outcome == 'success') > 0 by CallerHash; union (C | summarize CallerDays=countif(Initialized) | extend StepOrder=1, Stage='Initialized'), (C | summarize CallerDays=countif(Initialized and Listed) | extend StepOrder=2, Stage='Listed tools'), (C | summarize CallerDays=countif(Initialized and ListedPrompts) | extend StepOrder=3, Stage='Listed prompts'), (C | summarize CallerDays=countif(Initialized and OpenedPrompt) | extend StepOrder=4, Stage='Opened a prompt'), (C | summarize CallerDays=countif(Initialized and Listed and Called) | extend StepOrder=5, Stage='Called a tool'), (C | summarize CallerDays=countif(Initialized and Listed and Called and Succeeded) | extend StepOrder=6, Stage='Successful tool result') | order by StepOrder asc | project Stage, CallerDays`, 'barchart', '60');
 query('mcp-errors', 'MCP errors by code', `${mcpEvents} M | where Outcome == 'error' | extend ErrorCode=iff(isempty(ErrorCode), 'unclassified', ErrorCode) | summarize Errors=count(), CallerDays=dcountif(CallerHash, isnotempty(CallerHash)), LastSeen=max(Timestamp) by ErrorCode, Tool | order by Errors desc`, 'table', '40');
 
-const workbook = { version: 'Notebook/1.0', items, fallbackResourceIds: [], fromTemplateId: null, $schema: 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json' };
+const workbook = { version: 'Notebook/1.0', items, fallbackResourceIds: [applicationInsightsResourceId], fromTemplateId: null, $schema: 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json' };
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, `${JSON.stringify(workbook, null, 2)}\n`);
 console.log(`Generated ${path.relative(process.cwd(), outputPath)} with ${items.length} items.`);

--- a/styles/main.css
+++ b/styles/main.css
@@ -407,6 +407,87 @@ body {
   transition: top 0.3s ease, opacity 0.3s ease;
 }
 
+.search-bar__activation {
+  display: grid;
+  justify-items: center;
+  width: min(620px, calc(100vw - 32px));
+  gap: 5px;
+  padding: 16px 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel-90);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-strong);
+  text-align: center;
+}
+
+.search-bar__eyebrow {
+  color: #22d3ee;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.search-bar__activation h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.search-bar__activation p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.search-bar__own-profile,
+.search-bar__submit {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid #0891b2;
+  border-radius: 6px;
+  background: #0891b2;
+  color: #fff;
+  font: 800 12px var(--font);
+  cursor: pointer;
+}
+
+.search-bar__own-profile {
+  margin-top: 7px;
+  padding: 0 16px;
+}
+
+.search-bar__own-profile svg {
+  width: 16px;
+  height: 16px;
+}
+
+.search-bar__submit {
+  flex: 0 0 auto;
+  padding: 0 14px;
+}
+
+.search-bar__submit:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.search-bar__own-profile:hover,
+.search-bar__submit:not(:disabled):hover {
+  background: #0e7490;
+}
+
+.search-bar__own-profile:focus-visible,
+.search-bar__submit:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
 .search-bar__samples.hidden {
   opacity: 0;
   pointer-events: none;
@@ -4487,6 +4568,137 @@ body {
   font-size: 10px;
 }
 
+.repository-agents {
+  margin: 0 0 24px;
+  padding: 16px;
+  border: 1px solid rgba(46, 164, 79, 0.3);
+  border-left: 3px solid #2ea44f;
+  border-radius: 8px;
+  background: var(--overlay-subtle);
+}
+
+.repository-agents__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.repository-agents__heading span {
+  display: block;
+  margin-bottom: 3px;
+  color: #4ade80;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.repository-agents__heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.repository-agents__heading strong {
+  flex: 0 0 auto;
+  color: #4ade80;
+  font-size: 10px;
+}
+
+.repository-agents__status,
+.repository-agents__note {
+  margin: 11px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.repository-agents__signals {
+  display: grid;
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.repository-agents__signals details {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-card);
+}
+
+.repository-agents__signals summary {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.repository-agents__signals summary small {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 500;
+}
+
+.repository-agents__signals ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0 10px 10px;
+  list-style: none;
+}
+
+.repository-agents__signals li {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.repository-agents__signals a {
+  color: #4ade80;
+  font-size: 10px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.repository-agents__signals li span {
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font-family: monospace;
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.repository-agents__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 11px;
+  color: #fca5a5;
+  font-size: 11px;
+}
+
+.repository-agents__error button {
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  border-radius: 6px;
+  background: transparent;
+  color: #fca5a5;
+  cursor: pointer;
+}
+
+.repository-agents :is(summary, a, button):focus-visible {
+  outline: 2px solid #4ade80;
+  outline-offset: 2px;
+}
+
 .opportunity-signal {
   display: grid;
   gap: 9px;
@@ -5592,7 +5804,7 @@ body {
 
 .loading-indicator {
   position: fixed;
-  top: 108px;
+  bottom: 20px;
   left: 50%;
   z-index: 94;
   display: flex;
@@ -5795,7 +6007,7 @@ body {
   }
   .search-bar__inner {
     display: grid;
-    grid-template-columns: 18px minmax(0, 1fr) auto auto;
+    grid-template-columns: 18px minmax(0, 1fr) auto auto auto;
     width: 100%;
     gap: 6px 8px;
     padding: 8px 10px;
@@ -5807,7 +6019,7 @@ body {
     grid-row: 1;
   }
   .search-bar__inner input {
-    grid-column: 2 / -1;
+    grid-column: 2 / 5;
     grid-row: 1;
     width: 100%;
     min-width: 0;
@@ -5820,6 +6032,12 @@ body {
     grid-column: 4;
     grid-row: 1;
   }
+  .search-bar__submit {
+    grid-column: 5;
+    grid-row: 1;
+    min-height: 44px;
+    padding: 0 10px;
+  }
   .search-bar__inner select:first-of-type {
     grid-column: 1 / 3;
     grid-row: 2;
@@ -5831,7 +6049,7 @@ body {
     justify-self: start;
   }
   .search-bar__features {
-    grid-column: 4;
+    grid-column: 4 / 6;
     grid-row: 2;
     margin-left: 0;
     padding-left: 6px;

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -27,7 +27,7 @@ test('allows only documented engagement properties and never stores search text'
 });
 
 test('accepts privacy-safe daily mission funnel events without a target profile', () => {
-  for (const eventName of ['mission_viewed', 'mission_accepted', 'mission_passed', 'mission_completed', 'mission_unavailable', 'mission_exhausted', 'mission_preview_requested', 'mission_preview_shown', 'mission_preview_signin_selected', 'mission_onboarding_completed']) {
+  for (const eventName of ['activation_started', 'activation_action_selected', 'mission_viewed', 'mission_accepted', 'mission_passed', 'mission_completed', 'mission_unavailable', 'mission_exhausted', 'mission_preview_requested', 'mission_preview_shown', 'mission_preview_signin_selected', 'mission_onboarding_completed']) {
     assert.deepEqual(normalizeEngagementEvent({
       eventName,
       properties: { journey: 'daily_mission', issueTitle: 'private issue text' },
@@ -183,7 +183,7 @@ test('suppresses each low-volume mission metric and counts recovered availabilit
   assert.equal(metrics.availabilityRate, 1);
 });
 
-test('requires a target profile for a completed claim', () => {
+test('requires a target profile for completed profile activation events', () => {
   assert.deepEqual(normalizeEngagementEvent({
     eventName: 'profile_claimed',
     targetLogin: 'OctoCat',
@@ -194,4 +194,7 @@ test('requires a target profile for a completed claim', () => {
     properties: { source: 'linkedin' },
   });
   assert.throws(() => normalizeEngagementEvent({ eventName: 'profile_claimed' }), EngagementValidationError);
+  assert.throws(() => normalizeEngagementEvent({ eventName: 'personalized_profile_viewed' }), EngagementValidationError);
+  assert.throws(() => normalizeEngagementEvent({ eventName: 'activation_completed' }), EngagementValidationError);
+  assert.equal(normalizeEngagementEvent({ eventName: 'activation_completed', targetLogin: 'OctoCat' }).targetLogin, 'octocat');
 });

--- a/tests/repository-agent-signals.test.js
+++ b/tests/repository-agent-signals.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRepositoryAgentSignalsHandler } from '../app/api/repository-agent-signals/route.js';
+import {
+  detectRepositoryAgentSignals,
+  isValidGitHubLogin,
+  MAX_AGENT_SIGNAL_PATHS,
+  MAX_AGENT_SIGNAL_REPOSITORIES,
+} from '../lib/repository-agent-signals.js';
+
+test('detects agent configuration paths without reading repository content', () => {
+  const signals = detectRepositoryAgentSignals([{
+    fullName: 'octocat/hello-world',
+    paths: [
+      'README.md',
+      '.github/copilot-instructions.md',
+      '.github/agents/reviewer.agent.md',
+      'CLAUDE.md',
+      '.cursor/rules/project.mdc',
+      'packages/api/AGENTS.md',
+      'GEMINI.md',
+    ],
+  }]);
+
+  assert.deepEqual(signals.map(signal => signal.id), [
+    'claude-code',
+    'cursor',
+    'custom-agent',
+    'gemini-cli',
+    'github-copilot',
+  ]);
+  assert.equal(signals.find(signal => signal.id === 'github-copilot').repositories[0].paths.length, 2);
+  assert.equal(JSON.stringify(signals).includes('content'), false);
+});
+
+test('deduplicates evidence and enforces repository and path bounds', () => {
+  const repositories = Array.from({ length: MAX_AGENT_SIGNAL_REPOSITORIES + 3 }, (_, index) => ({
+    fullName: `owner/repository-${index}`,
+    paths: Array.from({ length: MAX_AGENT_SIGNAL_PATHS + 3 }, (__, pathIndex) => `.github/agents/agent-${pathIndex}.agent.md`),
+  }));
+  const [signal] = detectRepositoryAgentSignals(repositories);
+
+  assert.equal(signal.repositories.length, MAX_AGENT_SIGNAL_REPOSITORIES);
+  assert.equal(signal.repositories[0].paths.length, MAX_AGENT_SIGNAL_PATHS);
+});
+
+test('validates GitHub logins before making upstream requests', () => {
+  assert.equal(isValidGitHubLogin('octocat'), true);
+  assert.equal(isValidGitHubLogin('valid-login-2'), true);
+  assert.equal(isValidGitHubLogin('-invalid'), false);
+  assert.equal(isValidGitHubLogin('owner/repository'), false);
+});
+
+test('API scans bounded public owner repositories and caches path evidence', async () => {
+  let calls = 0;
+  const handler = createRepositoryAgentSignalsHandler({
+    cache: new Map(),
+    token: 'test-token',
+    fetchImpl: async url => {
+      calls += 1;
+      if (String(url).includes('/users/')) return Response.json([
+        { full_name: 'octocat/agents', default_branch: 'main', private: false, fork: false, archived: false },
+        { full_name: 'octocat/fork', default_branch: 'main', private: false, fork: true, archived: false },
+      ]);
+      return Response.json({ tree: [
+        { type: 'blob', path: 'CLAUDE.md' },
+        { type: 'blob', path: '.github/copilot-instructions.md' },
+        { type: 'blob', path: 'src/index.js' },
+      ] });
+    },
+  });
+  const request = new Request('https://www.devglobe.dev/api/repository-agent-signals?login=OctoCat');
+  const response = await handler(request);
+  const body = await response.json();
+  await handler(request);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('cache-control'), 'public, s-maxage=604800, stale-while-revalidate=86400');
+  assert.equal(body.login, 'octocat');
+  assert.equal(body.scannedRepositories, 1);
+  assert.deepEqual(body.signals.map(signal => signal.id), ['claude-code', 'github-copilot']);
+  assert.equal(calls, 2);
+});
+
+test('API rejects malformed usernames before GitHub lookup', async () => {
+  let called = false;
+  const handler = createRepositoryAgentSignalsHandler({ fetchImpl: async () => { called = true; } });
+  const response = await handler(new Request('https://www.devglobe.dev/api/repository-agent-signals?login=owner/repository'));
+
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).code, 'invalid_login');
+  assert.equal(called, false);
+});


### PR DESCRIPTION
## Summary
- focus the homepage on a measurable GitHub username activation flow
- detect agent configuration filenames in bounded public repository scans without reading file contents
- show repository evidence separately from self-declared AI tool usage
- pin the product adoption workbook to the production Application Insights resource

## Validation
- npm test (339 passed)
- npm run build
- mobile and desktop browser verification