### PR TITLE
Surface agent network onboarding

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -67,6 +67,7 @@ export default function Home() {
   const [showContributions, setShowContributions] = useState(false);
   const [similarLogin, setSimilarLogin] = useState('');
   const [completionVersion, setCompletionVersion] = useState(0);
+  const [agentProfileStatus, setAgentProfileStatus] = useState('idle');
   const [agentGlobeLayerVisible, setAgentGlobeLayerVisible] = useState(false);
   const [agentRelationshipGraph, setAgentRelationshipGraph] = useState({ nodes: [], developers: [], links: [] });
   const [trending, setTrending] = useState(null);
@@ -220,16 +221,42 @@ export default function Home() {
     }
   }, [user, developers]);
 
+  useEffect(() => {
+    if (!user || claimStatus !== 'claimed') {
+      setAgentProfileStatus('idle');
+      return undefined;
+    }
+
+    let cancelled = false;
+    setAgentProfileStatus('loading');
+    fetch('/api/ai-profile', { cache: 'no-store', credentials: 'same-origin' })
+      .then(async response => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Unable to load AI profile');
+        return data.profile;
+      })
+      .then(profile => {
+        if (!cancelled) setAgentProfileStatus(profile?.tools?.length > 0 ? 'configured' : 'missing');
+      })
+      .catch(() => {
+        if (!cancelled) setAgentProfileStatus('unavailable');
+      });
+
+    return () => { cancelled = true; };
+  }, [user, claimStatus]);
+
   const handleLogout = useCallback(async () => {
     await fetch('/api/auth/logout', { method: 'POST' });
     setUser(null);
     setClaimStatus('unclaimed');
+    setAgentProfileStatus('idle');
     setShowAiProfile(false);
     setShowIntroductions(false);
   }, []);
 
