### PR TITLE
Close acquisition attribution gaps

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -18,7 +18,7 @@ import SimilarDevelopersModal from '../components/SimilarDevelopersModal.jsx';
 import QuickTour from '../components/QuickTour.jsx';
 import PlatformActivityBanner from '../components/PlatformActivityBanner.jsx';
 import { prepareDeveloperDataset } from '../lib/developer-dataset.js';
-import { socialAttributionProperties } from '../lib/share-attribution.js';
+import { acquisitionAttributionProperties, socialAttributionProperties } from '../lib/share-attribution.js';
 import { developerSnapshotUrl, publicApiUrl } from '../lib/public-api.js';
 import { resolveIdentityCardDeveloper } from '../lib/home-actions.js';
 import dynamic from 'next/dynamic';
@@ -77,8 +77,9 @@ export default function Home() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
+    const attribution = acquisitionAttributionProperties(params, { referrer: document.referrer, siteUrl: window.location.origin });
     track('site_visited', {
-      source: (params.get('utm_source') || document.referrer) ? 'attributed' : 'direct',
+      ...attribution,
       journey: 'homepage',
     });
   }, []);
@@ -111,7 +112,8 @@ export default function Home() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    if (params.get('utm_source') !== 'weekly_digest') return;
+    const attribution = acquisitionAttributionProperties(params);
+    if (attribution.source !== 'weekly_digest' || attribution.campaign !== 'weekly_impact') return;
     const destination = params.get('open');
     if (['introductions', 'contributions'].includes(destination)) {
       try {
@@ -119,9 +121,9 @@ export default function Home() {
       } catch { /* The attributed landing still works without session storage. */ }
     }
     track('weekly_digest_returned', {
-      action: params.get('utm_content') || 'unknown',
+      ...attribution,
+      action: attribution.action || 'unknown',
       journey: 'weekly_digest',
-      source: 'weekly_digest',
     });
   }, []);
 
@@ -247,8 +249,8 @@ export default function Home() {
           return { ok: false, ...result };
         }
         setClaimStatus('claimed');
-        const source = socialAttributionProperties(new URLSearchParams(window.location.search)).source;
-        track('claim_completed', { login: user.login, source });
+        const attribution = acquisitionAttributionProperties(new URLSearchParams(window.location.search));
+        track('claim_completed', { login: user.login, ...attribution });
         setClaimedLogins(prev => new Set(prev).add(user.login));
         let claimedDeveloper = developers.find(developer => developer.login === user.login);
         // If a new profile was created, reload developers to include it
@@ -618,7 +620,7 @@ export default function Home() {
     if (existing) {
       deepLinkHandledRef.current = true;
       handleSelectDev(existing);
-      track('shared_profile_link_opened', { login: existing.login, ...attribution });
+      if (attribution.source !== 'direct') track('shared_profile_link_opened', { login: existing.login, ...attribution });
       return;
     }
 
@@ -630,7 +632,7 @@ export default function Home() {
         const developer = await response.json();
         if (developer?.login) {
           handleSelectDev(developer);
-          track('shared_profile_link_opened', { login: developer.login, ...attribution });
+          if (attribution.source !== 'direct') track('shared_profile_link_opened', { login: developer.login, ...attribution });
         }
       })
       .catch(() => {});

--- a/components/DetailPanel.jsx
+++ b/components/DetailPanel.jsx
@@ -12,7 +12,7 @@ import { AI_TOOLS } from '../lib/ai-profile.js';
 import { publicApiUrl } from '../lib/public-api.js';
 import { resolveReadmeAccess } from '../lib/profile-readme.js';
 import { PROFILE_PRIMARY_ACTIONS, resolveProfilePrimaryAction } from '../lib/profile-primary-action.js';
-import { identityCardShareUrl, socialAttributionProperties } from '../lib/share-attribution.js';
+import { acquisitionAttributionProperties, attributedGlobePath, identityCardShareUrl } from '../lib/share-attribution.js';
 import SpecialTags from './SpecialTags.jsx';
 import ReadmeGeneratorModal from './ReadmeGeneratorModal.jsx';
 import RepositoryAgentSignals from './RepositoryAgentSignals.jsx';
