### PR TITLE
Improve developer profile discoverability

### DIFF
--- a/app/developer/[login]/page.jsx
+++ b/app/developer/[login]/page.jsx
@@ -1,14 +1,65 @@
 import DeveloperActivityPage from '../../../components/DeveloperActivityPage.jsx';
+import { normalizeDeveloperLogin } from '../../../lib/share-attribution.js';
+import { getSiteUrl, SOCIAL_PREVIEW_VERSION } from '../../../lib/site.js';
 
 export async function generateMetadata({ params }) {
-  const { login } = await params;
+  const login = normalizeDeveloperLogin((await params).login);
+  const siteUrl = getSiteUrl();
+  const encodedLogin = encodeURIComponent(login);
+  const pageUrl = `${siteUrl}/developer/${encodedLogin}`;
+  const title = `@${login} Open-Source Developer Activity | DevGlobe`;
+  const description = `Explore @${login}'s public GitHub activity, open-source contributions, developer ranking, and collaboration profile on DevGlobe.`;
+  const imageUrl = `${siteUrl}/api/preview/v${SOCIAL_PREVIEW_VERSION}/${encodedLogin}.png`;
+
   return {
-    title: `${login} activity | DevGlobe`,
-    description: `Recent public GitHub activity for ${login} on DevGlobe.`,
+    title,
+    description,
+    alternates: { canonical: pageUrl },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      siteName: 'DevGlobe',
+      type: 'profile',
+      images: [{ url: imageUrl, width: 1200, height: 630, type: 'image/png', alt: `DevGlobe profile for @${login}` }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [{ url: imageUrl, alt: `DevGlobe profile for @${login}` }],
+    },
   };
 }
 
 export default async function DeveloperPage({ params }) {
-  const { login } = await params;
-  return <DeveloperActivityPage login={login} />;
+  const login = normalizeDeveloperLogin((await params).login);
+  const siteUrl = getSiteUrl();
+  const encodedLogin = encodeURIComponent(login);
+  const pageUrl = `${siteUrl}/developer/${encodedLogin}`;
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    '@id': `${pageUrl}#profile`,
+    url: pageUrl,
+    name: `@${login} Open-Source Developer Profile | DevGlobe`,
+    isPartOf: { '@id': `${siteUrl}/#website` },
+    mainEntity: {
+      '@type': 'Person',
+      identifier: login,
+      name: `@${login}`,
+      url: pageUrl,
+      sameAs: [`https://github.com/${encodedLogin}`],
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData).replace(/</g, '\\u003c') }}
+      />
+      <DeveloperActivityPage login={login} />
+    </>
+  );
 }

--- a/app/share/[login]/page.jsx
+++ b/app/share/[login]/page.jsx
@@ -11,12 +11,13 @@ export async function generateMetadata({ params }) {
   const title = `@${login}'s Developer Card | DevGlobe`;
   const description = `Explore @${login}'s open-source developer identity, global rank, and impact on DevGlobe.`;
   const pageUrl = `${siteUrl}/share/${encodedLogin}`;
+  const canonicalUrl = `${siteUrl}/developer/${encodedLogin}`;
   const imageUrl = `${siteUrl}/api/preview/v${SOCIAL_PREVIEW_VERSION}/${encodedLogin}.png`;
 
   return {
     title,
     description,
-    alternates: { canonical: pageUrl },
+    alternates: { canonical: canonicalUrl },
     openGraph: {
       title,
       description,
@@ -40,6 +41,7 @@ export default async function DeveloperSharePage({ params, searchParams }) {
   const encodedLogin = encodeURIComponent(login);
   const siteUrl = getSiteUrl();
   const pageUrl = `${siteUrl}/share/${encodedLogin}`;
+  const canonicalUrl = `${siteUrl}/developer/${encodedLogin}`;
   const attribution = {
     utm_source: 'share_page',
     utm_medium: 'referral',
@@ -52,8 +54,8 @@ export default async function DeveloperSharePage({ params, searchParams }) {
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'ProfilePage',
-    '@id': `${pageUrl}#profile`,
-    url: pageUrl,
+    '@id': `${canonicalUrl}#profile`,
+    url: canonicalUrl,
     name: `@${login}'s Developer Profile | DevGlobe`,
     description: profileDescription,
     isPartOf: { '@id': `${siteUrl}/#website` },
@@ -61,7 +63,7 @@ export default async function DeveloperSharePage({ params, searchParams }) {
       '@type': 'Person',
       identifier: login,
       name: `@${login}`,
-      url: pageUrl,
+      url: canonicalUrl,
       sameAs: [`https://github.com/${encodedLogin}`],
     },
   };

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -40,18 +40,11 @@ export function buildSitemapEntries(profileLogins, lastModified = new Date()) {
       changeFrequency: 'daily',
       priority: 0.9,
     },
-    ...logins.flatMap(login => [
-      {
-        url: `${siteUrl}/developer/${encodeURIComponent(login)}`,
-        changeFrequency: 'daily',
-        priority: 0.7,
-      },
-      {
-        url: `${siteUrl}/share/${encodeURIComponent(login)}`,
-        changeFrequency: 'monthly',
-        priority: 0.6,
-      },
-    ]),
+    ...logins.map(login => ({
+      url: `${siteUrl}/developer/${encodeURIComponent(login)}`,
+      changeFrequency: 'daily',
+      priority: 0.7,
+    })),
   ];
 }
 

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -9,7 +9,13 @@ test('includes every existing indexable acquisition route', () => {
   assert.ok(paths.includes('/countries'));
   assert.ok(paths.includes('/leaderboard'));
   assert.ok(paths.includes('/developer/octocat'));
-  assert.ok(paths.includes('/share/octocat'));
+  assert.ok(!paths.includes('/share/octocat'));
   assert.ok(paths.includes('/developer/octo%20cat'));
   assert.equal(paths.filter(path => path === '/developer/octocat').length, 1);
+});
+
+test('stays within the sitemap URL limit for the current dataset size', () => {
+  const logins = Array.from({ length: 27_000 }, (_, index) => `developer-${index}`);
+
+  assert.ok(buildSitemapEntries(logins).length <= 50_000);
 });


### PR DESCRIPTION
Keep sitemap under 50k by indexing canonical developer pages rather than duplicate share pages.

- add canonical/OG/Twitter/ProfilePage metadata to developer profiles
- canonicalize social share pages to developer profiles
- this advances but does not close #359

Validation:
- sitemap tests 2/2
- production build 70/70
- crawler metadata inspected
- diff check clean