### PR TITLE
feat: enable first-session mission preview

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -900,7 +900,7 @@ export default function Home() {
         showAgentPrompt={agentProfileStatus === 'missing'}
         onOpenAgentProfile={() => setShowAiProfile(true)}
         onOpenAgentNetwork={handleOpenAgentNetwork}
-        showMissionPreview={false}
+        showMissionPreview
       />
       <QuickTour
         step={tourStep}


### PR DESCRIPTION
## Summary
- expose the existing personalized contribution mission preview to anonymous homepage visitors
- give first-time visitors a concrete value moment before GitHub sign-in
- retain the existing mission funnel analytics and sign-in-to-accept CTA

## Validation
- 
pm test
- 
pm run build
- desktop browser: mission generated for @octocat with match reasons and sign-in CTA
- mobile browser: 390px viewport, no horizontal overflow

Fixes #358