### PR TITLE
Dismiss activation prompt while profile is open

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -804,6 +804,7 @@ export default function Home() {
         compareCount={compareDevs.length}
         signedIn={Boolean(user)}
         currentUsername={user?.login || ''}
+        profileOpen={Boolean(selectedDev)}
         onOpenOwnProfile={handleOpenOwnProfile}
         onOpenActivity={handleOpenActivity}
         showMissionPreview={false}

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -28,7 +28,7 @@ const SAMPLES_BY_MODE = {
   ],
 };
 
-export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0, signedIn = false, currentUsername = '', onOpenOwnProfile, onOpenActivity, showMissionPreview = true }) {
+export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0, signedIn = false, currentUsername = '', profileOpen = false, onOpenOwnProfile, onOpenActivity, showMissionPreview = true }) {
   const [query, setQuery] = useState('');
   const [mode, setMode] = useState('text');
   const [topN, setTopN] = useState(20);
@@ -206,7 +206,7 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
 
   return (
     <div className="search-bar" id="search-bar">
-      {!query && resultCount === null && (
+      {!profileOpen && !query && resultCount === null && (
         <div className="search-bar__activation">
           <span className="search-bar__eyebrow">Your open-source snapshot</span>
           <h2>{signedIn ? `Welcome back, @${currentUsername}` : 'See your open-source impact'}</h2>


### PR DESCRIPTION
## Summary
- hide the homepage activation introduction while a developer profile is open
- restore the introduction when the profile panel closes

## Validation
- signed-in browser flow: Open my profile -> prompt hidden -> close profile -> prompt restored
- npm run build