### PR TITLE
fix: add return briefing close button

### DIFF
--- a/components/ReturnBriefing.jsx
+++ b/components/ReturnBriefing.jsx
@@ -11,6 +11,7 @@ export default function ReturnBriefing({ login, onOpenContributions, onOpenWeekl
   const [result, setResult] = useState(EMPTY_RESULT);
   const [status, setStatus] = useState('loading');
   const [expanded, setExpanded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,6 +64,8 @@ export default function ReturnBriefing({ login, onOpenContributions, onOpenWeekl
       ? 'Your return tools are still available.'
       : 'Follow developers to receive meaningful updates here.');
 
+  if (dismissed) return null;
+
   return (
     <aside className={`return-briefing${expanded ? ' return-briefing--expanded' : ''}`} aria-labelledby="return-briefing-title">
       <div className="return-briefing__heading">
@@ -70,7 +73,18 @@ export default function ReturnBriefing({ login, onOpenContributions, onOpenWeekl
           <span>YOUR DEVGlobe</span>
           <h2 id="return-briefing-title">Welcome back</h2>
         </div>
-        {result.unreadCount > 0 && <strong aria-label={`${result.unreadCount} unread followed updates`}>{result.unreadCount} new</strong>}
+        <div className="return-briefing__heading-actions">
+          {result.unreadCount > 0 && <strong aria-label={`${result.unreadCount} unread followed updates`}>{result.unreadCount} new</strong>}
+          <button
+            type="button"
+            className="return-briefing__close"
+            onClick={() => setDismissed(true)}
+            aria-label="Close welcome back"
+            title="Close welcome back"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
       </div>
 
       <p className="return-briefing__summary">{updateLabel}</p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -254,9 +254,15 @@ body {
   gap: 12px;
 }
 
-.return-briefing__heading > div {
+.return-briefing__heading > div:first-child {
   display: grid;
   gap: 2px;
+}
+
+.return-briefing__heading-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .return-briefing__heading span {
@@ -277,6 +283,31 @@ body {
   background: color-mix(in srgb, #22d3ee 16%, transparent);
   color: #22d3ee;
   font-size: 10px;
+}
+
+.return-briefing__close {
+  display: inline-grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font: 400 24px/1 var(--font);
+  cursor: pointer;
+}
+
+.return-briefing__close:hover {
+  background: var(--overlay-subtle);
+  color: var(--text-primary);
+}
+
+.return-briefing__close:focus-visible {
+  outline: 2px solid #22d3ee;
+  outline-offset: 2px;
 }
 
 .return-briefing__summary {


### PR DESCRIPTION
## Summary
- Adds an accessible 44x44 close button to the Welcome back briefing.
- Keeps dismissal local to the current page visit.
- Verifies desktop and mobile layout and keyboard focus.

## Testing
- npm test (386 passed)
- npm run build (70/70 pages)