### PR TITLE
Publish MCP Registry version 1.5.1

### DIFF
--- a/app/.well-known/mcp/server-card.json/route.js
+++ b/app/.well-known/mcp/server-card.json/route.js
@@ -3,7 +3,7 @@ import { getSiteUrl } from '../../../../lib/site.js';
 export function GET() {
   const siteUrl = getSiteUrl();
   return Response.json({
-    serverInfo: { name: 'devglobe', version: '1.5.0' },
+    serverInfo: { name: 'devglobe', version: '1.5.1' },
     description: 'The open-source talent graph for humans and AI agents. Search public profiles and request consent-gated introductions.',
     homepage: `${siteUrl}/agents`,
     repository: {

--- a/lib/devglobe-mcp-server.js
+++ b/lib/devglobe-mcp-server.js
@@ -133,7 +133,7 @@ export function createDevGlobeMcpServer({ client = createDevGlobeMcpClient() } =
   const server = new McpServer({
     name: 'devglobe',
     title: 'DevGlobe',
-    version: '1.5.0',
+    version: '1.5.1',
     websiteUrl: 'https://www.devglobe.dev',
     description: 'The open-source talent graph for humans and AI agents. Discover public developers and request consent-gated introductions.',
   }, {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/sajeetharan/devglobe",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -51,7 +51,7 @@ test('serves a valid API catalog and OpenAPI description', async () => {
 test('describes the MCP server tools and authentication boundary', async () => {
   const card = await getMcpCard().json();
   assert.equal(card.transport.type, 'streamable-http');
-  assert.equal(card.serverInfo.version, '1.5.0');
+  assert.equal(card.serverInfo.version, '1.5.1');
   assert.equal(card.repository.url, 'https://github.com/sajeetharan/devglobe');
   assert.deepEqual(card.capabilities.resources.uris, ['devglobe://project']);
   assert.deepEqual(card.capabilities.prompts.names, ['find-developers', 'find-collaborators', 'find-contribution']);

--- a/tests/remote-mcp.test.js
+++ b/tests/remote-mcp.test.js
@@ -37,7 +37,7 @@ test('remote MCP initializes and lists DevGlobe tools without a session', async 
     },
   })));
   assert.equal(initialization.result.serverInfo.name, 'devglobe');
-  assert.equal(initialization.result.serverInfo.version, '1.5.0');
+  assert.equal(initialization.result.serverInfo.version, '1.5.1');
   assert.equal(initialization.result.serverInfo.websiteUrl, 'https://www.devglobe.dev');
   assert.match(initialization.result.instructions, /github\.com\/sajeetharan\/devglobe/);
   assert.deepEqual(initialization.result.capabilities.resources, { listChanged: true });


### PR DESCRIPTION
## Summary
- bump MCP Registry metadata to 1.5.1 after the duplicate-version publish failure
- keep the public server card and runtime handshake aligned
- update MCP version contract assertions

## Validation
- publisher workflow contract suite: 49/49 passing
- git diff --check