### PR TITLE
feat: claimed-user return briefing

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -17,6 +17,7 @@ import ContributionOpportunitiesModal from '../components/ContributionOpportunit
 import SimilarDevelopersModal from '../components/SimilarDevelopersModal.jsx';
 import QuickTour from '../components/QuickTour.jsx';
 import PlatformActivityBanner from '../components/PlatformActivityBanner.jsx';
+import ReturnBriefing from '../components/ReturnBriefing.jsx';
 import { prepareDeveloperDataset } from '../lib/developer-dataset.js';
 import { acquisitionAttributionProperties, socialAttributionProperties } from '../lib/share-attribution.js';
 import { developerSnapshotUrl, publicApiUrl } from '../lib/public-api.js';
@@ -67,6 +68,7 @@ export default function Home() {
   const [showContributions, setShowContributions] = useState(false);
   const [similarLogin, setSimilarLogin] = useState('');
   const [completionVersion, setCompletionVersion] = useState(0);
+  const [userMenuRequest, setUserMenuRequest] = useState(0);
   const [agentProfileStatus, setAgentProfileStatus] = useState('idle');
   const [agentGlobeLayerVisible, setAgentGlobeLayerVisible] = useState(false);
   const [agentRelationshipGraph, setAgentRelationshipGraph] = useState({ nodes: [], developers: [], links: [] });
@@ -872,6 +874,7 @@ export default function Home() {
         onOpenProfile={handleOpenOwnProfile}
         onGenerateCard={handleGenerateOwnCard}
         completionVersion={completionVersion}
+        userMenuRequest={userMenuRequest}
         claimStatus={claimStatus}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={handleToggleSidebar}
@@ -880,7 +883,15 @@ export default function Home() {
         onAddMe={handleAddMe}
         onStartTour={handleTourFocusSearch}
       />
-      <PlatformActivityBanner />
+      {user && claimStatus === 'claimed' ? (
+        <ReturnBriefing
+          login={user.login}
+          onOpenContributions={() => setShowContributions(true)}
+          onOpenWeeklyUpdates={() => setUserMenuRequest(request => request + 1)}
+        />
+      ) : (
+        <PlatformActivityBanner />
+      )}
       <SearchBar
         developers={developers}
         onResults={handleSearch}

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -6,7 +6,7 @@ import UserMenu from './UserMenu.jsx';
 
 const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
 
-export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
+export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, userMenuRequest, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
   return (
     <header className="header">
       <div className="header__brand" onClick={onHome} style={{ cursor: 'pointer' }}>
@@ -129,7 +129,7 @@ export default function Header({ onHome, theme, onToggleTheme, user, onLogout, o
           </svg>
           <span className="btn__label">Sponsor</span>
         </a>
-        <UserMenu user={user} onLogout={onLogout} onClaim={onClaim} onEditAiProfile={onEditAiProfile} onOpenIntroductions={onOpenIntroductions} onOpenShortlists={onOpenShortlists} onOpenContributions={onOpenContributions} onOpenSimilar={onOpenSimilar} onOpenProfile={onOpenProfile} onGenerateCard={onGenerateCard} completionVersion={completionVersion} claimStatus={claimStatus} />
+        <UserMenu user={user} onLogout={onLogout} onClaim={onClaim} onEditAiProfile={onEditAiProfile} onOpenIntroductions={onOpenIntroductions} onOpenShortlists={onOpenShortlists} onOpenContributions={onOpenContributions} onOpenSimilar={onOpenSimilar} onOpenProfile={onOpenProfile} onGenerateCard={onGenerateCard} completionVersion={completionVersion} openRequest={userMenuRequest} claimStatus={claimStatus} />
       </div>
     </header>
   );

--- a/components/ReturnBriefing.jsx
+++ b/components/ReturnBriefing.jsx
@@ -1,0 +1,122 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { track } from '../lib/analytics.js';
+import { formatRelativeTime } from '../lib/format.js';
+
+const EMPTY_RESULT = { events: [], unreadCount: 0 };
+
+export default function ReturnBriefing({ login, onOpenContributions, onOpenWeeklyUpdates }) {
+  const [result, setResult] = useState(EMPTY_RESULT);
+  const [status, setStatus] = useState('loading');
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/feed?limit=3', { cache: 'no-store', credentials: 'same-origin' })
+      .then(async response => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Unable to load followed updates');
+        if (!cancelled) {
+          setResult({
+            events: Array.isArray(data.events) ? data.events : [],
+            unreadCount: Number.isInteger(data.unreadCount) ? data.unreadCount : 0,
+          });
+          setStatus('ready');
+          track('return_briefing_viewed', { journey: 'personalized_return' });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('unavailable');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  async function reviewUpdates() {
+    const willExpand = !expanded;
+    setExpanded(willExpand);
+    if (!willExpand) return;
+
+    track('return_briefing_action_selected', { action: 'review_updates', journey: 'personalized_return' });
+    const unreadEvents = result.events.filter(event => !event.read);
+    if (unreadEvents.length === 0) return;
+
+    try {
+      const response = await fetch('/api/feed', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventIds: unreadEvents.flatMap(event => event.groupedIds || [event.id]) }),
+      });
+      if (!response.ok) return;
+      setResult(current => ({
+        events: current.events.map(event => ({ ...event, read: true })),
+        unreadCount: Math.max(0, current.unreadCount - unreadEvents.length),
+      }));
+    } catch { /* Reviewing updates remains available when read state cannot be saved. */ }
+  }
+
+  const newest = result.events[0];
+  const updateLabel = status === 'loading'
+    ? 'Checking followed developers...'
+    : newest?.summary || (status === 'unavailable'
+      ? 'Your return tools are still available.'
+      : 'Follow developers to receive meaningful updates here.');
+
+  return (
+    <aside className={`return-briefing${expanded ? ' return-briefing--expanded' : ''}`} aria-labelledby="return-briefing-title">
+      <div className="return-briefing__heading">
+        <div>
+          <span>YOUR DEVGlobe</span>
+          <h2 id="return-briefing-title">Welcome back</h2>
+        </div>
+        {result.unreadCount > 0 && <strong aria-label={`${result.unreadCount} unread followed updates`}>{result.unreadCount} new</strong>}
+      </div>
+
+      <p className="return-briefing__summary">{updateLabel}</p>
+
+      {expanded && result.events.length > 0 && (
+        <ol className="return-briefing__updates">
+          {result.events.map(event => (
+            <li key={event.id}>
+              <span>{event.summary}</span>
+              <small>@{event.subjectLogin} · {formatRelativeTime(event.createdAt)}</small>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <div className="return-briefing__actions">
+        {result.events.length > 0 && (
+          <button type="button" onClick={reviewUpdates} aria-expanded={expanded}>
+            {expanded ? 'Hide updates' : 'Review updates'}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            track('return_briefing_action_selected', { action: 'find_contribution', journey: 'personalized_return' });
+            onOpenContributions();
+          }}
+        >
+          Find a contribution
+        </button>
+        <Link
+          href={`/developer/${encodeURIComponent(login)}`}
+          onClick={() => track('return_briefing_action_selected', { action: 'view_impact', journey: 'personalized_return' })}
+        >
+          View my impact
+        </Link>
+        <button
+          type="button"
+          onClick={() => {
+            track('return_briefing_action_selected', { action: 'weekly_updates', journey: 'personalized_return' });
+            onOpenWeeklyUpdates();
+          }}
+        >
+          Weekly updates
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/components/UserMenu.jsx
+++ b/components/UserMenu.jsx
@@ -6,7 +6,7 @@ import { developerInviteUrl } from '../lib/share-attribution.js';
 import ProfileCompletionChecklist from './ProfileCompletionChecklist.jsx';
 import ProfileInsights from './ProfileInsights.jsx';
 
-export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, claimStatus }) {
+export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, openRequest = 0, claimStatus }) {
   const [open, setOpen] = useState(false);
   const [verificationStatus, setVerificationStatus] = useState('idle');
   const [digestPreference, setDigestPreference] = useState(null);
@@ -23,6 +23,10 @@ export default function UserMenu({ user, onLogout, onClaim, onEditAiProfile, onO
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  useEffect(() => {
+    if (openRequest > 0) setOpen(true);
+  }, [openRequest]);
 
   useEffect(() => {
     const status = new URLSearchParams(window.location.search).get('email_verification');

--- a/docs/prd/personalized-return-experience.md
+++ b/docs/prd/personalized-return-experience.md
@@ -1,0 +1,76 @@
+# PRD: Personalized Return Experience
+
+**Status:** MVP implementation
+**Issue:** [#360](https://github.com/sajeetharan/devglobe/issues/360)
+**Priority:** P0
+**Depends on:** [#111](https://github.com/sajeetharan/devglobe/issues/111), [#113](https://github.com/sajeetharan/devglobe/issues/113), [#127](https://github.com/sajeetharan/devglobe/issues/127), [#165](https://github.com/sajeetharan/devglobe/issues/165)
+**Last updated:** 2026-09-02
+
+## Summary
+
+DevGlobe will give signed-in, claimed developers a compact return briefing on the home page. The briefing combines meaningful updates from explicitly followed developers with direct paths to contribution recommendations, personal impact history, and weekly impact preferences. It turns existing retention capabilities into one understandable reason to return without adding another feed or notification system.
+
+## Problem
+
+DevGlobe already stores developer follows, builds a personalized activity feed, captures impact history, recommends contribution opportunities, and sends opt-in weekly impact email. These capabilities live in separate panels and menus, so a returning developer cannot quickly answer “what changed, and what should I do next?” Overall traffic has declined while profile exploration has increased, making repeat utility more important than adding another broad discovery feature.
+
+## Goals
+
+- Show a claimed developer whether followed-developer updates are waiting.
+- Preview the most recent meaningful update using the existing personalized feed.
+- Provide direct actions for reviewing updates, finding a contribution, and opening personal impact history.
+- Explain the weekly impact return loop without changing email consent or verification rules.
+- Measure briefing views and selected actions with bounded, privacy-safe telemetry.
+- Improve seven-day retention from 7.7% toward the issue target of 15%.
+
+## Non-goals
+
+- A new recommendation algorithm, ranking formula, follow model, or notification pipeline.
+- Public follower counts, inferred interests, or personalized content for signed-out visitors.
+- Exposing watchlists, email addresses, raw activity payloads, or opaque browser identifiers.
+- Automatically enabling weekly email or changing existing consent preferences.
+- Replacing the activity drawer, impact history, or contribution opportunity surfaces.
+
+## User experience
+
+- The briefing appears only after a signed-in developer's profile is confirmed as claimed.
+- It requests at most three personalized feed items and presents the newest item as a concise preview.
+- The unread count is descriptive, not a notification badge that implies real-time delivery.
+- **Review updates** expands the briefing to show up to three personalized feed items and marks those items read.
+- **Find a contribution** opens the existing contribution recommendations.
+- **View my impact** opens the developer's own profile and impact history.
+- **Weekly updates** opens the existing profile menu where email verification and weekly impact consent are managed.
+- If the feed is empty, the briefing explains that following developers creates personalized updates and still offers the contribution and impact actions.
+- If feed data is temporarily unavailable, the briefing keeps the durable actions available and does not expose an error stack or retry loop.
+
+## Data and privacy
+
+The briefing reads `GET /api/feed?limit=3`, which is authenticated, private, and already filters events through explicit follows and claimed-profile visibility. It receives only normalized public summaries. The component does not persist feed data or request contact information.
+
+Telemetry uses existing engagement ingestion with bounded values only:
+
+- `return_briefing_viewed` with `journey=personalized_return`
+- `return_briefing_action_selected` with an action from `review_updates`, `find_contribution`, `view_impact`, or `weekly_updates`
+
+No login, event summary, project name, URL, email state, or watchlist content is attached to these events.
+
+## Success metrics
+
+- Seven-day retention for claimed developers, with a target of 15%.
+- Percentage of eligible sessions that see the return briefing.
+- Briefing-to-action conversion by bounded action.
+- Personalized-feed opens and contribution-opportunity opens from the briefing.
+- Weekly impact return sessions, measured by the existing `weekly_digest_returned` event.
+
+Metrics are directional until four complete post-launch weeks are available. Cohorts below the existing privacy threshold remain suppressed in reporting.
+
+## Acceptance criteria
+
+- Claimed signed-in developers see a compact return briefing on the home page.
+- The briefing shows an unread count and newest personalized update when feed data exists.
+- Empty and unavailable feed states remain useful and do not block the page.
+- Actions reuse the existing activity, contribution, and own-profile experiences.
+- Briefing telemetry contains only bounded journey and action values.
+- Signed-out and unclaimed visitors do not see the personalized briefing.
+- Existing email verification and weekly digest consent behavior is unchanged.
+- Focused tests, the full test suite, and the production build pass.

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -30,6 +30,8 @@ const ENGAGEMENT_EVENT_MAP = {
 	site_visited: 'site_visited',
 	personalized_profile_viewed: 'personalized_profile_viewed',
 	recommendation_opened: 'recommendation_opened',
+	return_briefing_action_selected: 'return_briefing_action_selected',
+	return_briefing_viewed: 'return_briefing_viewed',
 	session_restored: 'session_restored',
 	weekly_digest_returned: 'weekly_digest_returned',
 };

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -27,6 +27,8 @@ export const ENGAGEMENT_EVENTS = new Set([
   'profile_viewed',
   'personalized_profile_viewed',
   'recommendation_opened',
+  'return_briefing_action_selected',
+  'return_briefing_viewed',
   'search_appearance',
   'search_submitted',
   'session_restored',
@@ -48,6 +50,7 @@ const ACQUISITION_SOURCES = new Set([...SHARE_CHANNELS, 'direct', 'external_refe
 const ACQUISITION_CHANNELS = new Set(['community', 'direct', 'email', 'other', 'referral', 'social']);
 const ACQUISITION_CAMPAIGNS = new Set(['agents', 'community', 'country_leaderboard', 'developer_activation', 'developer_invite', 'developer_spotlight', 'identity_card', 'india_top_50', 'none', 'organic_referral', 'product', 'rank_movement', 'shared_profile', 'unknown', 'weekly_impact']);
 const WEEKLY_DIGEST_ACTIONS = new Set(['contribution_opportunity', 'introduction_request', 'rank_movement', 'unknown']);
+const RETURN_BRIEFING_ACTIONS = new Set(['find_contribution', 'review_updates', 'view_impact', 'weekly_updates']);
 
 export class EngagementValidationError extends Error {}
 
@@ -80,6 +83,7 @@ function normalizeProperties(value, eventName) {
     if (key === 'source' && ACQUISITION_EVENTS.has(eventName) && !ACQUISITION_SOURCES.has(normalized)) normalized = 'other';
     if (key === 'campaign' && !ACQUISITION_CAMPAIGNS.has(normalized)) normalized = 'unknown';
     if (key === 'action' && eventName === 'weekly_digest_returned' && !WEEKLY_DIGEST_ACTIONS.has(normalized)) normalized = 'unknown';
+    if (key === 'action' && eventName === 'return_briefing_action_selected' && !RETURN_BRIEFING_ACTIONS.has(normalized)) normalized = 'unknown';
     if (normalized) properties[key] = normalized;
   }
   return properties;
@@ -108,7 +112,7 @@ export function createEngagementEvent(input, options = {}) {
     ? [normalized.properties.channel || '', normalized.properties.action || ''].join(':')
     : normalized.eventName === 'site_visited'
       ? [normalized.properties.journey || '', normalized.properties.source || '', normalized.properties.channel || '', normalized.properties.campaign || ''].join(':')
-    : ['next_action_selected', 'profile_primary_action_viewed'].includes(normalized.eventName)
+    : ['next_action_selected', 'profile_primary_action_viewed', 'return_briefing_action_selected'].includes(normalized.eventName)
       ? normalized.properties.action || ''
       : normalized.eventName === 'recommendation_opened'
         ? normalized.properties.journey || ''

--- a/styles/main.css
+++ b/styles/main.css
@@ -231,6 +231,129 @@ body {
   background: color-mix(in srgb, #f97316 22%, transparent);
 }
 
+.return-briefing {
+  position: fixed;
+  top: 112px;
+  right: 24px;
+  z-index: 96;
+  display: grid;
+  width: min(340px, calc(100vw - 48px));
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel-92);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-strong);
+}
+
+.return-briefing__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.return-briefing__heading > div {
+  display: grid;
+  gap: 2px;
+}
+
+.return-briefing__heading span {
+  color: #22d3ee;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.return-briefing__heading h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+}
+
+.return-briefing__heading strong {
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: color-mix(in srgb, #22d3ee 16%, transparent);
+  color: #22d3ee;
+  font-size: 10px;
+}
+
+.return-briefing__summary {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.return-briefing__updates {
+  display: grid;
+  max-height: 210px;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.return-briefing__updates li {
+  display: grid;
+  gap: 3px;
+  padding: 9px 0;
+  border-top: 1px solid var(--border);
+  color: var(--text-primary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.return-briefing__updates small {
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.return-briefing__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.return-briefing__actions button,
+.return-briefing__actions a {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--overlay-subtle);
+  color: var(--text-primary);
+  font: 700 10px var(--font);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.return-briefing__actions button:hover,
+.return-briefing__actions a:hover {
+  border-color: #22d3ee;
+}
+
+@media (max-width: 1448px) {
+  .return-briefing {
+    top: auto;
+    bottom: 24px;
+  }
+}
+
+@media (max-width: 900px) {
+  .return-briefing {
+    right: 12px;
+    bottom: 76px;
+    left: 12px;
+    width: auto;
+  }
+
+}
+
 .btn {
   display: inline-flex;
   align-items: center;

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -332,3 +332,26 @@ test('accepts bounded agent onboarding events without prompt or identity data', 
     });
   }
 });
+
+test('accepts bounded return briefing telemetry without identity or feed content', () => {
+  assert.deepEqual(normalizeEngagementEvent({
+    eventName: 'return_briefing_viewed',
+    properties: { journey: 'personalized_return', login: 'octocat' },
+  }), {
+    eventName: 'return_briefing_viewed',
+    targetLogin: null,
+    properties: { journey: 'personalized_return' },
+  });
+  assert.deepEqual(normalizeEngagementEvent({
+    eventName: 'return_briefing_action_selected',
+    properties: { action: 'find_contribution', journey: 'personalized_return', summary: 'private feed content' },
+  }), {
+    eventName: 'return_briefing_action_selected',
+    targetLogin: null,
+    properties: { action: 'find_contribution', journey: 'personalized_return' },
+  });
+  assert.equal(normalizeEngagementEvent({
+    eventName: 'return_briefing_action_selected',
+    properties: { action: 'private-arbitrary-value' },
+  }).properties.action, 'unknown');
+});


### PR DESCRIPTION
## Summary
- Adds a claimed-user return briefing.
- Reuses existing feed, contribution, impact, and weekly-email controls.
- Adds bounded, privacy-safe telemetry and a dedicated PRD.

## Testing
- npm test (386 passed)
- npm run build (70/70 pages)
- Desktop/mobile Playwright checks

Closes #360