@@ -31,8 +31,8 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
   const primaryActionRecordedRef = useRef('');
 
   useEffect(() => {
-    const source = socialAttributionProperties(new URLSearchParams(window.location.search)).source;
-    track('profile_viewed', { login: dev.login, source });
+    const attribution = acquisitionAttributionProperties(new URLSearchParams(window.location.search));
+    track('profile_viewed', { login: dev.login, ...attribution });
   }, [dev.login]);
 
   const recordCardGeneration = () => {
@@ -48,11 +48,16 @@ export default function DetailPanel({ dev, onClose, onCardGenerated, onReadmeGen
   };
 
   const handleCopyDeepLink = async () => {
-    const deepLink = `${getSiteUrl()}/?dev=${encodeURIComponent(dev.login)}`;
+    const deepLink = new URL(attributedGlobePath(dev.login, {
+      utm_source: 'copy_link',
+      utm_medium: 'referral',
+      utm_campaign: 'identity_card',
+      utm_content: dev.login,
+    }), getSiteUrl()).toString();
     try {
       await navigator.clipboard.writeText(deepLink);
       setDeepLinkCopied(true);
-      track('profile_link_copied', { login: dev.login });
+      track('profile_link_copied', { login: dev.login, channel: 'copy_link' });
       setTimeout(() => setDeepLinkCopied(false), 2000);
     } catch {
       // Clipboard access can fail (e.g. permissions); the button simply won't confirm.

--- a/components/DeveloperActivityPage.jsx
+++ b/components/DeveloperActivityPage.jsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { track } from '../lib/analytics.js';
 import { formatNum, formatRelativeTime } from '../lib/format.js';
 import { publicApiUrl } from '../lib/public-api.js';
-import { socialAttributionProperties } from '../lib/share-attribution.js';
+import { acquisitionAttributionProperties } from '../lib/share-attribution.js';
 import { useActivityFeed } from './useActivityFeed.js';
 import SpecialTags from './SpecialTags.jsx';
 import ImpactHistoryPanel from './ImpactHistoryPanel.jsx';
@@ -22,9 +22,9 @@ export default function DeveloperActivityPage({ login }) {
   } = useActivityFeed(login, { limit: 20 });
 
   useEffect(() => {
-    const source = socialAttributionProperties(new URLSearchParams(window.location.search)).source;
-    track('site_visited', { source: source === 'direct' ? 'direct' : 'attributed', journey: 'developer_profile' });
-    track('profile_viewed', { login, source });
+    const attribution = acquisitionAttributionProperties(new URLSearchParams(window.location.search), { referrer: document.referrer, siteUrl: window.location.origin });
+    track('site_visited', { ...attribution, journey: 'developer_profile' });
+    track('profile_viewed', { login, ...attribution });
   }, [login]);
 
   useEffect(() => {

--- a/components/LeaderboardPage.jsx
+++ b/components/LeaderboardPage.jsx
@@ -16,7 +16,7 @@ import {
   LEADERBOARD_PERIODS,
 } from '../lib/leaderboard-movement.js';
 import { SCORE_METHODOLOGY } from '../lib/scoring.js';
-import { buildDeveloperStory, DEVELOPER_STORY_TYPES } from '../lib/share-attribution.js';
+import { acquisitionAttributionProperties, buildDeveloperStory, DEVELOPER_STORY_TYPES } from '../lib/share-attribution.js';
 import LeaderboardActivityRibbon from './LeaderboardActivityRibbon.jsx';
 import LeaderboardTrust from './LeaderboardTrust.jsx';
 
@@ -57,7 +57,8 @@ export default function LeaderboardPage() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    track('site_visited', { source: params.get('utm_source') ? 'attributed' : 'direct', journey: 'leaderboard' });
+    const attribution = acquisitionAttributionProperties(params, { referrer: document.referrer, siteUrl: window.location.origin });
+    track('site_visited', { ...attribution, journey: 'leaderboard' });
   }, []);
 
   useEffect(() => {

--- a/components/SharePageActions.jsx
+++ b/components/SharePageActions.jsx
@@ -3,17 +3,18 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { track } from '../lib/analytics.js';
-import { identityCardShareUrl, socialAttributionProperties } from '../lib/share-attribution.js';
+import { acquisitionAttributionProperties, identityCardShareUrl, socialAttributionProperties } from '../lib/share-attribution.js';
 
 export default function SharePageActions({ login, profilePath, createPath, previewVersion }) {
   const [shareStatus, setShareStatus] = useState('');
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const attribution = socialAttributionProperties(params);
-    track('site_visited', { source: attribution.source, journey: 'share_profile' });
-    if (attribution.source !== 'direct') {
-      track('shared_profile_link_opened', { login, ...attribution });
+    const attribution = acquisitionAttributionProperties(params, { referrer: document.referrer, siteUrl: window.location.origin });
+    track('site_visited', { ...attribution, journey: 'share_profile' });
+    const socialAttribution = socialAttributionProperties(params);
+    if (socialAttribution.source !== 'direct') {
+      track('shared_profile_link_opened', { login, ...socialAttribution });
     }
   }, [login]);
 

--- a/docs/growth-attribution.md
+++ b/docs/growth-attribution.md
@@ -2,6 +2,34 @@
 
 Identity card shares and member invitations use `utm_source`, `utm_medium`, and `utm_campaign`. Review the rolling seven-day funnel in the Application Insights workspace with:
 
+## Campaign URL conventions
+
+Every distributed URL uses lowercase values from this bounded vocabulary. Do not put a login, email address, search phrase, referrer URL, or free-form campaign name in a UTM field.
+
+| Field | Allowed values |
+| --- | --- |
+| `utm_source` | `copy_link`, `facebook`, `linkedin`, `manual_outreach`, `native_share`, `reddit`, `share_page`, `weekly_digest`, `weekly_spotlight`, `x` |
+| `utm_medium` | `community`, `email`, `referral`, `social` |
+| `utm_campaign` | `agents`, `community`, `country_leaderboard`, `developer_activation`, `developer_invite`, `developer_spotlight`, `identity_card`, `india_top_50`, `product`, `rank_movement`, `weekly_impact` |
+| `utm_content` | A public GitHub login for profile stories, or `contribution_opportunity`, `introduction_request`, or `rank_movement` for the weekly digest |
+
+Unknown source, medium, and campaign values are recorded as `other`, `other`, and `unknown`. An untagged visit with a browser referrer is recorded as `external_referral` / `referral` / `organic_referral`; the referrer URL itself is never retained.
+
+Review bounded acquisition events by source, channel, and campaign with:
+
+```kusto
+AppEvents
+| where TimeGenerated >= ago(7d)
+| where Name in ("site_visited", "profile_viewed", "shared_profile_link_opened", "claim_completed", "weekly_digest_returned")
+| extend Source=tostring(Properties.source), Channel=tostring(Properties.channel), Campaign=tostring(Properties.campaign)
+| summarize Events=count(), Users=dcount(UserId), Sessions=dcount(SessionId) by Name, Source, Channel, Campaign
+| order by Events desc
+```
+
+Use the shared attribution helpers for generated URLs and arrival telemetry. Durable ingestion applies the same finite categories so direct API submissions cannot introduce unbounded dimensions.
+
+## Referral funnel
+
 ```kusto
 let window = 7d;
 let actions = AppEvents
@@ -21,9 +49,9 @@ Compare referral arrivals, profile views, card generations, shares, and claims s
 
 ## Social developer stories
 
-Developer spotlights, country leaderboard stories, and rank-movement stories link to the canonical `/share/<login>` preview with `utm_source`, `utm_medium`, `utm_campaign`, and `utm_content`. Only public profile and ranking fields are used in generated copy. Opening the attributed developer panel records `social_profile_opened` with the target login, source, and campaign journey; arbitrary query fields are not retained.
+Developer spotlights, country leaderboard stories, and rank-movement stories link to the canonical `/share/<login>` preview with `utm_source`, `utm_medium`, `utm_campaign`, and `utm_content`. Only public profile and ranking fields are used in generated copy. Opening the attributed developer panel records `referral_profile_opened` with the target login, source, and campaign journey; arbitrary query fields are not retained.
 
-Measure the seven-day social landing-to-profile conversion as unique sessions with `social_profile_opened` divided by unique sessions landing on `/share/` with a social story campaign. The product target is at least 10%.
+Measure the seven-day shared-link landing-to-profile conversion as unique sessions with `referral_profile_opened` divided by unique sessions landing on `/share/` with a sharing campaign. The product target is at least 10%.
 
 ## Weekly impact email
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -20,7 +20,7 @@ const ENGAGEMENT_EVENT_MAP = {
 	next_action_selected: 'next_action_selected',
 	profile_primary_action_viewed: 'profile_primary_action_viewed',
 	profile_viewed: 'profile_viewed',
-	shared_profile_link_opened: 'social_profile_opened',
+	shared_profile_link_opened: 'referral_profile_opened',
 	leaderboard_story_shared: 'profile_shared',
 	search_submitted: 'search_submitted',
 	site_visited: 'site_visited',
@@ -29,7 +29,7 @@ const ENGAGEMENT_EVENT_MAP = {
 	session_restored: 'session_restored',
 	weekly_digest_returned: 'weekly_digest_returned',
 };
-const ALLOWED_PROPERTIES = new Set(['action', 'channel', 'journey', 'outcome', 'source']);
+const ALLOWED_PROPERTIES = new Set(['action', 'campaign', 'channel', 'journey', 'outcome', 'source']);
 
 function safeProperties(properties) {
 	return Object.fromEntries(Object.entries(properties || {})

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -27,7 +27,7 @@ export const ENGAGEMENT_EVENTS = new Set([
   'search_submitted',
   'session_restored',
   'site_visited',
-  'social_profile_opened',
+  'referral_profile_opened',
   'weekly_digest_returned',
 ]);
 
@@ -37,8 +37,13 @@ export const ENGAGEMENT_DEDUPLICATION_MS = 30 * 60 * 1000;
 export const INSIGHTS_PRIVACY_THRESHOLD = 3;
 const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
 const BOT_PATTERN = /bot|crawler|spider|preview|slurp|facebookexternalhit|linkedinbot|twitterbot|whatsapp|discordbot/i;
-const ALLOWED_PROPERTIES = new Set(['action', 'channel', 'journey', 'source']);
+const ALLOWED_PROPERTIES = new Set(['action', 'campaign', 'channel', 'journey', 'source']);
 const SHARE_CHANNELS = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
+const ACQUISITION_EVENTS = new Set(['profile_claimed', 'profile_viewed', 'referral_profile_opened', 'site_visited', 'weekly_digest_returned']);
+const ACQUISITION_SOURCES = new Set([...SHARE_CHANNELS, 'direct', 'external_referral', 'local', 'manual_outreach', 'other', 'search', 'search_button', 'search_enter', 'weekly_digest', 'weekly_spotlight']);
+const ACQUISITION_CHANNELS = new Set(['community', 'direct', 'email', 'other', 'referral', 'social']);
+const ACQUISITION_CAMPAIGNS = new Set(['agents', 'community', 'country_leaderboard', 'developer_activation', 'developer_invite', 'developer_spotlight', 'identity_card', 'india_top_50', 'none', 'organic_referral', 'product', 'rank_movement', 'shared_profile', 'unknown', 'weekly_impact']);
+const WEEKLY_DIGEST_ACTIONS = new Set(['contribution_opportunity', 'introduction_request', 'rank_movement', 'unknown']);
 
 export class EngagementValidationError extends Error {}
 
@@ -53,7 +58,7 @@ function normalizeTargetLogin(value) {
   return login;
 }
 
-function normalizeProperties(value) {
+function normalizeProperties(value, eventName) {
   if (value == null) return {};
   if (typeof value !== 'object' || Array.isArray(value)) {
     throw new EngagementValidationError('Invalid event properties');
@@ -63,7 +68,14 @@ function normalizeProperties(value) {
     if (!ALLOWED_PROPERTIES.has(key)) continue;
     if (typeof rawValue !== 'string') throw new EngagementValidationError(`Invalid ${key}`);
     let normalized = rawValue.trim().slice(0, 40);
-    if (key === 'channel' && !SHARE_CHANNELS.has(normalized)) normalized = 'other';
+    if (['campaign', 'channel', 'source'].includes(key)) normalized = normalized.toLowerCase();
+    if (key === 'channel') {
+      const allowedChannels = ACQUISITION_EVENTS.has(eventName) ? ACQUISITION_CHANNELS : SHARE_CHANNELS;
+      if (!allowedChannels.has(normalized)) normalized = 'other';
+    }
+    if (key === 'source' && ACQUISITION_EVENTS.has(eventName) && !ACQUISITION_SOURCES.has(normalized)) normalized = 'other';
+    if (key === 'campaign' && !ACQUISITION_CAMPAIGNS.has(normalized)) normalized = 'unknown';
+    if (key === 'action' && eventName === 'weekly_digest_returned' && !WEEKLY_DIGEST_ACTIONS.has(normalized)) normalized = 'unknown';
     if (normalized) properties[key] = normalized;
   }
   return properties;
@@ -73,10 +85,10 @@ export function normalizeEngagementEvent(input) {
   const eventName = String(input?.eventName || '').trim();
   if (!ENGAGEMENT_EVENTS.has(eventName)) throw new EngagementValidationError('Unsupported engagement event');
   const targetLogin = normalizeTargetLogin(input.targetLogin);
-  if (['activation_completed', 'card_generated', 'personalized_profile_viewed', 'profile_claimed', 'profile_primary_action_viewed', 'profile_shared', 'profile_viewed', 'search_appearance', 'social_profile_opened'].includes(eventName) && !targetLogin) {
+  if (['activation_completed', 'card_generated', 'personalized_profile_viewed', 'profile_claimed', 'profile_primary_action_viewed', 'profile_shared', 'profile_viewed', 'referral_profile_opened', 'search_appearance'].includes(eventName) && !targetLogin) {
     throw new EngagementValidationError('Target login is required');
   }
-  return { eventName, targetLogin, properties: normalizeProperties(input.properties) };
+  return { eventName, targetLogin, properties: normalizeProperties(input.properties, eventName) };
 }
 
 export function createEngagementEvent(input, options = {}) {
@@ -91,7 +103,7 @@ export function createEngagementEvent(input, options = {}) {
   const qualifier = normalized.eventName === 'profile_shared'
     ? [normalized.properties.channel || '', normalized.properties.action || ''].join(':')
     : normalized.eventName === 'site_visited'
-      ? normalized.properties.journey || ''
+      ? [normalized.properties.journey || '', normalized.properties.source || '', normalized.properties.channel || '', normalized.properties.campaign || ''].join(':')
     : ['next_action_selected', 'profile_primary_action_viewed'].includes(normalized.eventName)
       ? normalized.properties.action || ''
       : normalized.eventName === 'recommendation_opened'

--- a/lib/share-attribution.js
+++ b/lib/share-attribution.js
@@ -3,6 +3,10 @@ const TRACKING_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content'
 const SOCIAL_SOURCES = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
 const SOCIAL_CAMPAIGNS = new Set(['country_leaderboard', 'developer_spotlight', 'identity_card', 'india_top_50', 'rank_movement']);
 const SHARE_CHANNELS = new Set(['copy_link', 'facebook', 'linkedin', 'native_share', 'reddit', 'share_page', 'x']);
+const ACQUISITION_SOURCES = new Set([...SOCIAL_SOURCES, 'direct', 'external_referral', 'manual_outreach', 'other', 'weekly_digest', 'weekly_spotlight']);
+const ACQUISITION_CHANNELS = new Set(['community', 'direct', 'email', 'other', 'referral', 'social']);
+const ACQUISITION_CAMPAIGNS = new Set([...SOCIAL_CAMPAIGNS, 'agents', 'community', 'developer_activation', 'developer_invite', 'none', 'organic_referral', 'product', 'shared_profile', 'unknown', 'weekly_impact']);
+const WEEKLY_DIGEST_ACTIONS = new Set(['contribution_opportunity', 'introduction_request', 'rank_movement']);
 const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
 
 export const DEVELOPER_STORY_TYPES = Object.freeze({
@@ -22,21 +26,62 @@ export function normalizeDeveloperLogin(value) {
   return login;
 }
 
+function normalizeShareChannel(value) {
+  const channel = cleanText(value, 'copy_link', 40).toLowerCase();
+  const source = channel === 'twitter' ? 'x' : channel;
+  return SHARE_CHANNELS.has(source) ? source : 'copy_link';
+}
+
+export function acquisitionAttributionProperties(params, { referrer = '', siteUrl = '' } = {}) {
+  const rawSource = String(params?.get?.('utm_source') || '').trim().toLowerCase();
+  const rawChannel = String(params?.get?.('utm_medium') || '').trim().toLowerCase();
+  const rawCampaign = String(params?.get?.('utm_campaign') || '').trim().toLowerCase();
+  const rawAction = String(params?.get?.('utm_content') || '').trim().toLowerCase();
+  let hasExternalReferrer = Boolean(referrer);
+  if (referrer && siteUrl) {
+    try {
+      hasExternalReferrer = new URL(referrer).origin !== new URL(siteUrl).origin;
+    } catch {
+      hasExternalReferrer = false;
+    }
+  }
+  const source = rawSource
+    ? (ACQUISITION_SOURCES.has(rawSource) ? rawSource : 'other')
+    : (hasExternalReferrer ? 'external_referral' : 'direct');
+  const defaultChannel = source === 'direct' ? 'direct'
+    : source === 'external_referral' || source === 'copy_link' || source === 'share_page' ? 'referral'
+      : source === 'weekly_digest' ? 'email'
+        : source === 'manual_outreach' ? 'community'
+          : SOCIAL_SOURCES.has(source) || source === 'weekly_spotlight' ? 'social'
+            : 'other';
+  const defaultCampaign = source === 'direct' ? 'none'
+    : source === 'external_referral' ? 'organic_referral'
+      : SOCIAL_SOURCES.has(source) ? 'shared_profile'
+        : 'unknown';
+  const attribution = {
+    source,
+    channel: ACQUISITION_CHANNELS.has(rawChannel) ? rawChannel : defaultChannel,
+    campaign: ACQUISITION_CAMPAIGNS.has(rawCampaign) ? rawCampaign : defaultCampaign,
+  };
+  if (WEEKLY_DIGEST_ACTIONS.has(rawAction)) attribution.action = rawAction;
+  return attribution;
+}
+
 function trackingParams(params = {}) {
   const sourceValue = String(params.utm_source || '').trim().toLowerCase();
   const campaignValue = String(params.utm_campaign || '').trim().toLowerCase();
   const contentValue = String(params.utm_content || '').trim().toLowerCase();
   const source = SOCIAL_SOURCES.has(sourceValue) ? sourceValue : 'direct';
   const campaign = SOCIAL_CAMPAIGNS.has(campaignValue) ? campaignValue : 'shared_profile';
-  const result = new URLSearchParams({ utm_source: source, utm_medium: source === 'copy_link' || source === 'share_page' ? 'referral' : 'social', utm_campaign: campaign });
+  const medium = source === 'direct' ? 'direct' : source === 'copy_link' || source === 'share_page' ? 'referral' : 'social';
+  const result = new URLSearchParams({ utm_source: source, utm_medium: medium, utm_campaign: campaign });
   if (LOGIN_PATTERN.test(contentValue)) result.set('utm_content', contentValue);
   return result;
 }
 
 export function identityCardShareUrl(siteUrl, login, channel, version) {
   const targetLogin = normalizeDeveloperLogin(login);
-  const source = channel === 'twitter' ? 'x' : cleanText(channel, 'copy_link', 40).toLowerCase();
-  const safeSource = SHARE_CHANNELS.has(source) ? source : 'copy_link';
+  const safeSource = normalizeShareChannel(channel);
   const url = new URL(`/share/${encodeURIComponent(targetLogin)}`, siteUrl);
   if (version) url.searchParams.set('v', version);
   url.searchParams.set('utm_source', safeSource);
@@ -47,17 +92,19 @@ export function identityCardShareUrl(siteUrl, login, channel, version) {
 }
 
 export function developerInviteUrl(siteUrl, login, channel) {
+  const targetLogin = normalizeDeveloperLogin(login);
+  const source = normalizeShareChannel(channel);
   const url = new URL('/', siteUrl);
-  url.searchParams.set('ref', login);
-  url.searchParams.set('utm_source', channel);
+  url.searchParams.set('ref', targetLogin);
+  url.searchParams.set('utm_source', source);
   url.searchParams.set('utm_medium', 'referral');
   url.searchParams.set('utm_campaign', 'developer_invite');
   return url.toString();
 }
 
 export function buildDeveloperStory({ siteUrl, developer, type, channel = 'copy_link', period = 7, movement = 0 } = {}) {
-  const login = cleanText(developer?.login, '', 39);
-  if (!/^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(login)) throw new TypeError('A valid developer login is required');
+  const login = normalizeDeveloperLogin(developer?.login);
+  const source = normalizeShareChannel(channel);
   if (!Object.values(DEVELOPER_STORY_TYPES).includes(type)) throw new TypeError('A supported developer story type is required');
 
   const name = cleanText(developer?.name, `@${login}`);
@@ -83,19 +130,18 @@ export function buildDeveloperStory({ siteUrl, developer, type, channel = 'copy_
     },
   }[type];
   const url = new URL(`/share/${encodeURIComponent(login)}`, siteUrl);
-  url.searchParams.set('utm_source', cleanText(channel, 'copy_link', 40));
-  url.searchParams.set('utm_medium', channel === 'copy_link' ? 'referral' : 'social');
+  url.searchParams.set('utm_source', source);
+  url.searchParams.set('utm_medium', source === 'copy_link' ? 'referral' : 'social');
   url.searchParams.set('utm_campaign', type);
   url.searchParams.set('utm_content', login.toLowerCase());
   return { ...content, type, url: url.toString() };
 }
 
 export function socialAttributionProperties(params) {
-  const source = String(params?.get?.('utm_source') || '').trim().toLowerCase();
-  const journey = String(params?.get?.('utm_campaign') || '').trim().toLowerCase();
+  const attribution = acquisitionAttributionProperties(params);
   return {
-    source: SOCIAL_SOURCES.has(source) ? source : 'direct',
-    journey: SOCIAL_CAMPAIGNS.has(journey) ? journey : 'shared_profile',
+    source: SOCIAL_SOURCES.has(attribution.source) ? attribution.source : 'direct',
+    journey: SOCIAL_CAMPAIGNS.has(attribution.campaign) ? attribution.campaign : 'shared_profile',
   };
 }
 

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -62,8 +62,13 @@ test('preserves separate route visits in the same browser window', () => {
   const options = { session: 'session', secret: 'secret', now: '2026-08-21T10:05:00.000Z' };
   const homepage = createEngagementEvent({ eventName: 'site_visited', properties: { journey: 'homepage' } }, options);
   const leaderboard = createEngagementEvent({ eventName: 'site_visited', properties: { journey: 'leaderboard' } }, options);
+  const campaignHomepage = createEngagementEvent({
+    eventName: 'site_visited',
+    properties: { journey: 'homepage', source: 'x', channel: 'social', campaign: 'product' },
+  }, options);
 
   assert.notEqual(homepage.id, leaderboard.id);
+  assert.notEqual(homepage.id, campaignHomepage.id);
 });
 
 test('preserves distinct share channels while deduplicating retries', () => {
@@ -86,13 +91,13 @@ test('preserves distinct leaderboard story types on the same share channel', () 
 
 test('accepts attributed social profile opens without arbitrary campaign data', () => {
   const event = normalizeEngagementEvent({
-    eventName: 'social_profile_opened',
+    eventName: 'referral_profile_opened',
     targetLogin: 'OctoCat',
     properties: { source: 'reddit', journey: 'rank_movement', utmContent: 'private-value' },
   });
 
   assert.deepEqual(event, {
-    eventName: 'social_profile_opened',
+    eventName: 'referral_profile_opened',
     targetLogin: 'octocat',
     properties: { source: 'reddit', journey: 'rank_movement' },
   });
@@ -257,6 +262,41 @@ test('accepts privacy-safe weekly digest return attribution without a target pro
       journey: 'weekly_digest',
       source: 'weekly_digest',
     },
+  });
+});
+
+test('bounds acquisition categories during durable ingestion', () => {
+  assert.deepEqual(normalizeEngagementEvent({
+    eventName: 'site_visited',
+    properties: {
+      source: 'person@example.com',
+      channel: 'private channel',
+      campaign: 'secret campaign',
+      journey: 'homepage',
+    },
+  }), {
+    eventName: 'site_visited',
+    targetLogin: null,
+    properties: {
+      source: 'other',
+      channel: 'other',
+      campaign: 'unknown',
+      journey: 'homepage',
+    },
+  });
+  assert.deepEqual(normalizeEngagementEvent({
+    eventName: 'weekly_digest_returned',
+    properties: {
+      source: 'weekly_digest',
+      channel: 'email',
+      campaign: 'weekly_impact',
+      action: 'private message',
+    },
+  }).properties, {
+    source: 'weekly_digest',
+    channel: 'email',
+    campaign: 'weekly_impact',
+    action: 'unknown',
   });
 });
 

--- a/tests/share-attribution.test.js
+++ b/tests/share-attribution.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  acquisitionAttributionProperties,
   attributedGlobePath,
   buildDeveloperStory,
   developerInviteUrl,
@@ -9,6 +10,48 @@ import {
   normalizeDeveloperLogin,
   socialAttributionProperties,
 } from '../lib/share-attribution.js';
+
+test('normalizes acquisition attribution into bounded reporting categories', () => {
+  assert.deepEqual(acquisitionAttributionProperties(new URLSearchParams({
+    utm_source: 'weekly_digest',
+    utm_medium: 'email',
+    utm_campaign: 'weekly_impact',
+    utm_content: 'contribution_opportunity',
+  })), {
+    source: 'weekly_digest',
+    channel: 'email',
+    campaign: 'weekly_impact',
+    action: 'contribution_opportunity',
+  });
+  assert.deepEqual(acquisitionAttributionProperties(new URLSearchParams(), {
+    referrer: 'https://example.com/private/path',
+  }), {
+    source: 'external_referral',
+    channel: 'referral',
+    campaign: 'organic_referral',
+  });
+  assert.deepEqual(acquisitionAttributionProperties(new URLSearchParams({
+    utm_source: 'person@example.com',
+    utm_medium: 'private channel',
+    utm_campaign: 'secret campaign',
+    utm_content: 'private message',
+  })), {
+    source: 'other',
+    channel: 'other',
+    campaign: 'unknown',
+  });
+});
+
+test('does not classify same-origin navigation as acquisition', () => {
+  assert.deepEqual(acquisitionAttributionProperties(new URLSearchParams(), {
+    referrer: 'https://www.devglobe.dev/leaderboard?private=value',
+    siteUrl: 'https://www.devglobe.dev/developer/octocat',
+  }), {
+    source: 'direct',
+    channel: 'direct',
+    campaign: 'none',
+  });
+});
 
 test('builds channel-specific identity card referral URLs', () => {
   const linkedIn = new URL(identityCardShareUrl('https://www.devglobe.dev', 'OctoCat', 'linkedin', '4'));
@@ -51,13 +94,27 @@ test('preserves only campaign attribution when entering the globe', () => {
 });
 
 test('attributes member invitations without exposing identity outside ref', () => {
-  const url = new URL(developerInviteUrl('https://www.devglobe.dev', 'octocat', 'native_share'));
+  const url = new URL(developerInviteUrl('https://www.devglobe.dev', 'OctoCat', 'native_share'));
 
   assert.equal(url.pathname, '/');
   assert.equal(url.searchParams.get('ref'), 'octocat');
   assert.equal(url.searchParams.get('utm_source'), 'native_share');
   assert.equal(url.searchParams.get('utm_medium'), 'referral');
   assert.equal(url.searchParams.get('utm_campaign'), 'developer_invite');
+});
+
+test('bounds channels in invitation and developer story URLs', () => {
+  const invite = new URL(developerInviteUrl('https://www.devglobe.dev', 'OctoCat', 'person@example.com'));
+  const story = buildDeveloperStory({
+    siteUrl: 'https://www.devglobe.dev',
+    developer: { login: 'OctoCat' },
+    type: DEVELOPER_STORY_TYPES.SPOTLIGHT,
+    channel: 'person@example.com',
+  });
+
+  assert.equal(invite.searchParams.get('ref'), 'octocat');
+  assert.equal(invite.searchParams.get('utm_source'), 'copy_link');
+  assert.equal(new URL(story.url).searchParams.get('utm_source'), 'copy_link');
 });
 
 test('builds canonical public developer spotlight stories with bounded attribution', () => {
@@ -129,7 +186,7 @@ test('sanitizes hostile attribution before forwarding to the profile funnel', ()
 
   assert.equal(url.searchParams.get('dev'), 'octocat');
   assert.equal(url.searchParams.get('utm_source'), 'direct');
-  assert.equal(url.searchParams.get('utm_medium'), 'social');
+  assert.equal(url.searchParams.get('utm_medium'), 'direct');
   assert.equal(url.searchParams.get('utm_campaign'), 'shared_profile');
   assert.equal(url.searchParams.has('utm_content'), false);
 });


### PR DESCRIPTION
## Summary
- Bounded source/medium/campaign/content taxonomy for attribution events and derived URLs.
- Attribution coverage for homepage, leaderboard, profile, share, and claim entry points.
- External vs same-origin referral classification and safe referral handling.
- Hardened campaign URL builders and canonical attribution values.
- `referral_profile_opened` naming alignment for profile-open attribution.
- Attribution-aware deduplication and durable ingestion enforcement.
- Documentation/report query support for attribution analysis.

## Validation
- Focused: 33/33
- Full: 372/372 across 67 files
- Next production build: 70/70
- Diff check: clean

Closes #357