### PR TITLE
Plot repository-detected agent signals

### DIFF
--- a/app/api/agent-network/route.js
+++ b/app/api/agent-network/route.js
@@ -15,14 +15,18 @@ export async function GET() {
   try {
     const [developerResult, introductionResult] = await Promise.all([
       developers.items.query({
-        query: `SELECT c.login, c.name, c.avatarUrl, c.lat, c.lng, c.score, c.claimed, c.location, c.aiProfile
+        query: `SELECT c.id, c.login, c.name, c.avatarUrl, c.lat, c.lng, c.score, c.claimed, c.location, c.aiProfile,
+          c.repositoryAgentSignals.toolIds AS repositoryAgentTools
           FROM c
-          WHERE c.claimed = true
-            AND IS_DEFINED(c.aiProfile)
-            AND c.aiProfile.visibility = 'public'
-            AND c.aiProfile.acceptsAgentRequests = true
-            AND c.aiProfile.contactPolicy = 'verified-agents'
-            AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')`,
+          WHERE (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')
+            AND (
+              (c.claimed = true
+                AND IS_DEFINED(c.aiProfile)
+                AND c.aiProfile.visibility = 'public'
+                AND c.aiProfile.acceptsAgentRequests = true
+                AND c.aiProfile.contactPolicy = 'verified-agents')
+              OR (IS_ARRAY(c.repositoryAgentSignals.toolIds) AND ARRAY_LENGTH(c.repositoryAgentSignals.toolIds) > 0)
+            )`,
       }).fetchAll(),
       introductions.items.query({
         query: 'SELECT c.status, COUNT(1) AS count FROM c GROUP BY c.status',

--- a/components/AgentNetworkPanel.jsx
+++ b/components/AgentNetworkPanel.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 const METRICS = [
   { key: 'openDevelopers', label: 'Open developers' },
+  { key: 'repositoryDevelopers', label: 'Repo signals' },
   { key: 'acceptedConnections', label: 'Connections' },
   { key: 'pendingRequests', label: 'In review' },
   { key: 'countries', label: 'Countries' },
@@ -43,9 +44,9 @@ export default function AgentNetworkPanel({ globeLayerVisible = false, onToggleG
   return (
     <div className="agent-network">
       <header className="agent-network__header">
-        <span>CONSENT-BASED NETWORK</span>
+        <span>PUBLIC AGENT SIGNALS</span>
         <h2>Agent Network</h2>
-        <p>Aggregate activity from public, opted-in profiles.</p>
+        <p>Public declarations and repository configuration evidence.</p>
       </header>
 
       <dl className="agent-network__metrics">
@@ -65,7 +66,7 @@ export default function AgentNetworkPanel({ globeLayerVisible = false, onToggleG
       <section className="agent-network__globe-control" aria-labelledby="agent-globe-title">
         <span>
           <strong id="agent-globe-title">Agent and developer links</strong>
-          <small>Plot public AI tool declarations and opted-in developers.</small>
+          <small>Plot public declarations and repository configuration evidence.</small>
         </span>
         <button
           type="button"
@@ -94,7 +95,7 @@ export default function AgentNetworkPanel({ globeLayerVisible = false, onToggleG
       <section className="agent-network__section" aria-labelledby="agent-tools-title">
         <div className="agent-network__section-heading">
           <h3 id="agent-tools-title">AI tools</h3>
-          <span>Self-declared</span>
+          <span>Declared + repository-detected</span>
         </div>
         {snapshot.tools.length > 0 ? (
           <div className="agent-network__tools">
@@ -106,12 +107,12 @@ export default function AgentNetworkPanel({ globeLayerVisible = false, onToggleG
             ))}
           </div>
         ) : (
-          <p className="agent-network__suppressed">Tool cohorts appear after {snapshot.privacyThreshold} public declarations.</p>
+          <p className="agent-network__suppressed">Tool cohorts appear after {snapshot.privacyThreshold} public signals.</p>
         )}
       </section>
 
       <footer className="agent-network__footer">
-        <p className="agent-network__privacy">Small cohorts are hidden to protect developer privacy.</p>
+        <p className="agent-network__privacy">Repository evidence does not imply personal usage or contact consent. Small cohorts are hidden.</p>
         <a
           href="https://github.com/sajeetharan/devglobe/blob/main/docs/mcp-server.md"
           target="_blank"

--- a/components/Globe.jsx
+++ b/components/Globe.jsx
@@ -101,12 +101,16 @@ function hexResolutionForAltitude(altitude) {
 
 function createAvatarMarker(developer, onSelectDev, setAutoRotate) {
   const marker = document.createElement('div');
-  marker.className = 'globe-avatar-marker';
+  marker.className = developer.repositoryDetected
+    ? 'globe-avatar-marker globe-avatar-marker--repository'
+    : 'globe-avatar-marker';
   marker.style.setProperty('--marker-color', getScoreColor(developer.score));
   marker.setAttribute('role', 'button');
   marker.setAttribute('tabindex', '0');
-  marker.setAttribute('aria-label', `Open ${developer.name || developer.login}'s profile`);
-  marker.title = developer.name || developer.login;
+  const name = developer.name || developer.login;
+  const evidence = developer.repositoryDetected ? '; AI configuration detected in public repositories' : '';
+  marker.setAttribute('aria-label', `Open ${name}'s profile${evidence}`);
+  marker.title = `${name}${evidence}`;
 
   const selectDeveloper = (event) => {
     event.stopPropagation();
@@ -959,9 +963,9 @@ const Globe = forwardRef(function Globe({
               )}
               {agentNetworkVisible && (
                 <>
-                  <span className="globe-legend__item"><span className="globe-legend__agent-mark">AI</span>Publicly listed tool</span>
-                  <span className="globe-legend__item"><span className="globe-legend__line" />Tool relationship</span>
-                  <span className="globe-legend__item">Links reflect public profile declarations</span>
+                  <span className="globe-legend__item"><span className="globe-legend__agent-mark">AI</span>Declared or repository-detected tool</span>
+                  <span className="globe-legend__item"><span className="globe-legend__line" />Public evidence relationship</span>
+                  <span className="globe-legend__item">Repository detection does not imply contact consent</span>
                 </>
               )}
               {trendingRings.length > 0 && (

--- a/docs/agent-readiness.md
+++ b/docs/agent-readiness.md
@@ -14,6 +14,12 @@ DevGlobe publishes machine-readable discovery without claiming authentication ca
 - `/robots.txt` includes Content Signals while retaining crawler access rules.
 - Supported early-preview browsers receive guarded, read-only WebMCP search and profile tools.
 
+## Repository agent evidence
+
+DevGlobe periodically scans filenames in a bounded set of recent public owner repositories for recognized agent configuration conventions. Detected tools can appear on the globe as repository evidence after the privacy threshold is met. The scan excludes private, forked, and archived repositories and does not read file contents.
+
+Repository detection does not prove personal tool usage and does not grant contact permission. Agent introductions remain available only for claimed developers who publish an AI profile and explicitly accept verified-agent requests.
+
 DevGlobe publishes protected-resource metadata without listing an authorization server. The current agent credentials are static bearer tokens, not OAuth grants. Adding RFC 8414 authorization-server metadata requires an OAuth 2.1 issuer with authorization and token endpoints; those endpoints must not be advertised until DevGlobe can issue and validate scoped grants.
 
 ## DNS-AID deployment

--- a/docs/azure-backend.md
+++ b/docs/azure-backend.md
@@ -13,6 +13,7 @@ Azure Functions serves:
 - `GET /api/activities`
 - `GET /api/activities/live`
 - GitHub activity ingestion every five minutes
+- Repository agent-signal ingestion every fifteen minutes
 - Hourly generation of the compressed developer snapshot
 
 Azure Blob Storage serves `developers.json` directly to browsers. Azure Container Apps serves the frontend, OAuth, private account mutations, nominations, cards, share metadata, and MCP endpoint.
@@ -29,6 +30,10 @@ The deployment uses these resources in `devglobe-rg`:
 - Static website endpoint: `https://devglobeactivityfn.z13.web.core.windows.net/`
 
 The Container App and Function App require their existing Cosmos, GitHub, and Azure OpenAI application settings. Never place secrets in public frontend variables or image build arguments.
+
+The `repository-agent-ingest` timer uses the Function App's `GITHUB_TOKEN` to scan a bounded batch of stale developer profiles. It examines filenames from up to eight recent public, non-fork, non-archived owner repositories and stores the resulting tool IDs and evidence on the existing developer document. It never reads or stores repository file contents. Each profile is refreshed after seven days, and GitHub rate-limit responses stop the current batch.
+
+Repository evidence is observational. It does not imply that a developer personally uses a tool or consents to agent contact; only a public, self-declared AI profile controls contact availability.
 
 ## Frontend configuration
 
@@ -68,3 +73,4 @@ Confirm all of the following after deployment:
 - `/api/search?q=typescript&mode=text` returns bounded results.
 - Blob `developers.json` returns `Content-Encoding: gzip` and a long-lived cache header.
 - The activity timer writes directly to the activity container.
+- `repository-agent-ingest` logs bounded updates and persists `repositoryAgentSignals.scannedAt`, `toolIds`, and filename evidence without repository contents.

--- a/functions/repository-agent-ingest/function.json
+++ b/functions/repository-agent-ingest/function.json
@@ -1,0 +1,13 @@
+{
+  "bindings": [
+    {
+      "name": "timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */15 * * * *",
+      "runOnStartup": false,
+      "useMonitor": true
+    }
+  ],
+  "scriptFile": "index.js"
+}

--- a/functions/repository-agent-ingest/index.js
+++ b/functions/repository-agent-ingest/index.js
@@ -1,0 +1,67 @@
+const { getContainer } = require('../shared/cosmos');
+const { scanDeveloperRepositorySignals } = require('../shared/repository-agent-signals');
+
+const BATCH_SIZE = 40;
+const REFRESH_DAYS = 7;
+
+module.exports = async function repositoryAgentIngest(context, {
+  container = getContainer(),
+  fetchImpl = fetch,
+  now = () => new Date(),
+  token = process.env.GITHUB_TOKEN,
+} = {}) {
+  token = String(token || '').trim();
+  if (!token) {
+    context.log.warn('Repository agent ingestion skipped: GITHUB_TOKEN is not configured');
+    return;
+  }
+
+  const runAt = now();
+  const cutoff = new Date(runAt.getTime() - REFRESH_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const { resources: developers } = await container.items.query({
+    query: `SELECT TOP ${BATCH_SIZE} c.id, c.login, c.location
+      FROM c
+      WHERE IS_DEFINED(c.login)
+        AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')
+        AND (NOT IS_DEFINED(c.repositoryAgentSignals.scannedAt) OR c.repositoryAgentSignals.scannedAt < @cutoff)`,
+    parameters: [{ name: '@cutoff', value: cutoff }],
+  }).fetchAll();
+
+  let updated = 0;
+  let detected = 0;
+  let failed = 0;
+
+  for (const developer of developers) {
+    try {
+      const result = await scanDeveloperRepositorySignals(fetchImpl, developer.login, token);
+      const value = {
+        source: 'public-repository',
+        scannedAt: runAt.toISOString(),
+        scannedRepositories: result.scannedRepositories,
+        toolIds: result.signals.map(signal => signal.id),
+        signals: result.signals,
+      };
+      await container.item(developer.id, developer.location || 'Unknown').patch({
+        operations: [{ op: 'set', path: '/repositoryAgentSignals', value }],
+      });
+      updated += 1;
+      if (result.signals.length > 0) detected += 1;
+    } catch (error) {
+      failed += 1;
+      context.log.warn('Repository agent scan failed', {
+        login: developer.login,
+        status: error.status,
+        message: error.message,
+      });
+      if (error.status === 403 || error.status === 429 || error.rateLimitRemaining === 0) break;
+    }
+  }
+
+  context.log('Repository agent ingestion completed', {
+    selected: developers.length,
+    updated,
+    detected,
+    failed,
+    cutoff,
+  });
+};

--- a/functions/shared/repository-agent-signals.js
+++ b/functions/shared/repository-agent-signals.js
@@ -1,0 +1,124 @@
+const MAX_AGENT_SIGNAL_REPOSITORIES = 8;
+const MAX_AGENT_SIGNAL_PATHS = 5;
+const GITHUB_API = 'https://api.github.com';
+
+const TOOL_NAMES = new Map([
+  ['github-copilot', 'GitHub Copilot'],
+  ['claude-code', 'Claude Code'],
+  ['cursor', 'Cursor'],
+  ['openai-codex', 'OpenAI Codex'],
+  ['gemini-cli', 'Gemini CLI'],
+  ['windsurf', 'Windsurf'],
+  ['custom-agent', 'Custom agent'],
+]);
+
+const SIGNAL_RULES = [
+  { id: 'github-copilot', matches: path => path === '.github/copilot-instructions.md' || /^\.github\/instructions\/.+\.instructions\.md$/.test(path) || /^\.github\/agents\/.+\.agent\.md$/.test(path) },
+  { id: 'claude-code', matches: path => path === 'claude.md' || path.startsWith('.claude/') },
+  { id: 'cursor', matches: path => path === '.cursorrules' || path.startsWith('.cursor/rules/') },
+  { id: 'openai-codex', matches: path => path === '.codex/config.toml' },
+  { id: 'gemini-cli', matches: path => path === 'gemini.md' || path.startsWith('.gemini/') },
+  { id: 'windsurf', matches: path => path === '.windsurfrules' || path.startsWith('.windsurf/rules/') },
+  { id: 'custom-agent', matches: path => path === 'agents.md' || path.endsWith('/agents.md') },
+];
+
+function normalizePath(value) {
+  return String(value || '').trim().replaceAll('\\', '/').replace(/^\.\//, '').toLowerCase();
+}
+
+function detectRepositoryAgentSignals(repositories) {
+  const signals = new Map();
+
+  for (const repository of repositories.slice(0, MAX_AGENT_SIGNAL_REPOSITORIES)) {
+    const repositoryName = String(repository?.fullName || '').trim();
+    if (!repositoryName || !Array.isArray(repository.paths)) continue;
+    const matchesByTool = new Map();
+
+    for (const rawPath of repository.paths) {
+      const path = normalizePath(rawPath);
+      if (!path) continue;
+      for (const rule of SIGNAL_RULES) {
+        if (!rule.matches(path)) continue;
+        const paths = matchesByTool.get(rule.id) || [];
+        if (paths.length < MAX_AGENT_SIGNAL_PATHS && !paths.includes(path)) paths.push(path);
+        matchesByTool.set(rule.id, paths);
+      }
+    }
+
+    for (const [id, paths] of matchesByTool) {
+      const signal = signals.get(id) || {
+        id,
+        name: TOOL_NAMES.get(id),
+        source: 'public-repository',
+        repositories: [],
+      };
+      signal.repositories.push({
+        name: repositoryName,
+        url: `https://github.com/${repositoryName}`,
+        paths,
+      });
+      signals.set(id, signal);
+    }
+  }
+
+  return [...signals.values()].sort((first, second) =>
+    second.repositories.length - first.repositories.length || first.name.localeCompare(second.name));
+}
+
+function githubHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'devglobe-agent-signal-ingest',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+async function scanDeveloperRepositorySignals(fetchImpl, login, token) {
+  const response = await fetchImpl(`${GITHUB_API}/users/${encodeURIComponent(login)}/repos?type=owner&sort=updated&direction=desc&per_page=30`, {
+    headers: githubHeaders(token),
+  });
+  if (response.status === 404) return { scannedRepositories: 0, signals: [] };
+  if (!response.ok) {
+    const error = new Error(`GitHub repository lookup returned ${response.status}`);
+    error.status = response.status;
+    error.rateLimitRemaining = Number(response.headers.get('x-ratelimit-remaining'));
+    throw error;
+  }
+
+  const payload = await response.json();
+  const repositories = (Array.isArray(payload) ? payload : [])
+    .filter(repository => !repository.private && !repository.fork && !repository.archived && repository.default_branch)
+    .slice(0, MAX_AGENT_SIGNAL_REPOSITORIES);
+  const scanned = [];
+  for (const repository of repositories) {
+    const treeResponse = await fetchImpl(`${GITHUB_API}/repos/${repository.full_name}/git/trees/${encodeURIComponent(repository.default_branch)}?recursive=1`, {
+      headers: githubHeaders(token),
+    });
+    if (!treeResponse.ok) {
+      const error = new Error(`GitHub repository tree lookup returned ${treeResponse.status}`);
+      error.status = treeResponse.status;
+      error.rateLimitRemaining = Number(treeResponse.headers.get('x-ratelimit-remaining'));
+      throw error;
+    }
+    const tree = await treeResponse.json();
+    scanned.push({
+      fullName: repository.full_name,
+      paths: Array.isArray(tree.tree)
+        ? tree.tree.filter(entry => entry.type === 'blob').map(entry => entry.path)
+        : [],
+    });
+  }
+
+  return {
+    scannedRepositories: scanned.length,
+    signals: detectRepositoryAgentSignals(scanned),
+  };
+}
+
+module.exports = {
+  MAX_AGENT_SIGNAL_PATHS,
+  MAX_AGENT_SIGNAL_REPOSITORIES,
+  detectRepositoryAgentSignals,
+  scanDeveloperRepositorySignals,
+};

--- a/lib/agent-network.js
+++ b/lib/agent-network.js
@@ -13,6 +13,14 @@ export const AGENT_GLOBE_NODES = [
   { id: 'windsurf', name: 'Windsurf', lat: -32, lng: 76, color: '#00c4b4' },
   { id: 'custom-agent', name: 'Custom agent', lat: 58, lng: 34, color: '#00b0d8' },
 ];
+const AGENT_GLOBE_NODE_IDS = new Set(AGENT_GLOBE_NODES.map(node => node.id));
+
+function repositoryToolIds(developer) {
+  const ids = Array.isArray(developer.repositoryAgentTools)
+    ? developer.repositoryAgentTools
+    : (developer.repositoryAgentSignals?.signals || []).map(signal => signal.id);
+  return [...new Set(ids.filter(id => AGENT_GLOBE_NODE_IDS.has(id)))];
+}
 
 export function isAgentReadyDeveloper(developer) {
   const profile = getPublicAiProfile(developer.aiProfile);
@@ -26,11 +34,13 @@ export function projectAgentReadiness(developer) {
   const agentReady = developer.claimed === true
     && profile?.acceptsAgentRequests === true
     && profile.contactPolicy === 'verified-agents';
-  const { aiProfile, ...publicDeveloper } = developer;
+  const repositoryAgentTools = repositoryToolIds(developer);
+  const { aiProfile, repositoryAgentSignals, ...publicDeveloper } = developer;
   return {
     ...publicDeveloper,
     agentReady,
     agentTools: agentReady ? profile.tools.map(tool => tool.id) : [],
+    repositoryAgentTools,
   };
 }
 
@@ -44,22 +54,41 @@ export function buildAgentRelationshipGraph(
   const counts = new Map();
   const links = [];
   const linkedDevelopers = new Map();
+  const uniqueDevelopers = new Map();
 
   for (const developer of developers) {
-    if (!developer.agentReady || developer.lat == null || developer.lng == null) continue;
-    for (const toolId of developer.agentTools || []) {
+    const login = String(developer.login || '').trim().toLowerCase();
+    if (!login) continue;
+    const current = uniqueDevelopers.get(login);
+    uniqueDevelopers.set(login, current ? {
+      ...current,
+      ...developer,
+      agentReady: current.agentReady || developer.agentReady,
+      agentTools: [...new Set([...(current.agentTools || []), ...(developer.agentTools || [])])],
+      repositoryAgentTools: [...new Set([...(current.repositoryAgentTools || []), ...(developer.repositoryAgentTools || [])])],
+    } : developer);
+  }
+
+  for (const developer of uniqueDevelopers.values()) {
+    if (developer.lat == null || developer.lng == null) continue;
+    const toolIds = new Set([...(developer.agentTools || []), ...(developer.repositoryAgentTools || [])]);
+    for (const toolId of toolIds) {
       if (nodesById.has(toolId)) cohortCounts.set(toolId, (cohortCounts.get(toolId) || 0) + 1);
     }
   }
 
-  for (const developer of developers) {
-    if (!developer.agentReady || developer.lat == null || developer.lng == null) continue;
-    for (const toolId of developer.agentTools || []) {
+  for (const developer of uniqueDevelopers.values()) {
+    if (developer.lat == null || developer.lng == null) continue;
+    const login = developer.login.toLowerCase();
+    const toolIds = new Set([...(developer.agentTools || []), ...(developer.repositoryAgentTools || [])]);
+    for (const toolId of toolIds) {
       const node = nodesById.get(toolId);
       const count = counts.get(toolId) || 0;
       if (!node || (cohortCounts.get(toolId) || 0) < privacyThreshold || count >= limitPerTool) continue;
+      const source = developer.agentTools?.includes(toolId) ? 'self-declared' : 'public-repository';
       counts.set(toolId, count + 1);
-      linkedDevelopers.set(developer.login, {
+      linkedDevelopers.set(login, {
+        id: developer.id || developer.login,
         login: developer.login,
         name: developer.name || developer.login,
         avatarUrl: developer.avatarUrl,
@@ -68,20 +97,24 @@ export function buildAgentRelationshipGraph(
         markerLat: developer.lat,
         markerLng: developer.lng,
         markerType: 'developer',
-        agentReady: true,
+        agentReady: developer.agentReady === true,
+        repositoryDetected: source === 'public-repository',
         score: developer.score || 0,
       });
       links.push({
-        id: `${toolId}:${developer.login}`,
+        id: `${toolId}:${login}`,
         toolId,
         toolName: node.name,
-        developerLogin: developer.login,
+        developerLogin: login,
         startLat: node.lat,
         startLng: node.lng,
         endLat: developer.lat,
         endLng: developer.lng,
         color: [node.color, 'rgba(34, 211, 238, 0.72)'],
-        label: `${node.name} is publicly listed by @${developer.login}`,
+        source,
+        label: source === 'self-declared'
+          ? `${node.name} is publicly listed by @${developer.login}`
+          : `${node.name} configuration detected in @${developer.login}'s public repositories`,
       });
     }
   }
@@ -125,14 +158,18 @@ export function buildAgentNetworkSnapshot({ developers = [], introductionCounts 
   const countries = new Set();
 
   const openDevelopers = developers.filter(isAgentReadyDeveloper);
+  const repositoryDevelopers = developers.filter(developer => repositoryToolIds(developer).length > 0);
 
-  for (const developer of openDevelopers) {
-    const country = normalizeCountry(extractCountry(developer.location || ''));
-    if (country) countries.add(country.toLowerCase());
-
-    for (const tool of developer.aiProfile.tools) {
-      toolCounts.set(tool.id, (toolCounts.get(tool.id) || 0) + 1);
+  for (const developer of developers) {
+    const toolIds = new Set();
+    if (isAgentReadyDeveloper(developer)) {
+      const country = normalizeCountry(extractCountry(developer.location || ''));
+      if (country) countries.add(country.toLowerCase());
+      for (const tool of developer.aiProfile.tools) toolIds.add(tool.id);
     }
+    for (const toolId of repositoryToolIds(developer)) toolIds.add(toolId);
+
+    for (const toolId of toolIds) toolCounts.set(toolId, (toolCounts.get(toolId) || 0) + 1);
   }
 
   const tools = [...toolCounts.entries()]
@@ -144,6 +181,7 @@ export function buildAgentNetworkSnapshot({ developers = [], introductionCounts 
     privacyThreshold: threshold,
     metrics: {
       openDevelopers: reportMetric(openDevelopers.length, threshold),
+      repositoryDevelopers: reportMetric(repositoryDevelopers.length, threshold),
       acceptedConnections: reportMetric(introductionCounts.accepted || 0, threshold),
       pendingRequests: reportMetric(introductionCounts.pending || 0, threshold),
       countries: reportMetric(countries.size, threshold),

--- a/styles/main.css
+++ b/styles/main.css
@@ -1107,6 +1107,15 @@ body {
   object-fit: cover;
 }
 
+.globe-avatar-marker--repository::after {
+  position: absolute;
+  inset: -5px;
+  border: 1px dashed #22d3ee;
+  border-radius: 50%;
+  content: '';
+  pointer-events: none;
+}
+
 .globe-agent-marker {
   position: relative;
   display: grid;
@@ -3340,6 +3349,10 @@ body {
 
 .agent-network__metrics > div:nth-child(2n) { border-right: 0; }
 .agent-network__metrics > div:nth-last-child(-n + 2) { border-bottom: 0; }
+.agent-network__metrics > div:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  border-right: 0;
+}
 
 .agent-network__metrics dt {
   color: var(--text-muted);

--- a/tests/agent-network.test.js
+++ b/tests/agent-network.test.js
@@ -61,6 +61,52 @@ test('builds bounded public tool-to-developer relationships', () => {
   assert.match(graph.links[0].label, /publicly listed/);
 });
 
+test('plots repository evidence without implying agent contact consent', () => {
+  const repositoryDeveloper = projectAgentReadiness({
+    login: 'repo-user',
+    lat: 40,
+    lng: -70,
+    claimed: false,
+    repositoryAgentSignals: {
+      signals: [{ id: 'github-copilot' }, { id: 'claude-code' }, { id: 'unknown-tool' }],
+    },
+  });
+  const graph = buildAgentRelationshipGraph([repositoryDeveloper], 20, 1);
+
+  assert.equal(repositoryDeveloper.agentReady, false);
+  assert.deepEqual(repositoryDeveloper.repositoryAgentTools, ['github-copilot', 'claude-code']);
+  assert.deepEqual(graph.nodes.map(node => node.id), ['github-copilot', 'claude-code']);
+  assert.equal(graph.links.every(link => link.source === 'public-repository'), true);
+  assert.equal(graph.developers[0].repositoryDetected, true);
+  assert.match(graph.links[0].label, /configuration detected/);
+});
+
+test('accepts projected repository tool IDs from the aggregate query', () => {
+  const projected = projectAgentReadiness({
+    login: 'projected-user',
+    claimed: false,
+    repositoryAgentTools: ['github-copilot', 'unknown-tool', 'github-copilot'],
+  });
+
+  assert.deepEqual(projected.repositoryAgentTools, ['github-copilot']);
+  assert.equal('repositoryAgentSignals' in projected, false);
+});
+
+test('counts duplicate login documents once for privacy and links', () => {
+  const duplicates = [
+    { id: 'duplicate-old', login: 'Duplicate', lat: 40, lng: -70, repositoryAgentTools: ['github-copilot'] },
+    { id: 'duplicate-new', login: 'duplicate', lat: 41, lng: -71, repositoryAgentTools: ['github-copilot'] },
+    { id: 'second', login: 'second', lat: 42, lng: -72, repositoryAgentTools: ['github-copilot'] },
+  ];
+  const suppressed = buildAgentRelationshipGraph(duplicates, 20, 3);
+  const visible = buildAgentRelationshipGraph(duplicates, 20, 2);
+
+  assert.equal(suppressed.links.length, 0);
+  assert.equal(visible.links.length, 2);
+  assert.deepEqual(visible.developers.map(developer => developer.login.toLowerCase()).sort(), ['duplicate', 'second']);
+  assert.equal(visible.developers.every(developer => developer.id), true);
+});
+
 test('projects reportable aggregate Agent Network metrics', () => {
   const snapshot = buildAgentNetworkSnapshot({
     developers: [
@@ -72,8 +118,26 @@ test('projects reportable aggregate Agent Network metrics', () => {
   });
 
   assert.deepEqual(snapshot.metrics.openDevelopers, { value: 3, suppressed: false });
+  assert.deepEqual(snapshot.metrics.repositoryDevelopers, { value: null, suppressed: true });
   assert.deepEqual(snapshot.metrics.countries, { value: 3, suppressed: false });
   assert.deepEqual(snapshot.tools, [{ id: 'github-copilot', name: 'GitHub Copilot', count: 3 }]);
+});
+
+test('combines declared and repository-detected tools without double counting developers', () => {
+  const developers = [
+    {
+      ...developer('one', 'USA', ['github-copilot']),
+      repositoryAgentSignals: { signals: [{ id: 'github-copilot' }, { id: 'claude-code' }] },
+    },
+    { login: 'two', repositoryAgentSignals: { signals: [{ id: 'claude-code' }] } },
+    { login: 'three', repositoryAgentSignals: { signals: [{ id: 'claude-code' }] } },
+  ];
+  const snapshot = buildAgentNetworkSnapshot({ developers });
+
+  assert.deepEqual(snapshot.metrics.repositoryDevelopers, { value: 3, suppressed: false });
+  assert.deepEqual(snapshot.tools, [
+    { id: 'claude-code', name: 'Claude Code', count: 3 },
+  ]);
 });
 
 test('suppresses small cohorts and excludes private or unclaimed profiles', () => {

--- a/tests/repository-agent-ingest.test.js
+++ b/tests/repository-agent-ingest.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import repositoryAgentIngest from '../functions/repository-agent-ingest/index.js';
+
+function logger() {
+  const entries = [];
+  const log = (message, details) => entries.push({ level: 'info', message, details });
+  log.warn = (message, details) => entries.push({ level: 'warn', message, details });
+  return { log, entries };
+}
+
+test('scheduled ingestion patches filename-only repository evidence by location partition', async () => {
+  const patches = [];
+  const { log, entries } = logger();
+  const container = {
+    items: {
+      query: () => ({ fetchAll: async () => ({ resources: [
+        { id: 'octocat', login: 'octocat', location: 'San Francisco, USA' },
+      ] }) }),
+    },
+    item: (id, partitionKey) => ({
+      patch: async value => patches.push({ id, partitionKey, value }),
+    }),
+  };
+  const fetchImpl = async url => String(url).includes('/users/')
+    ? Response.json([{ full_name: 'octocat/agents', default_branch: 'main', private: false, fork: false, archived: false }])
+    : Response.json({ tree: [{ type: 'blob', path: '.github/copilot-instructions.md' }] });
+
+  await repositoryAgentIngest({ log }, {
+    container,
+    fetchImpl,
+    token: 'test-token',
+    now: () => new Date('2026-09-01T06:00:00.000Z'),
+  });
+
+  assert.equal(patches.length, 1);
+  assert.equal(patches[0].id, 'octocat');
+  assert.equal(patches[0].partitionKey, 'San Francisco, USA');
+  assert.deepEqual(patches[0].value.operations[0].value.toolIds, ['github-copilot']);
+  assert.deepEqual(patches[0].value.operations[0].value.signals.map(signal => signal.id), ['github-copilot']);
+  assert.equal(patches[0].value.operations[0].value.scannedAt, '2026-09-01T06:00:00.000Z');
+  assert.equal(JSON.stringify(patches).includes('content'), false);
+  assert.deepEqual(entries.at(-1).details, {
+    selected: 1,
+    updated: 1,
+    detected: 1,
+    failed: 0,
+    cutoff: '2026-08-25T06:00:00.000Z',
+  });
+});
+
+test('scheduled ingestion skips safely when the GitHub token is absent', async () => {
+  const { log, entries } = logger();
+  await repositoryAgentIngest({ log }, {
+    container: { items: { query: () => { throw new Error('should not query'); } } },
+    token: '',
+  });
+
+  assert.match(entries[0].message, /GITHUB_TOKEN/);
+});

--- a/tests/repository-agent-signals.test.js
+++ b/tests/repository-agent-signals.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import functionAgentSignals from '../functions/shared/repository-agent-signals.js';
 import { createRepositoryAgentSignalsHandler } from '../app/api/repository-agent-signals/route.js';
 import {
   detectRepositoryAgentSignals,
@@ -7,6 +8,8 @@ import {
   MAX_AGENT_SIGNAL_PATHS,
   MAX_AGENT_SIGNAL_REPOSITORIES,
 } from '../lib/repository-agent-signals.js';
+
+const { scanDeveloperRepositorySignals } = functionAgentSignals;
 
 test('detects agent configuration paths without reading repository content', () => {
   const signals = detectRepositoryAgentSignals([{
@@ -90,4 +93,35 @@ test('API rejects malformed usernames before GitHub lookup', async () => {
   assert.equal(response.status, 400);
   assert.equal((await response.json()).code, 'invalid_login');
   assert.equal(called, false);
+});
+
+test('scheduled scanner stores only filename evidence from eligible owner repositories', async () => {
+  const calls = [];
+  const result = await scanDeveloperRepositorySignals(async url => {
+    calls.push(String(url));
+    if (String(url).includes('/users/')) return Response.json([
+      { full_name: 'octocat/agents', default_branch: 'main', private: false, fork: false, archived: false },
+      { full_name: 'octocat/private', default_branch: 'main', private: true, fork: false, archived: false },
+      { full_name: 'octocat/fork', default_branch: 'main', private: false, fork: true, archived: false },
+    ]);
+    return Response.json({ tree: [
+      { type: 'blob', path: '.github/copilot-instructions.md' },
+      { type: 'blob', path: 'CLAUDE.md' },
+      { type: 'tree', path: '.cursor' },
+    ] });
+  }, 'octocat', 'test-token');
+
+  assert.equal(result.scannedRepositories, 1);
+  assert.deepEqual(result.signals.map(signal => signal.id), ['claude-code', 'github-copilot']);
+  assert.equal(calls.length, 2);
+  assert.equal(JSON.stringify(result).includes('content'), false);
+});
+
+test('scheduled scanner fails the profile when a repository tree cannot be read', async () => {
+  await assert.rejects(
+    scanDeveloperRepositorySignals(async url => String(url).includes('/users/')
+      ? Response.json([{ full_name: 'octocat/agents', default_branch: 'main', private: false, fork: false, archived: false }])
+      : new Response(null, { status: 403, headers: { 'x-ratelimit-remaining': '0' } }), 'octocat', 'test-token'),
+    error => error.status === 403 && error.rateLimitRemaining === 0,
+  );
 });


### PR DESCRIPTION
## Summary
- add a bounded Azure Functions timer that scans filenames in recent public owner repositories and persists agent-tool evidence
- combine repository-detected tools with self-declared tools on the globe while keeping contact consent separate
- enforce privacy thresholds by unique GitHub login and retain normal developer rendering
- label repository-derived relationships and markers as observational evidence
- stop batches on GitHub rate limits and never overwrite evidence after partial tree failures

## Rollout
- scans 40 stale profiles every 15 minutes
- refreshes each profile after 7 days
- scans at most 8 eligible repositories per profile
- GITHUB_TOKEN is present on devglobe-public-api

## Validation
- npm test: 385/385 passing
- npm run build: 70/70 pages
- npm run docs:build
- node --check for both Function files
- git diff --check
- review fixes cover failed tree reads, duplicate-login privacy cohorts, marker hydration, bounded concurrency, and UI consent wording