### PR TITLE
Add attributed profile card referral loop

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -247,7 +247,7 @@ export default function Home() {
           return { ok: false, ...result };
         }
         setClaimStatus('claimed');
-        const source = new URLSearchParams(window.location.search).get('utm_source') || 'direct';
+        const source = socialAttributionProperties(new URLSearchParams(window.location.search)).source;
         track('claim_completed', { login: user.login, source });
         setClaimedLogins(prev => new Set(prev).add(user.login));
         let claimedDeveloper = developers.find(developer => developer.login === user.login);

--- a/app/share/[login]/page.jsx
+++ b/app/share/[login]/page.jsx
@@ -1,16 +1,16 @@
 import { getSiteUrl, SOCIAL_PREVIEW_VERSION } from '../../../lib/site.js';
-import { attributedGlobePath } from '../../../lib/share-attribution.js';
+import { attributedGlobePath, normalizeDeveloperLogin } from '../../../lib/share-attribution.js';
 import SharePageActions from '../../../components/SharePageActions.jsx';
 
 export const revalidate = 86400;
 
 export async function generateMetadata({ params }) {
-  const { login } = await params;
+  const login = normalizeDeveloperLogin((await params).login);
   const siteUrl = getSiteUrl();
   const encodedLogin = encodeURIComponent(login);
   const title = `@${login}'s Developer Card | DevGlobe`;
   const description = `Explore @${login}'s open-source developer identity, global rank, and impact on DevGlobe.`;
-  const pageUrl = `${siteUrl}/share/${encodedLogin}?v=${SOCIAL_PREVIEW_VERSION}`;
+  const pageUrl = `${siteUrl}/share/${encodedLogin}`;
   const imageUrl = `${siteUrl}/api/preview/v${SOCIAL_PREVIEW_VERSION}/${encodedLogin}.png`;
 
   return {
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }) {
 }
 
 export default async function DeveloperSharePage({ params, searchParams }) {
-  const { login } = await params;
+  const login = normalizeDeveloperLogin((await params).login);
   const tracking = await searchParams;
   const encodedLogin = encodeURIComponent(login);
   const siteUrl = getSiteUrl();

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -12,7 +12,7 @@ import { AI_TOOLS } from '../lib/ai-profile.js';
 import { publicApiUrl } from '../lib/public-api.js';
 import { resolveReadmeAccess } from '../lib/profile-readme.js';
 import { PROFILE_PRIMARY_ACTIONS, resolveProfilePrimaryAction } from '../lib/profile-primary-action.js';
-import { identityCardShareUrl } from '../lib/share-attribution.js';
+import { identityCardShareUrl, socialAttributionProperties } from '../lib/share-attribution.js';
 import SpecialTags from './SpecialTags.jsx';
 import ReadmeGeneratorModal from './ReadmeGeneratorModal.jsx';
 import RepositoryAgentSignals from './RepositoryAgentSignals.jsx';
@@ -31,7 +31,7 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
   const primaryActionRecordedRef = useRef('');
 
   useEffect(() => {
-    const source = new URLSearchParams(window.location.search).get('utm_source') || 'direct';
+    const source = socialAttributionProperties(new URLSearchParams(window.location.search)).source;
     track('profile_viewed', { login: dev.login, source });
   }, [dev.login]);
 
@@ -444,7 +444,8 @@ function AiCollaborationProfile({ dev, profile }) {
 
   const shareAgentProfile = async () => {
     const tools = profile.tools.map(tool => toolNames.get(tool.id) || tool.id).join(' · ');
-    const url = `${window.location.origin}/share/${encodeURIComponent(dev.login)}`;
+    const channel = navigator.share ? 'native_share' : 'copy_link';
+    const url = identityCardShareUrl(window.location.origin, dev.login, channel, SOCIAL_PREVIEW_VERSION);
     const text = `${dev.name || `@${dev.login}`} is open to verified AI agent collaborations on DevGlobe.${tools ? ` ${tools}.` : ''}`;
     try {
       if (navigator.share) {
@@ -454,7 +455,7 @@ function AiCollaborationProfile({ dev, profile }) {
         await navigator.clipboard.writeText(`${text}\n${url}`);
         setShareStatus('Copied');
       }
-      track('agent_profile_shared', { login: dev.login });
+      track('agent_profile_shared', { login: dev.login, channel });
     } catch (error) {
       if (error.name !== 'AbortError') setShareStatus('Unable to share');
     }
@@ -843,10 +844,11 @@ function CardModal({ dev, claimSuccess, onClose }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [captionCopiedFor, setCaptionCopiedFor] = useState('');
+  const [shareStatus, setShareStatus] = useState('');
   const { login } = dev;
   const name = dev.name || login;
   const cardUrl = `/api/card?login=${encodeURIComponent(login)}&v=${IDENTITY_CARD_VERSION}`;
-  const shareUrls = Object.fromEntries(['copy_link', 'twitter', 'facebook', 'linkedin', 'reddit']
+  const shareUrls = Object.fromEntries(['copy_link', 'x', 'facebook', 'linkedin', 'reddit']
     .map(channel => [channel, identityCardShareUrl(getSiteUrl(), login, channel, SOCIAL_PREVIEW_VERSION)]));
 
   const rankText = dev.globalRank ? `Global #${dev.globalRank} of ${dev.globalTotal}` : 'Ranked on DevGlobe';
@@ -858,7 +860,7 @@ function CardModal({ dev, claimSuccess, onClose }) {
   const facebookCaption = `Open-source work tells a richer story than a job title.\n\nDevGlobe mapped my public contributions into a developer identity that helps teams, communities, and AI agents discover what I build and where I can contribute.\n\n${agent.name} · ${rankText}\n\nExplore my profile and create yours.\n\n${hashtagText}`;
 
   const shareLinks = {
-    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterCaption)}&url=${encodeURIComponent(shareUrls.twitter)}`,
+    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterCaption)}&url=${encodeURIComponent(shareUrls.x)}`,
     facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrls.facebook)}`,
     linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrls.linkedin)}`,
     reddit: `https://reddit.com/submit?url=${encodeURIComponent(shareUrls.reddit)}&title=${encodeURIComponent(`${name}'s open-source developer identity on DevGlobe - ${agent.name}, ${rankText}`)}`,
@@ -886,12 +888,29 @@ function CardModal({ dev, claimSuccess, onClose }) {
   };
 
   const handleCopyLink = async () => {
-    await navigator.clipboard.writeText(shareUrls.copy_link);
-    track('identity_card_shared', { login, channel: 'copy_link' });
+    try {
+      await navigator.clipboard.writeText(shareUrls.copy_link);
+      setShareStatus('Card link copied');
+      track('identity_card_shared', { login, channel: 'copy_link' });
+    } catch {
+      setShareStatus('Unable to copy link');
+    }
+  };
+
+  const handleNativeShare = async () => {
+    try {
+      if (!navigator.share) return handleCopyLink();
+      await navigator.share({ title: `${name}'s developer card`, text: `Explore ${name}'s open-source developer identity on DevGlobe.`, url: identityCardShareUrl(getSiteUrl(), login, 'native_share', SOCIAL_PREVIEW_VERSION) });
+      setShareStatus('Card shared');
+      track('identity_card_shared', { login, channel: 'native_share' });
+    } catch (shareError) {
+      if (shareError.name !== 'AbortError') setShareStatus('Unable to share card');
+    }
   };
 
   const handleLinkedInShare = () => {
     navigator.clipboard?.writeText(linkedinCaption).then(() => setCaptionCopiedFor('LinkedIn')).catch(() => {});
+    setShareStatus('Opening LinkedIn');
     track('identity_card_shared', { login, channel: 'linkedin' });
     window.open(shareLinks.linkedin, '_blank', 'noopener,noreferrer');
   };
@@ -900,6 +919,7 @@ function CardModal({ dev, claimSuccess, onClose }) {
     if (channel === 'facebook') {
       navigator.clipboard?.writeText(facebookCaption).then(() => setCaptionCopiedFor('Facebook')).catch(() => {});
     }
+    setShareStatus(`Opening ${channel === 'x' ? 'X' : channel[0].toUpperCase() + channel.slice(1)}`);
     track('identity_card_shared', { login, channel });
   };
 
@@ -965,6 +985,14 @@ function CardModal({ dev, claimSuccess, onClose }) {
             </svg>
             Copy Link
           </button>
+          <button className="card-modal__btn card-modal__btn--copy" onClick={handleNativeShare}>
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+              <path d="m8.6 10.5 6.8-4M8.6 13.5l6.8 4" />
+            </svg>
+            Share
+          </button>
+          <span className="card-modal__action-status" role="status" aria-live="polite">{shareStatus}</span>
         </div>
 
         <div className="card-modal__share">
@@ -977,7 +1005,7 @@ function CardModal({ dev, claimSuccess, onClose }) {
               <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
             </svg>
           </button>
-          <a href={shareLinks.twitter} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--twitter" title="Share on X/Twitter" onClick={() => handleSocialShare('twitter')}>
+          <a href={shareLinks.twitter} target="_blank" rel="noreferrer" className="card-modal__social card-modal__social--twitter" title="Share on X" aria-label="Share on X" onClick={() => handleSocialShare('x')}>
             <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor">
               <path d="M13.5 1h-3.7L8 3.6 6.2 1H2.5L6.6 6.5 2.3 13h1.7l2.5-3.2L9 13h4.2l-4.5-6.7L13.5 1zm-1.1 11h-1L4.5 2h1l6.9 10z" />
             </svg>

--- a/components/DeveloperActivityPage.jsx
+++ b/components/DeveloperActivityPage.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { track } from '../lib/analytics.js';
 import { formatNum, formatRelativeTime } from '../lib/format.js';
 import { publicApiUrl } from '../lib/public-api.js';
+import { socialAttributionProperties } from '../lib/share-attribution.js';
 import { useActivityFeed } from './useActivityFeed.js';
 import SpecialTags from './SpecialTags.jsx';
 import ImpactHistoryPanel from './ImpactHistoryPanel.jsx';
@@ -21,7 +22,7 @@ export default function DeveloperActivityPage({ login }) {
   } = useActivityFeed(login, { limit: 20 });
 
   useEffect(() => {
-    const source = new URLSearchParams(window.location.search).get('utm_source') || 'direct';
+    const source = socialAttributionProperties(new URLSearchParams(window.location.search)).source;
     track('site_visited', { source: source === 'direct' ? 'direct' : 'attributed', journey: 'developer_profile' });
     track('profile_viewed', { login, source });
   }, [login]);

--- a/components/SharePageActions.jsx
+++ b/components/SharePageActions.jsx
@@ -3,20 +3,24 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { track } from '../lib/analytics.js';
-import { identityCardShareUrl } from '../lib/share-attribution.js';
+import { identityCardShareUrl, socialAttributionProperties } from '../lib/share-attribution.js';
 
 export default function SharePageActions({ login, profilePath, createPath, previewVersion }) {
   const [shareStatus, setShareStatus] = useState('');
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    track('site_visited', { source: params.get('utm_source') ? 'attributed' : 'direct', journey: 'share_profile' });
-  }, []);
+    const attribution = socialAttributionProperties(params);
+    track('site_visited', { source: attribution.source, journey: 'share_profile' });
+    if (attribution.source !== 'direct') {
+      track('shared_profile_link_opened', { login, ...attribution });
+    }
+  }, [login]);
 
   async function shareCard() {
-    const url = identityCardShareUrl(window.location.origin, login, 'native_share', previewVersion);
     try {
       if (navigator.share) {
+        const url = identityCardShareUrl(window.location.origin, login, 'native_share', previewVersion);
         await navigator.share({
           title: `@${login}'s developer card`,
           text: `Explore @${login}'s open-source developer identity on DevGlobe.`,
@@ -25,6 +29,7 @@ export default function SharePageActions({ login, profilePath, createPath, previ
         setShareStatus('Shared');
         track('identity_card_shared', { login, channel: 'native_share' });
       } else {
+        const url = identityCardShareUrl(window.location.origin, login, 'copy_link', previewVersion);
         await navigator.clipboard.writeText(url);
         setShareStatus('Link copied');
         track('identity_card_shared', { login, channel: 'copy_link' });

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -38,6 +38,7 @@ export const INSIGHTS_PRIVACY_THRESHOLD = 3;
 const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
 const BOT_PATTERN = /bot|crawler|spider|preview|slurp|facebookexternalhit|linkedinbot|twitterbot|whatsapp|discordbot/i;
 const ALLOWED_PROPERTIES = new Set(['action', 'channel', 'journey', 'source']);
+const SHARE_CHANNELS = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
 
 export class EngagementValidationError extends Error {}
 
@@ -61,7 +62,8 @@ function normalizeProperties(value) {
   for (const [key, rawValue] of Object.entries(value)) {
     if (!ALLOWED_PROPERTIES.has(key)) continue;
     if (typeof rawValue !== 'string') throw new EngagementValidationError(`Invalid ${key}`);
-    const normalized = rawValue.trim().slice(0, 40);
+    let normalized = rawValue.trim().slice(0, 40);
+    if (key === 'channel' && !SHARE_CHANNELS.has(normalized)) normalized = 'other';
     if (normalized) properties[key] = normalized;
   }
   return properties;

--- a/lib/share-attribution.js
+++ b/lib/share-attribution.js
@@ -2,6 +2,8 @@ const CAMPAIGN = 'identity_card';
 const TRACKING_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content'];
 const SOCIAL_SOURCES = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
 const SOCIAL_CAMPAIGNS = new Set(['country_leaderboard', 'developer_spotlight', 'identity_card', 'india_top_50', 'rank_movement']);
+const SHARE_CHANNELS = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
+const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
 
 export const DEVELOPER_STORY_TYPES = Object.freeze({
   SPOTLIGHT: 'developer_spotlight',
@@ -14,20 +16,33 @@ function cleanText(value, fallback, maxLength = 48) {
   return (text || fallback).slice(0, maxLength);
 }
 
+export function normalizeDeveloperLogin(value) {
+  const login = cleanText(value, '', 39).toLowerCase();
+  if (!LOGIN_PATTERN.test(login)) throw new TypeError('A valid developer login is required');
+  return login;
+}
+
 function trackingParams(params = {}) {
-  return TRACKING_KEYS.reduce((result, key) => {
-    const value = params[key];
-    if (typeof value === 'string' && value.trim()) result.set(key, value.trim());
-    return result;
-  }, new URLSearchParams());
+  const sourceValue = String(params.utm_source || '').trim().toLowerCase();
+  const campaignValue = String(params.utm_campaign || '').trim().toLowerCase();
+  const contentValue = String(params.utm_content || '').trim().toLowerCase();
+  const source = SOCIAL_SOURCES.has(sourceValue) ? sourceValue : 'direct';
+  const campaign = SOCIAL_CAMPAIGNS.has(campaignValue) ? campaignValue : 'shared_profile';
+  const result = new URLSearchParams({ utm_source: source, utm_medium: source === 'copy_link' || source === 'share_page' ? 'referral' : 'social', utm_campaign: campaign });
+  if (LOGIN_PATTERN.test(contentValue)) result.set('utm_content', contentValue);
+  return result;
 }
 
 export function identityCardShareUrl(siteUrl, login, channel, version) {
-  const url = new URL(`/share/${encodeURIComponent(login)}`, siteUrl);
+  const targetLogin = normalizeDeveloperLogin(login);
+  const source = channel === 'twitter' ? 'x' : cleanText(channel, 'copy_link', 40).toLowerCase();
+  const safeSource = SHARE_CHANNELS.has(source) ? source : 'copy_link';
+  const url = new URL(`/share/${encodeURIComponent(targetLogin)}`, siteUrl);
   if (version) url.searchParams.set('v', version);
-  url.searchParams.set('utm_source', channel);
-  url.searchParams.set('utm_medium', channel === 'copy_link' ? 'referral' : 'social');
+  url.searchParams.set('utm_source', safeSource);
+  url.searchParams.set('utm_medium', safeSource === 'copy_link' ? 'referral' : 'social');
   url.searchParams.set('utm_campaign', CAMPAIGN);
+  url.searchParams.set('utm_content', targetLogin);
   return url.toString();
 }
 
@@ -86,7 +101,7 @@ export function socialAttributionProperties(params) {
 
 export function attributedGlobePath(login, params = {}) {
   const query = trackingParams(params);
-  if (login) query.set('dev', login);
+  if (login) query.set('dev', normalizeDeveloperLogin(login));
   const value = query.toString();
   return value ? `/?${value}` : '/';
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -8705,8 +8705,17 @@ body {
 
 .card-modal__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   margin-bottom: 20px;
+}
+
+.card-modal__action-status {
+  flex-basis: 100%;
+  min-height: 16px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
 }
 
 .card-modal__btn {
@@ -8721,6 +8730,7 @@ body {
   border: 1px solid var(--border);
   cursor: pointer;
   transition: background 0.15s, transform 0.1s;
+  min-height: 44px;
 }
 
 .card-modal__btn:hover {
@@ -8777,8 +8787,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   border: 1px solid var(--border);
   background: transparent;

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -273,3 +273,9 @@ test('accepts visitor and search funnel events without storing query text', () =
     });
   }
 });
+
+test('collapses unknown share channels before durable storage', () => {
+  const event = normalizeEngagementEvent({ eventName: 'profile_shared', targetLogin: 'octocat', properties: { channel: 'person@example.com' } });
+
+  assert.equal(event.properties.channel, 'other');
+});

--- a/tests/share-attribution.test.js
+++ b/tests/share-attribution.test.js
@@ -6,19 +6,32 @@ import {
   developerInviteUrl,
   DEVELOPER_STORY_TYPES,
   identityCardShareUrl,
+  normalizeDeveloperLogin,
   socialAttributionProperties,
 } from '../lib/share-attribution.js';
 
 test('builds channel-specific identity card referral URLs', () => {
-  const linkedIn = new URL(identityCardShareUrl('https://www.devglobe.dev', 'octo cat', 'linkedin', '4'));
+  const linkedIn = new URL(identityCardShareUrl('https://www.devglobe.dev', 'OctoCat', 'linkedin', '4'));
   const copied = new URL(identityCardShareUrl('https://www.devglobe.dev', 'octocat', 'copy_link', '4'));
 
-  assert.equal(linkedIn.pathname, '/share/octo%20cat');
+  assert.equal(linkedIn.pathname, '/share/octocat');
   assert.equal(linkedIn.searchParams.get('v'), '4');
   assert.equal(linkedIn.searchParams.get('utm_source'), 'linkedin');
   assert.equal(linkedIn.searchParams.get('utm_medium'), 'social');
   assert.equal(linkedIn.searchParams.get('utm_campaign'), 'identity_card');
+  assert.equal(linkedIn.searchParams.get('utm_content'), 'octocat');
   assert.equal(copied.searchParams.get('utm_medium'), 'referral');
+});
+
+test('bounds identity card channels and normalizes X referrals', () => {
+  const x = new URL(identityCardShareUrl('https://www.devglobe.dev', 'octocat', 'twitter', '5'));
+  const unknown = new URL(identityCardShareUrl('https://www.devglobe.dev', 'octocat', 'person@example.com', '5'));
+
+  assert.equal(x.searchParams.get('utm_source'), 'x');
+  assert.equal(x.searchParams.get('utm_medium'), 'social');
+  assert.equal(unknown.searchParams.get('utm_source'), 'copy_link');
+  assert.equal(unknown.searchParams.get('utm_medium'), 'referral');
+  assert.throws(() => identityCardShareUrl('https://www.devglobe.dev', '../private', 'copy_link', '5'), /valid developer login/);
 });
 
 test('preserves only campaign attribution when entering the globe', () => {
@@ -103,4 +116,25 @@ test('allow-lists social attribution values before telemetry', () => {
     utm_source: 'person@example.com',
     utm_campaign: 'private campaign text',
   })), { source: 'direct', journey: 'shared_profile' });
+});
+
+test('sanitizes hostile attribution before forwarding to the profile funnel', () => {
+  const path = attributedGlobePath('OctoCat', {
+    utm_source: 'person@example.com',
+    utm_medium: 'private text',
+    utm_campaign: 'secret campaign',
+    utm_content: '../private',
+  });
+  const url = new URL(path, 'https://www.devglobe.dev');
+
+  assert.equal(url.searchParams.get('dev'), 'octocat');
+  assert.equal(url.searchParams.get('utm_source'), 'direct');
+  assert.equal(url.searchParams.get('utm_medium'), 'social');
+  assert.equal(url.searchParams.get('utm_campaign'), 'shared_profile');
+  assert.equal(url.searchParams.has('utm_content'), false);
+});
+
+test('normalizes canonical developer logins', () => {
+  assert.equal(normalizeDeveloperLogin('OctoCat'), 'octocat');
+  assert.throws(() => normalizeDeveloperLogin('../private'), /valid developer login/);
 });


### PR DESCRIPTION
- canonical target-preserving identity-card URLs
- bounded source/channel/campaign attribution
- share-page referral-open telemetry
- copy/native/social feedback and 44px mobile controls
- canonical login normalization
- privacy protections

Validation:
- focused 29/29
- full 368/368
- production build 70/70
- desktop/mobile browser checks with no overflow and correct copy attribution

Closes #391