-  const handleAiProfileSaved = useCallback((aiProfile) => {
-    setSelectedDev(current => current?.login === user?.login ? { ...current, aiProfile } : current);
+  const handleAiProfileSaved = useCallback((publicAiProfile, savedProfile) => {
+    setSelectedDev(current => current?.login === user?.login ? { ...current, aiProfile: publicAiProfile } : current);
+    setAgentProfileStatus(savedProfile?.tools?.length > 0 ? 'configured' : 'missing');
     setCompletionVersion(version => version + 1);
   }, [user]);
 
@@ -693,6 +720,12 @@ export default function Home() {
     setSidebarOpen(true);
   }, [sidebarView]);
 
+  const handleOpenAgentNetwork = useCallback(() => {
+    setSidebarView('agents');
+    setSidebarOpen(true);
+    setAgentGlobeLayerVisible(true);
+  }, []);
+
   const handleCloseSidebar = useCallback(() => {
     setSidebarOpen(false);
     setSidebarView('leaderboard');
@@ -849,8 +882,10 @@ export default function Home() {
         signedIn={Boolean(user)}
         currentUsername={user?.login || ''}
         profileOpen={Boolean(selectedDev)}
-        onOpenOwnProfile={handleOpenOwnProfile}
         onOpenActivity={handleOpenActivity}
+        showAgentPrompt={agentProfileStatus === 'missing'}
+        onOpenAgentProfile={() => setShowAiProfile(true)}
+        onOpenAgentNetwork={handleOpenAgentNetwork}
         showMissionPreview={false}
       />
       <QuickTour

--- a/components/AiProfileModal.jsx
+++ b/components/AiProfileModal.jsx
@@ -118,7 +118,7 @@ export default function AiProfileModal({ onClose, onSaved }) {
       });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Failed to save AI settings');
-      onSaved(data.profile.visibility === 'public' ? data.profile : null);
+      onSaved(data.profile.visibility === 'public' ? data.profile : null, data.profile);
       onClose();
     } catch (saveError) {
       setError(saveError.message);

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import SpecialTags from './SpecialTags.jsx';
 import { track, trackSearchAppearances } from '../lib/analytics.js';
 import { countryKey } from '../lib/country.js';
@@ -29,7 +29,7 @@ const SAMPLES_BY_MODE = {
   ],
 };
 
-export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0, signedIn = false, currentUsername = '', profileOpen = false, onOpenOwnProfile, onOpenActivity, showMissionPreview = true }) {
+export default function SearchBar({ developers, onResults, onReset, onSelectDeveloper, onGenerateCard, onSearchState, onOpenCardFeature, onOpenReadmeFeature, readmeTooltip = 'Generate a README for your GitHub profile', onOpenCompareFeature, compareCount = 0, signedIn = false, currentUsername = '', profileOpen = false, onOpenActivity, showAgentPrompt = false, onOpenAgentProfile, onOpenAgentNetwork, showMissionPreview = true }) {
   const [query, setQuery] = useState('');
   const [mode, setMode] = useState('text');
   const [topN, setTopN] = useState(20);
@@ -38,9 +38,38 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
   const [visibleResults, setVisibleResults] = useState([]);
   const [singleResult, setSingleResult] = useState(null);
   const [searchError, setSearchError] = useState('');
+  const [agentPromptDismissed, setAgentPromptDismissed] = useState(false);
   const inputRef = useRef(null);
   const abortRef = useRef(null);
   const timerRef = useRef(null);
+  const agentPromptViewedRef = useRef('');
+  const agentPromptKey = currentUsername
+    ? `devglobe-agent-prompt-dismissed:v1:${currentUsername.toLowerCase()}`
+    : '';
+
+  useEffect(() => {
+    if (!agentPromptKey) {
+      setAgentPromptDismissed(false);
+      return;
+    }
+    try {
+      setAgentPromptDismissed(localStorage.getItem(agentPromptKey) === '1');
+    } catch {
+      setAgentPromptDismissed(false);
+    }
+  }, [agentPromptKey]);
+
+  useEffect(() => {
+    if (!showAgentPrompt || agentPromptDismissed || !agentPromptKey || agentPromptViewedRef.current === agentPromptKey) return;
+    agentPromptViewedRef.current = agentPromptKey;
+    track('agent_setup_viewed', { action: 'profile_tools_prompt', source: 'homepage_prompt' });
+  }, [agentPromptDismissed, agentPromptKey, showAgentPrompt]);
+
+  const dismissAgentPrompt = useCallback((source) => {
+    setAgentPromptDismissed(true);
+    try { localStorage.setItem(agentPromptKey, '1'); } catch { /* Dismissal remains active for this render. */ }
+    track('next_action_selected', { action: source, journey: 'agent_onboarding', source: 'homepage_prompt' });
+  }, [agentPromptKey]);
 
   const openSearchResult = useCallback((developer, source) => {
     track('personalized_profile_viewed', {
@@ -225,27 +254,54 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
 
   return (
     <div className="search-bar" id="search-bar">
-      {signedIn && !profileOpen && !query && resultCount === null && (
+      {signedIn && showAgentPrompt && !agentPromptDismissed && !profileOpen && !query && resultCount === null && (
         <div className="search-bar__activation">
-          <span className="search-bar__eyebrow">Your open-source snapshot</span>
-          <h2>Welcome back, @{currentUsername}</h2>
-          <p>Review your ranking, recent activity, and next step.</p>
           <button
             type="button"
-            className="search-bar__own-profile"
-            onClick={() => {
-              track('activation_started', { journey: 'username_profile', source: 'signed_in_cta' });
-              track('activation_action_selected', { action: 'open_own_profile', journey: 'username_profile', source: 'signed_in_cta' });
-              track('personalized_profile_viewed', { login: currentUsername, journey: 'username_profile', source: 'signed_in_cta' });
-              track('activation_completed', { login: currentUsername, journey: 'username_profile', outcome: 'profile_opened', source: 'signed_in_cta' });
-              onOpenOwnProfile?.();
-            }}
+            className="search-bar__activation-close"
+            aria-label="Dismiss agent setup prompt"
+            onClick={() => dismissAgentPrompt('close')}
           >
-            Open my profile
             <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-              <path d="M4 10h12M11 5l5 5-5 5" />
+              <path d="M5 5l10 10M15 5L5 15" />
             </svg>
           </button>
+          <span className="search-bar__eyebrow">Developer + agent network</span>
+          <h2>Put your AI tools on the map</h2>
+          <p>@{currentUsername}, link the tools you already use so developers and AI agents can discover your expertise.</p>
+          <div className="search-bar__agent-actions">
+            <button
+              type="button"
+              className="search-bar__agent-action search-bar__agent-action--primary"
+              onClick={() => {
+                dismissAgentPrompt('add_tools');
+                track('agent_setup_started', { source: 'homepage_prompt', client: 'developer_profile' });
+                onOpenAgentProfile?.();
+              }}
+            >
+              Add my AI tools
+            </button>
+          <button
+            type="button"
+              className="search-bar__agent-action"
+            onClick={() => {
+                dismissAgentPrompt('view_network');
+                onOpenAgentNetwork?.();
+            }}
+          >
+              View agent network
+          </button>
+            <a
+              className="search-bar__agent-action"
+              href="/agents"
+              onClick={() => {
+                dismissAgentPrompt('connect_agent');
+                track('agent_setup_started', { source: 'homepage_prompt', client: 'mcp' });
+              }}
+            >
+              Connect via MCP
+            </a>
+          </div>
         </div>
       )}
       <div className="search-bar__inner">

--- a/styles/main.css
+++ b/styles/main.css
@@ -409,17 +409,37 @@ body {
 }
 
 .search-bar__activation {
+  position: relative;
   display: grid;
-  justify-items: center;
+  justify-items: start;
   width: min(620px, calc(100vw - 32px));
   gap: 5px;
-  padding: 16px 20px;
+  padding: 16px 56px 16px 20px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-panel-90);
   backdrop-filter: blur(16px);
   box-shadow: var(--shadow-strong);
-  text-align: center;
+  text-align: left;
+}
+
+.search-bar__activation-close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.search-bar__activation-close svg {
+  width: 18px;
+  height: 18px;
 }
 
 .search-bar__eyebrow {
@@ -443,7 +463,7 @@ body {
   line-height: 1.5;
 }
 
-.search-bar__own-profile,
+.search-bar__agent-action,
 .search-bar__submit {
   display: inline-flex;
   min-height: 44px;
@@ -458,14 +478,52 @@ body {
   cursor: pointer;
 }
 
-.search-bar__own-profile {
+.search-bar__agent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   margin-top: 7px;
-  padding: 0 16px;
 }
 
-.search-bar__own-profile svg {
-  width: 16px;
-  height: 16px;
+.search-bar__agent-action {
+  padding: 0 13px;
+  border-color: var(--border);
+  background: var(--overlay-subtle);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.search-bar__agent-action--primary {
+  border-color: #0891b2;
+  background: #0891b2;
+  color: #fff;
+}
+
+@media (max-width: 480px) {
+  .search-bar__activation {
+    padding: 14px 16px;
+  }
+
+  .search-bar__activation h2 {
+    padding-right: 34px;
+    font-size: 18px;
+  }
+
+  .search-bar__agent-actions {
+    display: grid;
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .search-bar__agent-action {
+    min-width: 0;
+    padding: 0 8px;
+    text-align: center;
+  }
+
+  .search-bar__agent-action--primary {
+    grid-column: 1 / -1;
+  }
 }
 
 .search-bar__submit {
@@ -478,12 +536,14 @@ body {
   opacity: 0.45;
 }
 
-.search-bar__own-profile:hover,
+.search-bar__agent-action:hover,
 .search-bar__submit:not(:disabled):hover {
   background: #0e7490;
+  color: #fff;
 }
 
-.search-bar__own-profile:focus-visible,
+.search-bar__activation-close:focus-visible,
+.search-bar__agent-action:focus-visible,
 .search-bar__submit:focus-visible {
   outline: 2px solid #38bdf8;
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- replace the signed-in snapshot card with profile-aware agent onboarding
- link developers directly to AI tool settings, the visible globe network, and MCP setup
- permanently dismiss the prompt per account after any action or close
- suppress onboarding for developers who already declare AI tools
- keep actions contained and accessible on mobile

## Validation
- npm test: 377/377 passing
- npm run build: 70/70 pages
- git diff --check
- Playwright: verified prompt gating, AI settings action, agent network activation, persistent dismissal, configured-profile suppression, and desktop/mobile layout