### PR TITLE
Promote deep links to developer and leaderboard stories

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -18,6 +18,7 @@ import SimilarDevelopersModal from '../components/SimilarDevelopersModal.jsx';
 import QuickTour from '../components/QuickTour.jsx';
 import PlatformActivityBanner from '../components/PlatformActivityBanner.jsx';
 import { prepareDeveloperDataset } from '../lib/developer-dataset.js';
+import { socialAttributionProperties } from '../lib/share-attribution.js';
 import { developerSnapshotUrl, publicApiUrl } from '../lib/public-api.js';
 import { resolveIdentityCardDeveloper } from '../lib/home-actions.js';
 import dynamic from 'next/dynamic';
@@ -600,14 +601,16 @@ export default function Home() {
   const deepLinkHandledRef = useRef(false);
   useEffect(() => {
     if (deepLinkHandledRef.current) return;
-    const login = new URLSearchParams(window.location.search).get('dev')?.trim();
+    const params = new URLSearchParams(window.location.search);
+    const login = params.get('dev')?.trim();
     if (!login || !/^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(login)) return;
+    const attribution = socialAttributionProperties(params);
 
     const existing = developers.find(candidate => candidate.login?.toLowerCase() === login.toLowerCase());
     if (existing) {
       deepLinkHandledRef.current = true;
       handleSelectDev(existing);
-      track('shared_profile_link_opened', { login: existing.login });
+      track('shared_profile_link_opened', { login: existing.login, ...attribution });
       return;
     }
 
@@ -619,7 +622,7 @@ export default function Home() {
         const developer = await response.json();
         if (developer?.login) {
           handleSelectDev(developer);
-          track('shared_profile_link_opened', { login: developer.login });
+          track('shared_profile_link_opened', { login: developer.login, ...attribution });
         }
       })
       .catch(() => {});

--- a/components/LeaderboardPage.jsx
+++ b/components/LeaderboardPage.jsx
@@ -16,6 +16,7 @@ import {
   LEADERBOARD_PERIODS,
 } from '../lib/leaderboard-movement.js';
 import { SCORE_METHODOLOGY } from '../lib/scoring.js';
+import { buildDeveloperStory, DEVELOPER_STORY_TYPES } from '../lib/share-attribution.js';
 import LeaderboardActivityRibbon from './LeaderboardActivityRibbon.jsx';
 import LeaderboardTrust from './LeaderboardTrust.jsx';
 
@@ -52,6 +53,7 @@ export default function LeaderboardPage() {
   const [pendingLookup, setPendingLookup] = useState('');
   const [locatedLogin, setLocatedLogin] = useState('');
   const [lookupStatus, setLookupStatus] = useState('');
+  const [shareStatus, setShareStatus] = useState('');
 
   useEffect(() => {
     try {
@@ -149,6 +151,7 @@ export default function LeaderboardPage() {
     if (!movementLogins) return undefined;
     const controller = new AbortController();
     setMovementStatus('loading');
+    setMovementResult(null);
     const params = new URLSearchParams({ days: String(period), logins: movementLogins });
     fetch(`/api/leaderboard/movement?${params}`, { signal: controller.signal })
       .then(async response => {
@@ -221,6 +224,32 @@ export default function LeaderboardPage() {
   function handleLookup(event) {
     event.preventDefault();
     locateDeveloper(lookup);
+  }
+
+  async function shareDeveloperStory(developer, rankMovement) {
+    const type = rankMovement?.status === 'up'
+      ? DEVELOPER_STORY_TYPES.RANK_MOVEMENT
+      : country && Number.isInteger(developer.countryRank)
+        ? DEVELOPER_STORY_TYPES.COUNTRY_LEADER
+        : DEVELOPER_STORY_TYPES.SPOTLIGHT;
+    const channel = navigator.share ? 'native_share' : 'copy_link';
+    const story = buildDeveloperStory({
+      siteUrl: window.location.origin,
+      developer,
+      type,
+      channel,
+      period,
+      movement: rankMovement?.delta,
+    });
+
+    try {
+      if (navigator.share) await navigator.share({ title: story.title, text: story.text, url: story.url });
+      else await navigator.clipboard.writeText(`${story.text}\n${story.url}`);
+      setShareStatus(`${developer.name || `@${developer.login}`} story ${navigator.share ? 'shared' : 'copied'}.`);
+      track('leaderboard_story_shared', { login: developer.login, channel, action: type });
+    } catch (error) {
+      if (error.name !== 'AbortError') setShareStatus('Unable to share this story.');
+    }
   }
 
   return (
@@ -409,6 +438,18 @@ export default function LeaderboardPage() {
                         </Link>
                         <span>@{developer.login}{developer.claimed ? ' / claimed' : ''}</span>
                       </div>
+                      <button
+                        type="button"
+                        className="leaderboard-board__share"
+                        onClick={() => shareDeveloperStory(developer, movementUnavailable ? null : rankMovement)}
+                        aria-label={`Share ${developer.name || developer.login}'s leaderboard story`}
+                        title="Share leaderboard story"
+                      >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                          <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+                          <path d="m8.6 10.5 6.8-4M8.6 13.5l6.8 4" />
+                        </svg>
+                      </button>
                     </td>
                     <td data-label="Location">
                       <strong>{developer.location || 'Location unknown'}</strong>
@@ -434,6 +475,7 @@ export default function LeaderboardPage() {
                 ))}
               </tbody>
             </table>
+            <span className="visually-hidden" role="status" aria-live="polite">{shareStatus}</span>
             {locatedIndex < 0 && visible.length < ranked.length && (
               <button
                 type="button"

--- a/docs/growth-attribution.md
+++ b/docs/growth-attribution.md
@@ -19,6 +19,12 @@ union actions, arrivals
 
 Compare referral arrivals, profile views, card generations, shares, and claims seven days after each distribution change. The weekly spotlight workflow produces a review-only artifact every Monday; publishing remains a human decision.
 
+## Social developer stories
+
+Developer spotlights, country leaderboard stories, and rank-movement stories link to the canonical `/share/<login>` preview with `utm_source`, `utm_medium`, `utm_campaign`, and `utm_content`. Only public profile and ranking fields are used in generated copy. Opening the attributed developer panel records `social_profile_opened` with the target login, source, and campaign journey; arbitrary query fields are not retained.
+
+Measure the seven-day social landing-to-profile conversion as unique sessions with `social_profile_opened` divided by unique sessions landing on `/share/` with a social story campaign. The product target is at least 10%.
+
 ## Weekly impact email
 
 Weekly impact emails use `utm_source=weekly_digest`, `utm_medium=email`, and `utm_campaign=weekly_impact`. An arrival records the privacy-safe `weekly_digest_returned` event with only the update type, journey, and source. The product adoption workbook compares seven-day return sessions with provider-accepted messages and reports progress toward the 20% return-rate target.

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -20,6 +20,8 @@ const ENGAGEMENT_EVENT_MAP = {
 	next_action_selected: 'next_action_selected',
 	profile_primary_action_viewed: 'profile_primary_action_viewed',
 	profile_viewed: 'profile_viewed',
+	shared_profile_link_opened: 'social_profile_opened',
+	leaderboard_story_shared: 'profile_shared',
 	personalized_profile_viewed: 'personalized_profile_viewed',
 	recommendation_opened: 'recommendation_opened',
 	session_restored: 'session_restored',

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -25,6 +25,7 @@ export const ENGAGEMENT_EVENTS = new Set([
   'recommendation_opened',
   'search_appearance',
   'session_restored',
+  'social_profile_opened',
   'weekly_digest_returned',
 ]);
 
@@ -67,7 +68,7 @@ export function normalizeEngagementEvent(input) {
   const eventName = String(input?.eventName || '').trim();
   if (!ENGAGEMENT_EVENTS.has(eventName)) throw new EngagementValidationError('Unsupported engagement event');
   const targetLogin = normalizeTargetLogin(input.targetLogin);
-  if (['activation_completed', 'card_generated', 'personalized_profile_viewed', 'profile_claimed', 'profile_primary_action_viewed', 'profile_shared', 'profile_viewed', 'search_appearance'].includes(eventName) && !targetLogin) {
+  if (['activation_completed', 'card_generated', 'personalized_profile_viewed', 'profile_claimed', 'profile_primary_action_viewed', 'profile_shared', 'profile_viewed', 'search_appearance', 'social_profile_opened'].includes(eventName) && !targetLogin) {
     throw new EngagementValidationError('Target login is required');
   }
   return { eventName, targetLogin, properties: normalizeProperties(input.properties) };
@@ -83,7 +84,7 @@ export function createEngagementEvent(input, options = {}) {
   const privacyHash = createHmac('sha256', secret).update(`privacy:${options.privacyKey || 'unknown'}`).digest('base64url');
   const window = Math.floor(now.getTime() / ENGAGEMENT_DEDUPLICATION_MS);
   const qualifier = normalized.eventName === 'profile_shared'
-    ? normalized.properties.channel || ''
+    ? [normalized.properties.channel || '', normalized.properties.action || ''].join(':')
     : ['next_action_selected', 'profile_primary_action_viewed'].includes(normalized.eventName)
       ? normalized.properties.action || ''
       : normalized.eventName === 'recommendation_opened'

--- a/lib/share-attribution.js
+++ b/lib/share-attribution.js
@@ -1,5 +1,18 @@
 const CAMPAIGN = 'identity_card';
-const TRACKING_KEYS = ['utm_source', 'utm_medium', 'utm_campaign'];
+const TRACKING_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content'];
+const SOCIAL_SOURCES = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
+const SOCIAL_CAMPAIGNS = new Set(['country_leaderboard', 'developer_spotlight', 'identity_card', 'india_top_50', 'rank_movement']);
+
+export const DEVELOPER_STORY_TYPES = Object.freeze({
+  SPOTLIGHT: 'developer_spotlight',
+  COUNTRY_LEADER: 'country_leaderboard',
+  RANK_MOVEMENT: 'rank_movement',
+});
+
+function cleanText(value, fallback, maxLength = 48) {
+  const text = String(value || '').trim();
+  return (text || fallback).slice(0, maxLength);
+}
 
 function trackingParams(params = {}) {
   return TRACKING_KEYS.reduce((result, key) => {
@@ -25,6 +38,50 @@ export function developerInviteUrl(siteUrl, login, channel) {
   url.searchParams.set('utm_medium', 'referral');
   url.searchParams.set('utm_campaign', 'developer_invite');
   return url.toString();
+}
+
+export function buildDeveloperStory({ siteUrl, developer, type, channel = 'copy_link', period = 7, movement = 0 } = {}) {
+  const login = cleanText(developer?.login, '', 39);
+  if (!/^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(login)) throw new TypeError('A valid developer login is required');
+  if (!Object.values(DEVELOPER_STORY_TYPES).includes(type)) throw new TypeError('A supported developer story type is required');
+
+  const name = cleanText(developer?.name, `@${login}`);
+  const language = cleanText(developer?.topLanguage, 'open source', 28);
+  const country = cleanText(developer?.country || developer?.location, 'their country', 36);
+  const globalRank = Number.isInteger(developer?.globalRank) ? developer.globalRank : null;
+  const countryRank = Number.isInteger(developer?.countryRank) ? developer.countryRank : null;
+  const safePeriod = [7, 30, 90].includes(Number(period)) ? Number(period) : 7;
+  const safeMovement = Number.isInteger(movement) && movement > 0 ? movement : 0;
+  const rankText = globalRank ? `global #${globalRank}` : 'ranked on DevGlobe';
+  const content = {
+    [DEVELOPER_STORY_TYPES.SPOTLIGHT]: {
+      title: `${name} on DevGlobe`,
+      text: `Developer spotlight: ${name} (@${login}) builds with ${language} and is ${rankText}.`,
+    },
+    [DEVELOPER_STORY_TYPES.COUNTRY_LEADER]: {
+      title: `${name} on the ${country} leaderboard`,
+      text: `${country} leaderboard: ${name} (@${login}) is ${countryRank ? `#${countryRank}` : 'a ranked developer'} and ${rankText}.`,
+    },
+    [DEVELOPER_STORY_TYPES.RANK_MOVEMENT]: {
+      title: `${name} is moving up on DevGlobe`,
+      text: `${name} (@${login}) moved up ${safeMovement || 'the'} ${safeMovement === 1 ? 'place' : 'places'} to ${rankText} in ${safePeriod} days.`,
+    },
+  }[type];
+  const url = new URL(`/share/${encodeURIComponent(login)}`, siteUrl);
+  url.searchParams.set('utm_source', cleanText(channel, 'copy_link', 40));
+  url.searchParams.set('utm_medium', channel === 'copy_link' ? 'referral' : 'social');
+  url.searchParams.set('utm_campaign', type);
+  url.searchParams.set('utm_content', login.toLowerCase());
+  return { ...content, type, url: url.toString() };
+}
+
+export function socialAttributionProperties(params) {
+  const source = String(params?.get?.('utm_source') || '').trim().toLowerCase();
+  const journey = String(params?.get?.('utm_campaign') || '').trim().toLowerCase();
+  return {
+    source: SOCIAL_SOURCES.has(source) ? source : 'direct',
+    journey: SOCIAL_CAMPAIGNS.has(journey) ? journey : 'shared_profile',
+  };
 }
 
 export function attributedGlobePath(login, params = {}) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -2291,7 +2291,47 @@ body {
 }
 
 .leaderboard-board__developer div {
+  flex: 1 1 auto;
   min-width: 0;
+}
+
+.leaderboard-board__share {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  flex: 0 0 44px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--board-muted);
+  cursor: pointer;
+}
+
+.leaderboard-board__share:hover,
+.leaderboard-board__share:focus-visible {
+  border-color: var(--board-cyan);
+  color: var(--board-cyan);
+  outline-offset: 2px;
+}
+
+.leaderboard-board__share svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  white-space: nowrap !important;
 }
 
 .leaderboard-board__developer a {

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -67,6 +67,28 @@ test('preserves distinct share channels while deduplicating retries', () => {
   assert.notEqual(linkedIn.id, copied.id);
 });
 
+test('preserves distinct leaderboard story types on the same share channel', () => {
+  const options = { session: 'session', secret: 'secret', now: '2026-08-21T10:05:00.000Z' };
+  const spotlight = createEngagementEvent({ eventName: 'profile_shared', targetLogin: 'octocat', properties: { channel: 'copy_link', action: 'developer_spotlight' } }, options);
+  const movement = createEngagementEvent({ eventName: 'profile_shared', targetLogin: 'octocat', properties: { channel: 'copy_link', action: 'rank_movement' } }, options);
+
+  assert.notEqual(spotlight.id, movement.id);
+});
+
+test('accepts attributed social profile opens without arbitrary campaign data', () => {
+  const event = normalizeEngagementEvent({
+    eventName: 'social_profile_opened',
+    targetLogin: 'OctoCat',
+    properties: { source: 'reddit', journey: 'rank_movement', utmContent: 'private-value' },
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'social_profile_opened',
+    targetLogin: 'octocat',
+    properties: { source: 'reddit', journey: 'rank_movement' },
+  });
+});
+
 test('accepts only signed server sessions and replaces forged cookies', () => {
   const created = resolveEngagementSession('', 'secret', () => 'server-id');
   const restored = resolveEngagementSession(created.cookieValue, 'secret', () => 'unused');

--- a/tests/share-attribution.test.js
+++ b/tests/share-attribution.test.js
@@ -1,6 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { attributedGlobePath, developerInviteUrl, identityCardShareUrl } from '../lib/share-attribution.js';
+import {
+  attributedGlobePath,
+  buildDeveloperStory,
+  developerInviteUrl,
+  DEVELOPER_STORY_TYPES,
+  identityCardShareUrl,
+  socialAttributionProperties,
+} from '../lib/share-attribution.js';
 
 test('builds channel-specific identity card referral URLs', () => {
   const linkedIn = new URL(identityCardShareUrl('https://www.devglobe.dev', 'octo cat', 'linkedin', '4'));
@@ -38,4 +45,62 @@ test('attributes member invitations without exposing identity outside ref', () =
   assert.equal(url.searchParams.get('utm_source'), 'native_share');
   assert.equal(url.searchParams.get('utm_medium'), 'referral');
   assert.equal(url.searchParams.get('utm_campaign'), 'developer_invite');
+});
+
+test('builds canonical public developer spotlight stories with bounded attribution', () => {
+  const story = buildDeveloperStory({
+    siteUrl: 'https://www.devglobe.dev',
+    developer: { login: 'octocat', name: 'Octo Cat', topLanguage: 'TypeScript', globalRank: 12, email: 'private@example.com' },
+    type: DEVELOPER_STORY_TYPES.SPOTLIGHT,
+    channel: 'native_share',
+  });
+  const url = new URL(story.url);
+
+  assert.equal(url.pathname, '/share/octocat');
+  assert.equal(url.searchParams.get('utm_source'), 'native_share');
+  assert.equal(url.searchParams.get('utm_medium'), 'social');
+  assert.equal(url.searchParams.get('utm_campaign'), 'developer_spotlight');
+  assert.equal(url.searchParams.get('utm_content'), 'octocat');
+  assert.match(story.text, /TypeScript/);
+  assert.doesNotMatch(JSON.stringify(story), /private@example\.com/);
+});
+
+test('builds country and weekly movement stories from public rank fields', () => {
+  const developer = { login: 'octocat', name: 'Octo Cat', country: 'India', countryRank: 3, globalRank: 12 };
+  const country = buildDeveloperStory({ siteUrl: 'https://www.devglobe.dev', developer, type: DEVELOPER_STORY_TYPES.COUNTRY_LEADER });
+  const movement = buildDeveloperStory({
+    siteUrl: 'https://www.devglobe.dev',
+    developer,
+    type: DEVELOPER_STORY_TYPES.RANK_MOVEMENT,
+    period: 7,
+    movement: 4,
+  });
+
+  assert.match(country.text, /India leaderboard.*#3/);
+  assert.match(movement.text, /moved up 4 places.*7 days/);
+});
+
+test('preserves story attribution but drops arbitrary share-page query fields', () => {
+  const path = attributedGlobePath('octocat', {
+    utm_source: 'reddit',
+    utm_medium: 'social',
+    utm_campaign: 'rank_movement',
+    utm_content: 'octocat',
+    email: 'do-not-forward@example.com',
+  });
+  const url = new URL(path, 'https://www.devglobe.dev');
+
+  assert.equal(url.searchParams.get('utm_content'), 'octocat');
+  assert.equal(url.searchParams.has('email'), false);
+});
+
+test('allow-lists social attribution values before telemetry', () => {
+  assert.deepEqual(socialAttributionProperties(new URLSearchParams({
+    utm_source: 'reddit',
+    utm_campaign: 'rank_movement',
+  })), { source: 'reddit', journey: 'rank_movement' });
+  assert.deepEqual(socialAttributionProperties(new URLSearchParams({
+    utm_source: 'person@example.com',
+    utm_campaign: 'private campaign text',
+  })), { source: 'direct', journey: 'shared_profile' });
 });


### PR DESCRIPTION
## Summary
- add reusable, privacy-bounded developer spotlight, country leaderboard, and rank-movement stories
- expose an accessible share action on desktop and mobile leaderboard rows
- route stories through canonical preview pages and durably measure attributed profile opens

## Validation
- npm test (360 passed)
- npm run build (70/70 pages)
- focused story and engagement tests (29 passed)
- desktop/mobile browser validation at 390px with no horizontal overflow
- git diff --check

Closes #348