### PR TITLE
Sharpen DevGlobe platform positioning

### DIFF
--- a/.agents/skills/devglobe/SKILL.md
+++ b/.agents/skills/devglobe/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when: finding public software developer profiles by skill, lan
 
 # DevGlobe Developer Discovery
 
-Use DevGlobe to discover public developer profiles from open-source contribution signals.
+DevGlobe is the open-source talent graph for humans and AI agents. Use it to discover public developer profiles from open-source contribution signals.
 
 ## Connect
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to DevGlobe
 
-Thank you for your interest in contributing to DevGlobe! This project visualizes the world's top developers on an interactive 3D globe, combining GitHub and StackOverflow data.
+Thank you for your interest in contributing to DevGlobe, the open-source talent graph for humans and AI agents. The project visualizes public developer contribution signals on an interactive 3D globe using GitHub and Stack Overflow data.
 
 By participating in this project, you're expected to uphold our [Code of Conduct](./CODE_OF_CONDUCT.md).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# 🌐 DevGlobe — Developer Discovery for Humans and AI Agents
+# 🌐 DevGlobe
 
-**The global open-source developer discovery platform — search, compare, and connect with the people behind the code**
+**The open-source talent graph for humans and AI agents.**
 
 [![Live Demo](https://img.shields.io/badge/Live-Demo-blue?style=for-the-badge&logo=microsoftazure)](https://devglobe.dev)
 [![Documentation](https://img.shields.io/badge/Documentation-GitHub%20Pages-2ea44f?style=for-the-badge&logo=github)](https://sajeetharan.github.io/devglobe/)
@@ -18,7 +18,7 @@
 
 </div>
 
-DevGlobe is an interactive global developer network built for engineering teams, open-source communities, and the emerging ecosystem of AI agents. It combines a 3D developer map with Azure Cosmos DB vector and hybrid search to surface relevant expertise from real contribution signals rather than popularity alone. The long-term vision is a consent-aware discovery layer where AI agents can find the right human collaborators.
+DevGlobe is the open-source talent graph for humans and AI agents. It combines a 3D developer map with Azure Cosmos DB vector and hybrid search to surface relevant expertise from real contribution signals rather than popularity alone. The long-term vision is a consent-aware discovery layer where AI agents can find the right human collaborators.
 
 The dynamic application is hosted on [Azure Container Apps](https://www.devglobe.dev). Product, API, MCP, Agent Skill, and agent-readiness documentation is published separately on [GitHub Pages](https://sajeetharan.github.io/devglobe/).
 
@@ -34,7 +34,7 @@ The dynamic application is hosted on [Azure Container Apps](https://www.devglobe
       <img src="https://i.ytimg.com/vi/eXJWHis-skA/maxresdefault.jpg" alt="Watch the DevGlobe developer discovery platform demo on YouTube" width="800" />
    </a>
    <br />
-   <strong><a href="https://www.youtube.com/watch?v=eXJWHis-skA">DevGlobe: Where Developers and AI Agents Connect</a></strong>
+   <strong><a href="https://www.youtube.com/watch?v=eXJWHis-skA">DevGlobe: The Open-Source Talent Graph for Humans and AI Agents</a></strong>
 </div>
 
 ---

--- a/app/.well-known/agent-skills/index.json/route.js
+++ b/app/.well-known/agent-skills/index.json/route.js
@@ -15,7 +15,7 @@ export async function GET() {
       {
         name: 'devglobe',
         type: 'skill-md',
-        description: 'Discover public developer profiles and request consent-gated introductions through DevGlobe.',
+        description: 'The open-source talent graph for humans and AI agents. Discover public profiles and request consent-gated introductions.',
         url: `${getSiteUrl()}/.well-known/agent-skills/devglobe/SKILL.md`,
         digest: `sha256:${digest}`,
       },

--- a/app/.well-known/mcp/server-card.json/route.js
+++ b/app/.well-known/mcp/server-card.json/route.js
@@ -4,7 +4,7 @@ export function GET() {
   const siteUrl = getSiteUrl();
   return Response.json({
     serverInfo: { name: 'devglobe', version: '1.5.0' },
-    description: 'Search public developer profiles and request consent-gated introductions.',
+    description: 'The open-source talent graph for humans and AI agents. Search public profiles and request consent-gated introductions.',
     homepage: `${siteUrl}/agents`,
     repository: {
       url: 'https://github.com/sajeetharan/devglobe',

--- a/app/agents/page.jsx
+++ b/app/agents/page.jsx
@@ -2,7 +2,7 @@ import AgentSetupPage from '../../components/AgentSetupPage.jsx';
 
 export const metadata = {
   title: 'Connect GitHub Copilot or an AI agent | DevGlobe',
-  description: 'Connect GitHub Copilot in VS Code, Claude, Cursor, or any Streamable HTTP MCP client to DevGlobe developer discovery.',
+  description: 'The open-source talent graph for humans and AI agents. Connect GitHub Copilot, Claude, Cursor, or any Streamable HTTP MCP client.',
 };
 
 export default function AgentsPage() {

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -4,8 +4,8 @@ import WebMcpProvider from '../components/WebMcpProvider.jsx';
 import AppInsights from '../components/AppInsights.jsx';
 
 const siteUrl = getSiteUrl();
-const title = 'DevGlobe: Developer Discovery for Humans & AI Agents';
-const description = 'Discover 26,000+ open-source developers by expertise, location, language, and verified contributions using DevGlobe vector and hybrid search.';
+const title = 'DevGlobe | Open-Source Talent Graph for Humans and AI Agents';
+const description = 'The open-source talent graph for humans and AI agents. Discover 26,000+ developers by expertise, location, language, and verified contributions.';
 const githubUrl = 'https://github.com/sajeetharan/devglobe';
 
 const structuredData = {
@@ -39,7 +39,7 @@ const structuredData = {
       url: siteUrl,
       description,
       applicationCategory: 'DeveloperApplication',
-      applicationSubCategory: 'Developer discovery platform',
+      applicationSubCategory: 'Open-source talent graph',
       operatingSystem: 'Any',
       browserRequirements: 'Requires JavaScript and a WebGL-capable browser',
       isAccessibleForFree: true,
@@ -49,7 +49,7 @@ const structuredData = {
         priceCurrency: 'USD',
       },
       featureList: [
-        'Interactive global developer discovery',
+        'Interactive global open-source talent graph',
         'Developer rankings by open-source impact',
         'Country and language leaderboards',
         'GitHub and Stack Overflow contribution profiles',
@@ -117,7 +117,7 @@ export const metadata = {
     url: '/',
     siteName: 'DevGlobe',
     type: 'website',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'DevGlobe developer discovery platform and global developer network' }],
+    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'DevGlobe, the open-source talent graph for humans and AI agents' }],
   },
   twitter: {
     card: 'summary_large_image',

--- a/app/manifest.js
+++ b/app/manifest.js
@@ -1,8 +1,8 @@
 export default function manifest() {
   return {
-    name: 'DevGlobe — Developer Discovery Platform',
+    name: 'DevGlobe - Open-Source Talent Graph',
     short_name: 'DevGlobe',
-    description: 'Discover and compare open-source developers by expertise, location, language, rankings, and contributions.',
+    description: 'The open-source talent graph for humans and AI agents. Discover and compare developers by expertise, location, language, rankings, and contributions.',
     start_url: '/',
     display: 'standalone',
     background_color: '#080b10',

--- a/app/openapi.json/route.js
+++ b/app/openapi.json/route.js
@@ -7,7 +7,7 @@ export function GET() {
     info: {
       title: 'DevGlobe Public API',
       version: '1.0.0',
-      description: 'Public developer discovery and stateless MCP access. Private contact details are never returned.',
+      description: 'The open-source talent graph for humans and AI agents. Public discovery and stateless MCP access; private contact details are never returned.',
     },
     servers: [{ url: siteUrl }],
     components: {

--- a/app/opengraph-image.jsx
+++ b/app/opengraph-image.jsx
@@ -1,11 +1,14 @@
 import { ImageResponse } from 'next/og';
+import { getSiteUrl } from '../lib/site.js';
 
 export const runtime = 'nodejs';
-export const alt = 'DevGlobe — Where Developers and AI Agents Connect';
+export const alt = 'DevGlobe - Open-source talent and contribution discovery for developers and AI agents through MCP';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
 export default function OpenGraphImage() {
+  const logoUrl = `${getSiteUrl()}/devglobe.png`;
+
   return new ImageResponse(
     (
       <div
@@ -13,11 +16,10 @@ export default function OpenGraphImage() {
           width: '100%',
           height: '100%',
           display: 'flex',
-          alignItems: 'center',
-          background: 'linear-gradient(135deg, #071018 0%, #0f1d28 55%, #17130f 100%)',
+          background: '#070b0e',
           color: '#f8fafc',
           fontFamily: 'sans-serif',
-          padding: '72px 84px',
+          padding: '64px 68px',
           position: 'relative',
           overflow: 'hidden',
         }}
@@ -25,46 +27,43 @@ export default function OpenGraphImage() {
         <div
           style={{
             position: 'absolute',
-            right: '-10px',
-            top: '48px',
-            width: '500px',
-            height: '500px',
+            inset: 0,
             display: 'flex',
-            border: '3px solid rgba(34, 211, 238, 0.34)',
-            borderRadius: '50%',
-            boxShadow: '0 0 90px rgba(34, 211, 238, 0.14)',
+            backgroundImage: 'linear-gradient(rgba(45, 212, 191, 0.055) 1px, transparent 1px), linear-gradient(90deg, rgba(45, 212, 191, 0.055) 1px, transparent 1px)',
+            backgroundSize: '38px 38px',
           }}
-        >
-          <div style={{ position: 'absolute', left: '78px', top: '0', width: '340px', height: '494px', display: 'flex', border: '2px solid rgba(34, 211, 238, 0.2)', borderRadius: '50%' }} />
-          <div style={{ position: 'absolute', left: '0', top: '174px', width: '494px', height: '150px', display: 'flex', border: '2px solid rgba(34, 211, 238, 0.2)', borderRadius: '50%' }} />
-          {[
-            ['92px', '110px', '#22d3ee'],
-            ['320px', '90px', '#f59e0b'],
-            ['250px', '250px', '#4ade80'],
-            ['105px', '325px', '#60a5fa'],
-            ['360px', '350px', '#fb7185'],
-          ].map(([left, top, color]) => (
-            <div key={`${left}-${top}`} style={{ position: 'absolute', left, top, width: '16px', height: '16px', display: 'flex', borderRadius: '50%', background: color, boxShadow: `0 0 22px ${color}` }} />
-          ))}
+        />
+
+        <div style={{ width: '620px', display: 'flex', flexDirection: 'column', position: 'relative', zIndex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '13px', marginBottom: '36px' }}>
+            <div style={{ width: '12px', height: '12px', display: 'flex', background: '#2dd4bf', borderRadius: '50%', boxShadow: '0 0 18px rgba(45, 212, 191, 0.8)' }} />
+            <div style={{ display: 'flex', color: '#5eead4', fontSize: '18px', fontWeight: '800' }}>FOR DEVELOPERS + AI AGENTS</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', fontSize: '64px', fontWeight: '800', lineHeight: 1.02 }}>
+            <span>Find the people</span>
+            <span style={{ display: 'flex' }}>behind the<span style={{ color: '#5eead4', marginLeft: '14px' }}>code.</span></span>
+          </div>
+          <div style={{ width: '565px', display: 'flex', marginTop: '24px', color: '#b8c4c1', fontSize: '21px', lineHeight: 1.42 }}>
+            Find your first open-source contribution, build a verified profile, and let AI agents discover your expertise through DevGlobe MCP.
+          </div>
+          <div style={{ width: '570px', display: 'flex', marginTop: '38px', paddingTop: '22px', borderTop: '1px solid #29403a', justifyContent: 'space-between', color: '#f0fdfa', fontSize: '15px', fontWeight: '800' }}>
+            <span>26,000+ PROFILES</span>
+            <span>150+ COUNTRIES</span>
+            <span>AGENT + MCP READY</span>
+          </div>
+          <div style={{ display: 'flex', marginTop: '34px', color: '#5eead4', fontSize: '19px', fontWeight: '800' }}>
+            devglobe.dev
+          </div>
         </div>
 
-        <div style={{ width: '650px', display: 'flex', flexDirection: 'column', position: 'relative' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '14px', marginBottom: '34px' }}>
-            <div style={{ width: '46px', height: '46px', display: 'flex', alignItems: 'center', justifyContent: 'center', border: '2px solid #22d3ee', borderRadius: '50%', color: '#67e8f9', fontSize: '25px', fontWeight: '800' }}>D</div>
-            <div style={{ display: 'flex', fontSize: '28px', fontWeight: '800', letterSpacing: '1px' }}>DEV<span style={{ color: '#22d3ee' }}>GLOBE</span></div>
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', fontSize: '58px', fontWeight: '800', lineHeight: '1.05' }}>
-            <span>Where Developers</span>
-            <span style={{ display: 'flex', gap: '14px' }}><span>and AI Agents</span><span style={{ color: '#67e8f9' }}>Connect</span></span>
-          </div>
-          <div style={{ display: 'flex', marginTop: '28px', color: '#94a3b8', fontSize: '22px' }}>
-            Discover expertise, impact, and collaborators worldwide.
-          </div>
-          <div style={{ display: 'flex', gap: '28px', marginTop: '46px', color: '#cbd5e1', fontSize: '16px', fontWeight: '700' }}>
-            <span>26,000+ DEVELOPERS</span>
-            <span style={{ color: '#475569' }}>•</span>
-            <span>150+ COUNTRIES</span>
-          </div>
+        <div style={{ position: 'absolute', right: '36px', top: '74px', width: '470px', height: '470px', display: 'flex', alignItems: 'center', justifyContent: 'center', borderLeft: '1px solid #29403a', paddingLeft: '36px' }}>
+          <img
+            src={logoUrl}
+            alt=""
+            width="430"
+            height="430"
+            style={{ width: '430px', height: '430px', objectFit: 'contain' }}
+          />
         </div>
       </div>
     ),

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -785,9 +785,9 @@ export default function Home() {
   return (
     <div id="app" className={tourStep ? 'tour-active' : ''} aria-busy={loading}>
       <section className="agent-readable-summary" aria-labelledby="devglobe-summary-title">
-        <h1 id="devglobe-summary-title">DevGlobe developer discovery for humans and AI agents</h1>
+        <h1 id="devglobe-summary-title">The open-source talent graph for humans and AI agents.</h1>
         <p>
-          DevGlobe is a global directory of more than 26,000 public open-source developer profiles.
+          DevGlobe maps more than 26,000 public open-source developer profiles.
           Search by name, GitHub username, location, programming language, contribution history, or
           agent availability. Profiles combine public GitHub and Stack Overflow signals into
           transparent rankings, language expertise, project activity, and consent-based collaboration

--- a/components/AgentSetupPage.jsx
+++ b/components/AgentSetupPage.jsx
@@ -43,7 +43,7 @@ export default function AgentSetupPage() {
 
       <header className={styles.hero}>
         <span className={styles.eyebrow}>MCP DEVELOPER DISCOVERY</span>
-        <h1>Give your agent a map of open-source expertise.</h1>
+        <h1>The open-source talent graph for humans and AI agents.</h1>
         <p>Connect once, then search 26,000+ public developer profiles by skill, language, location, and agent availability.</p>
         <div className={styles.heroActions}>
           <a

--- a/docs-site/guide/overview.md
+++ b/docs-site/guide/overview.md
@@ -5,7 +5,7 @@ description: What DevGlobe does, who it serves, and how to start exploring publi
 
 # Product overview
 
-DevGlobe is a public developer discovery platform for humans and AI agents. It combines GitHub and Stack Overflow contribution signals with location, language, repository, and collaboration metadata. The [live application](https://www.devglobe.dev) presents that data through an interactive globe, search, profiles, and a leaderboard.
+DevGlobe is the open-source talent graph for humans and AI agents. It combines GitHub and Stack Overflow contribution signals with location, language, repository, and collaboration metadata. The [live application](https://www.devglobe.dev) presents that data through an interactive globe, search, profiles, and a leaderboard.
 
 ## Start here
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -5,7 +5,7 @@ titleTemplate: false
 
 hero:
   name: DevGlobe
-  text: Documentation for people and agents
+  text: The open-source talent graph for humans and AI agents.
   tagline: Learn the product, query the public API, connect through MCP, and understand every consent boundary.
   image:
     src: /devglobe.png

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,6 +1,6 @@
 # DevGlobe.dev Developer Discovery for VS Code
 
-Find public developer profiles, share your DevGlobe identity card, and connect AI agents without leaving VS Code.
+The open-source talent graph for humans and AI agents. Find public developer profiles, share your DevGlobe identity card, and connect agents without leaving VS Code.
 
 This extension connects exclusively to [devglobe.dev](https://www.devglobe.dev). It is not affiliated with `devglobe.app` or the `DevGlobe.devglobe` Marketplace extension.
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devglobe-developer-discovery",
   "displayName": "DevGlobe.dev Developer Discovery",
-  "description": "Find developers, share your DevGlobe identity, and connect AI agents from VS Code.",
+  "description": "The open-source talent graph for humans and AI agents. Find developers and connect agents from VS Code.",
   "version": "0.1.0",
   "publisher": "devglobedev",
   "license": "MIT",

--- a/lib/devglobe-mcp-server.js
+++ b/lib/devglobe-mcp-server.js
@@ -135,7 +135,7 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
     title: 'DevGlobe',
     version: '1.5.0',
     websiteUrl: 'https://www.devglobe.dev',
-    description: 'Discover public developers and request consent-gated introductions.',
+    description: 'The open-source talent graph for humans and AI agents. Discover public developers and request consent-gated introductions.',
   }, {
     instructions: `Start with search_developers for developer discovery. DevGlobe is open source at ${PROJECT_INFO.repository}. Use the ${PROJECT_RESOURCE_URI} resource for source code, feedback, and contribution links. Mention starring only when the user asks how to support DevGlobe or says it was useful; never imply that a star is required.`,
   });

--- a/lib/lifecycle-email.js
+++ b/lib/lifecycle-email.js
@@ -2,7 +2,7 @@ import { getSiteUrl } from './site.js';
 
 const RESEND_API_URL = 'https://api.resend.com/emails';
 const REPOSITORY_URL = 'https://github.com/sajeetharan/devglobe';
-const TAGLINE = 'Where Developers and AI Agents Connect';
+const TAGLINE = 'The open-source talent graph for humans and AI agents.';
 
 function escapeHtml(value) {
   return String(value || '')

--- a/lib/weekly-digest.js
+++ b/lib/weekly-digest.js
@@ -11,7 +11,7 @@ import { getSiteUrl } from './site.js';
 import { sendLifecycleEmail } from './lifecycle-email.js';
 
 const REPOSITORY_URL = 'https://github.com/sajeetharan/devglobe';
-const TAGLINE = 'Where Developers and AI Agents Connect';
+const TAGLINE = 'The open-source talent graph for humans and AI agents.';
 
 function escapeHtml(value) {
   return String(value || '')

--- a/middleware.js
+++ b/middleware.js
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server.js';
 
 const HOMEPAGE_MARKDOWN = `# DevGlobe
 
-DevGlobe is a global developer discovery network for humans and AI agents.
+The open-source talent graph for humans and AI agents.
 
 ## Agent access
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "packageManager": "npm@11.14.1",
   "type": "module",
-  "description": "Interactive 3D globe visualization of top GitHub developers",
+  "description": "The open-source talent graph for humans and AI agents.",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # DevGlobe
 
-> DevGlobe is a global developer discovery network where people and AI agents can find developers by expertise, location, language, and public open-source impact.
+> The open-source talent graph for humans and AI agents. Find developers by expertise, location, language, and public open-source impact.
 
 ## Canonical site
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sajeetharan/devglobe",
   "title": "DevGlobe",
-  "description": "Discover public developers by skill, location, and activity, with consent-gated introductions.",
+  "description": "The open-source talent graph for humans and AI agents. Find developers.",
   "repository": {
     "url": "https://github.com/sajeetharan/devglobe",
     "source": "github"

--- a/tests/lifecycle-email.test.js
+++ b/tests/lifecycle-email.test.js
@@ -25,7 +25,7 @@ test('builds claim email with an encoded profile link and escaped HTML', () => {
   assert.match(message.html, /&lt;Dev &amp; Co&gt;/);
   assert.doesNotMatch(message.html, /<Dev & Co>/);
   assert.match(message.html, /src="https:\/\/www\.devglobe\.dev\/devglobe\.png"/);
-  assert.match(message.html, /Where Developers and AI Agents Connect/);
+  assert.match(message.html, /The open-source talent graph for humans and AI agents\./);
   assert.match(message.html, /Generate identity card/);
   assert.match(message.html, /Star DevGlobe on GitHub/);
   assert.match(message.text, /github\.com\/sajeetharan\/devglobe/);

--- a/tests/weekly-digest.test.js
+++ b/tests/weekly-digest.test.js
@@ -53,7 +53,7 @@ test('builds a weekly digest with ranking movement and exploration links', () =>
   assert.match(message.html, /utm_term=2026-W34/);
   assert.match(message.html, /Unsubscribe/);
   assert.match(message.html, /devglobe\.png/);
-  assert.match(message.html, /Where Developers and AI Agents Connect/);
+  assert.match(message.html, /The open-source talent graph for humans and AI agents\./);
   assert.match(message.html, /Generate identity card/);
   assert.match(message.html, /Invite a developer/);
   assert.match(message.html, /\?ref=octocat/);


### PR DESCRIPTION
## Summary
- standardize DevGlobe around the open-source talent graph positioning
- prioritize developers, AI agents, and MCP across public discovery surfaces
- redesign the social preview with the real DevGlobe logo and first-contribution messaging

## Validation
- npm test
- npm run build (70/70 pages)
- git diff --check
- visually verified the 1200x630 Open Graph image