### PR TITLE
Unify navigation destination palettes

### DIFF
--- a/components/AgentSetupPage.module.css
+++ b/components/AgentSetupPage.module.css
@@ -1,14 +1,14 @@
 .page {
-  --agent-ink: #132019;
-  --agent-muted: #58665e;
-  --agent-line: #ccd8d0;
-  --agent-green: #087a4b;
+  --agent-ink: var(--text-primary);
+  --agent-muted: var(--text-secondary);
+  --agent-line: var(--border);
+  --agent-green: var(--accent-blue);
   min-height: 100vh;
   overflow-x: hidden;
   background:
-    linear-gradient(rgba(19, 32, 25, 0.045) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(19, 32, 25, 0.045) 1px, transparent 1px),
-    #f4f7f4;
+    linear-gradient(color-mix(in srgb, var(--accent-blue) 4%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--accent-blue) 4%, transparent) 1px, transparent 1px),
+    var(--bg-primary);
   background-size: 32px 32px;
   color: var(--agent-ink);
   font-family: var(--font);
@@ -45,6 +45,7 @@
 .brand img { width: 34px; height: 34px; object-fit: contain; }
 .navLinks { display: flex; gap: 24px; }
 .navLinks a, .resources a { color: var(--agent-ink); font-size: 13px; font-weight: 700; }
+.page a:focus-visible, .page button:focus-visible { outline-color: var(--focus-ring); outline-offset: 3px; }
 
 .hero {
   padding: 92px 0 72px;
@@ -105,7 +106,7 @@
   margin-top: 42px;
   padding: 14px 16px;
   border: 1px solid var(--agent-line);
-  background: #fff;
+  background: var(--bg-card);
 }
 
 .endpoint span { color: var(--agent-muted); font-size: 11px; font-weight: 800; text-transform: uppercase; }
@@ -130,7 +131,7 @@
   display: inline-flex;
   padding: 4px;
   border: 1px solid var(--agent-line);
-  background: #e7ede9;
+  background: var(--bg-secondary);
 }
 
 .clientPicker button {
@@ -145,18 +146,18 @@
   font-weight: 700;
 }
 
-.clientPicker .activeClient { background: #fff; color: var(--agent-ink); box-shadow: 0 1px 4px rgba(19, 32, 25, 0.12); }
-.configPanel { max-width: 820px; margin-top: 18px; border: 1px solid #26362d; background: #101a14; color: #d9ebe0; }
-.configMeta { display: flex; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #304239; color: #91a69a; font-size: 12px; }
-.configMeta button { color: #6ce0a5; }
+.clientPicker .activeClient { background: var(--bg-card); color: var(--agent-ink); box-shadow: var(--shadow); }
+.configPanel { max-width: 820px; margin-top: 18px; border: 1px solid var(--agent-line); background: var(--bg-secondary); color: var(--agent-ink); }
+.configMeta { display: flex; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--agent-line); color: var(--agent-muted); font-size: 12px; }
+.configMeta button { color: var(--mission-link); }
 .configPanel pre { min-height: 180px; margin: 0; overflow-x: auto; padding: 22px; font-size: 14px; line-height: 1.65; }
 .setupAction { display: flex; max-width: 820px; align-items: center; gap: 16px; margin-top: 14px; }
 .setupAction a, .setupAction button { display: inline-flex; min-height: 44px; align-items: center; padding: 0 18px; border: 0; background: var(--agent-green); color: #fff; cursor: pointer; font: inherit; font-size: 13px; font-weight: 800; text-decoration: none; }
 .setupAction span { color: var(--agent-muted); font-size: 13px; line-height: 1.45; }
-.copyError { color: #b42318; font-size: 13px; }
+.copyError { color: var(--danger); font-size: 13px; }
 
 .workflows { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border-top: 1px solid var(--agent-line); border-left: 1px solid var(--agent-line); }
-.workflows article { min-height: 170px; padding: 24px; border-right: 1px solid var(--agent-line); border-bottom: 1px solid var(--agent-line); background: rgba(255, 255, 255, 0.62); }
+.workflows article { min-height: 170px; padding: 24px; border-right: 1px solid var(--agent-line); border-bottom: 1px solid var(--agent-line); background: var(--bg-panel-70); }
 .workflows article > span { color: var(--agent-green); font-family: monospace; font-size: 11px; }
 .workflows p { min-height: 64px; margin: 18px 0; font-size: 16px; line-height: 1.5; }
 .workflows button { padding: 0; }

--- a/components/HacktoberfestMatchmaker.module.css
+++ b/components/HacktoberfestMatchmaker.module.css
@@ -1,12 +1,12 @@
 .page {
-  --match-bg: #081019;
-  --match-surface: #101b27;
-  --match-surface-strong: #152332;
-  --match-line: #263748;
-  --match-text: #f3f6f8;
-  --match-muted: #9badbc;
-  --match-cyan: #53d5e8;
-  --match-orange: #f97316;
+  --match-bg: var(--bg-primary);
+  --match-surface: var(--bg-secondary);
+  --match-surface-strong: var(--bg-hover);
+  --match-line: var(--border);
+  --match-text: var(--text-primary);
+  --match-muted: var(--text-secondary);
+  --match-cyan: var(--accent-blue);
+  --match-orange: var(--mission-accent);
   position: fixed;
   inset: 0;
   height: 100vh;
@@ -17,8 +17,8 @@
   touch-action: pan-y;
   -webkit-overflow-scrolling: touch;
   background:
-    linear-gradient(rgba(83, 213, 232, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(83, 213, 232, 0.035) 1px, transparent 1px),
+    linear-gradient(color-mix(in srgb, var(--accent-blue) 4%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--accent-blue) 4%, transparent) 1px, transparent 1px),
     var(--match-bg);
   background-size: 32px 32px;
   color: var(--match-text);
@@ -56,7 +56,7 @@
 
 .brand img { width: 34px; height: 34px; object-fit: contain; }
 .nav > a:last-child, .footer a { color: var(--match-muted); font-size: 13px; font-weight: 700; }
-.nav a:focus-visible, .page button:focus-visible, .page input:focus-visible, .page article a:focus-visible, .footer a:focus-visible { outline: 2px solid var(--match-cyan); outline-offset: 3px; }
+.nav a:focus-visible, .page button:focus-visible, .page input:focus-visible, .page article a:focus-visible, .footer a:focus-visible { outline-color: var(--focus-ring); outline-offset: 3px; }
 
 .workspace {
   display: grid;
@@ -77,27 +77,27 @@
 .criteria { grid-area: criteria; margin: -20px 0 0; border-top: 1px solid var(--match-line); }
 .criteria div { display: grid; grid-template-columns: 42px 1fr; gap: 12px; padding: 15px 0; border-bottom: 1px solid var(--match-line); }
 .criteria dt { color: var(--match-cyan); font-family: monospace; font-size: 12px; }
-.criteria dd { margin: 0; color: #c9d4dc; font-size: 13px; }
+.criteria dd { margin: 0; color: var(--match-text); font-size: 13px; }
 
-.tool { grid-area: tool; border: 1px solid var(--match-line); background: rgba(16, 27, 39, 0.96); box-shadow: 0 28px 70px rgba(0, 0, 0, 0.28); }
+.tool { grid-area: tool; border: 1px solid var(--match-line); background: var(--bg-panel-95); box-shadow: var(--shadow-strong); }
 .toolHeading { display: flex; justify-content: space-between; gap: 12px; padding: 13px 18px; border-bottom: 1px solid var(--match-line); color: var(--match-muted); font-size: 10px; font-weight: 800; }
 .toolHeading span:last-child { color: var(--match-cyan); }
 .form { padding: 24px; }
 .form label { display: block; margin-bottom: 8px; color: var(--match-text); font-size: 13px; font-weight: 750; }
-.inputRow { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; min-height: 48px; border: 1px solid #405569; background: #081019; }
+.inputRow { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; min-height: 48px; border: 1px solid var(--match-line); background: var(--match-bg); }
 .inputRow > span { padding-left: 16px; color: var(--match-muted); font-size: 16px; }
 .inputRow input { position: relative; z-index: 1; min-width: 0; height: 46px; border: 0; outline: 0; background: transparent; color: var(--match-text); font: inherit; font-size: 16px; }
 .inputRow button { align-self: stretch; min-width: 150px; border: 0; background: var(--match-orange); color: #fff; cursor: pointer; font: inherit; font-size: 12px; font-weight: 800; }
-.inputRow button:hover { background: #ea650b; }
+.inputRow button:hover { background: color-mix(in srgb, var(--match-orange) 82%, white); }
 .inputRow button:disabled { cursor: wait; opacity: 0.7; }
 .form > p { margin: 9px 0 0; color: var(--match-muted); font-size: 11px; }
 
-.state { display: flex; align-items: center; gap: 14px; margin: 0 24px 24px; padding: 17px; border: 1px solid var(--match-line); border-left: 3px solid var(--match-cyan); background: #0b151f; }
+.state { display: flex; align-items: center; gap: 14px; margin: 0 24px 24px; padding: 17px; border: 1px solid var(--match-line); border-left: 3px solid var(--match-cyan); background: var(--bg-panel-70); }
 .state > div { display: grid; gap: 3px; }
 .state strong { font-size: 13px; }
 .state span { color: var(--match-muted); font-size: 12px; line-height: 1.45; }
-.error { border-left-color: #fb7185; }
-.spinner { flex: 0 0 20px; width: 20px; height: 20px; border: 2px solid rgba(83, 213, 232, 0.2); border-top-color: var(--match-cyan); border-radius: 50%; animation: spin 0.8s linear infinite; }
+.error { border-left-color: var(--danger); }
+.spinner { flex: 0 0 20px; width: 20px; height: 20px; border: 2px solid color-mix(in srgb, var(--match-cyan) 20%, transparent); border-top-color: var(--match-cyan); border-radius: 50%; animation: spin 0.8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 .results { border-top: 1px solid var(--match-line); }
@@ -119,11 +119,11 @@
 .repository { color: var(--match-cyan); font-size: 10px; font-weight: 800; overflow-wrap: anywhere; }
 .match h3 { margin: 0; font-size: 13px; line-height: 1.45; letter-spacing: 0; overflow-wrap: anywhere; }
 .reasons { display: flex; flex-wrap: wrap; gap: 5px; }
-.reasons span { border-color: rgba(74, 222, 128, 0.28); color: #86dba3; }
-.match > a { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 42px; padding: 0 12px; border: 1px solid #3a6171; color: var(--match-cyan); font-size: 11px; font-weight: 800; text-decoration: none; white-space: nowrap; }
-.match > a:hover { background: rgba(83, 213, 232, 0.08); }
+.reasons span { border-color: color-mix(in srgb, var(--mission-match) 28%, transparent); color: var(--mission-match); }
+.match > a { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 42px; padding: 0 12px; border: 1px solid var(--match-line); color: var(--match-cyan); font-size: 11px; font-weight: 800; text-decoration: none; white-space: nowrap; }
+.match > a:hover { background: color-mix(in srgb, var(--match-cyan) 8%, transparent); }
 
-.saveCta { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 20px 24px; background: #0b151f; }
+.saveCta { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 20px 24px; background: var(--bg-panel-70); }
 .saveCta > div { display: grid; gap: 3px; }
 .saveCta strong { font-size: 12px; }
 .saveCta span { max-width: 390px; color: var(--match-muted); font-size: 11px; line-height: 1.45; }
@@ -149,7 +149,7 @@
   .toolHeading { padding: 12px 14px; }
   .form { padding: 18px 14px; }
   .inputRow { grid-template-columns: auto minmax(0, 1fr); }
-  .inputRow:focus-within { border-color: var(--match-cyan); box-shadow: 0 0 0 3px rgba(83, 213, 232, 0.12); }
+  .inputRow:focus-within { border-color: var(--match-cyan); box-shadow: 0 0 0 3px color-mix(in srgb, var(--match-cyan) 12%, transparent); }
   .inputRow button { grid-column: 1 / -1; min-height: 48px; }
   .criteria { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); max-width: none; }
   .criteria div { grid-template-columns: 1fr; gap: 6px; padding: 12px 8px; border-right: 1px solid var(--match-line); }

--- a/components/RepositoryMatchTool.module.css
+++ b/components/RepositoryMatchTool.module.css
@@ -1,12 +1,12 @@
 .page {
-  --report-bg: #07110f;
-  --report-surface: #0e1c19;
-  --report-surface-strong: #142722;
-  --report-line: #29413a;
-  --report-text: #f4f7f5;
-  --report-muted: #a5b9b2;
-  --report-green: #68d391;
-  --report-yellow: #f5c451;
+  --report-bg: var(--bg-primary);
+  --report-surface: var(--bg-secondary);
+  --report-surface-strong: var(--bg-hover);
+  --report-line: var(--border);
+  --report-text: var(--text-primary);
+  --report-muted: var(--text-secondary);
+  --report-green: var(--accent-blue);
+  --report-yellow: var(--mission-link);
   position: fixed;
   inset: 0;
   height: 100vh;
@@ -15,8 +15,8 @@
   overflow-x: hidden;
   overscroll-behavior-y: contain;
   background:
-    linear-gradient(rgba(104, 211, 145, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(104, 211, 145, 0.035) 1px, transparent 1px),
+    linear-gradient(color-mix(in srgb, var(--accent-blue) 4%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--accent-blue) 4%, transparent) 1px, transparent 1px),
     var(--report-bg);
   background-size: 36px 36px;
   color: var(--report-text);
@@ -54,7 +54,7 @@
 
 .brand img { width: 34px; height: 34px; object-fit: contain; }
 .nav > a:last-child, .footer a { color: var(--report-muted); font-size: 13px; font-weight: 700; }
-.page a:focus-visible, .page button:focus-visible, .page input:focus-visible { outline: 2px solid var(--report-green); outline-offset: 3px; }
+.page a:focus-visible, .page button:focus-visible, .page input:focus-visible { outline-color: var(--focus-ring); outline-offset: 3px; }
 
 .workspace {
   display: grid;
@@ -73,27 +73,27 @@
 .criteria { grid-area: criteria; margin: -20px 0 0; border-top: 1px solid var(--report-line); }
 .criteria div { display: grid; grid-template-columns: 42px 1fr; gap: 12px; padding: 15px 0; border-bottom: 1px solid var(--report-line); }
 .criteria dt { color: var(--report-green); font-family: monospace; font-size: 12px; }
-.criteria dd { margin: 0; color: #cbd8d3; font-size: 13px; }
+.criteria dd { margin: 0; color: var(--report-text); font-size: 13px; }
 
-.tool { grid-area: tool; border: 1px solid var(--report-line); background: rgba(14, 28, 25, 0.97); box-shadow: 0 28px 70px rgba(0, 0, 0, 0.3); }
+.tool { grid-area: tool; border: 1px solid var(--report-line); background: var(--bg-panel-95); box-shadow: var(--shadow-strong); }
 .toolHeading { display: flex; justify-content: space-between; gap: 12px; padding: 13px 18px; border-bottom: 1px solid var(--report-line); color: var(--report-muted); font-size: 10px; font-weight: 800; }
 .toolHeading span:last-child { color: var(--report-green); }
 .form { padding: 24px; }
 .form label { display: block; margin-bottom: 8px; font-size: 13px; font-weight: 750; }
-.inputRow { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; min-height: 48px; border: 1px solid #456259; background: var(--report-bg); }
+.inputRow { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; min-height: 48px; border: 1px solid var(--report-line); background: var(--report-bg); }
 .inputRow > span { padding-left: 14px; color: var(--report-muted); font-family: monospace; font-size: 12px; }
 .inputRow input { min-width: 0; height: 46px; padding: 0 10px 0 2px; border: 0; outline: 0; background: transparent; color: var(--report-text); font: inherit; font-size: 16px; }
-.inputRow button { align-self: stretch; min-width: 136px; border: 0; background: var(--report-yellow); color: #1d1808; cursor: pointer; font: inherit; font-size: 12px; font-weight: 850; }
-.inputRow button:hover { background: #ffd36c; }
+.inputRow button { align-self: stretch; min-width: 136px; border: 0; background: var(--accent-blue); color: #fff; cursor: pointer; font: inherit; font-size: 12px; font-weight: 850; }
+.inputRow button:hover { background: color-mix(in srgb, var(--accent-blue) 82%, white); }
 .inputRow button:disabled { cursor: wait; opacity: 0.7; }
 .form > p { margin: 9px 0 0; color: var(--report-muted); font-size: 11px; }
 
-.state { display: flex; align-items: center; gap: 14px; margin: 0 24px 24px; padding: 17px; border: 1px solid var(--report-line); border-left: 3px solid var(--report-green); background: #091613; }
+.state { display: flex; align-items: center; gap: 14px; margin: 0 24px 24px; padding: 17px; border: 1px solid var(--report-line); border-left: 3px solid var(--report-green); background: var(--bg-panel-70); }
 .state > div { display: grid; gap: 3px; }
 .state strong { font-size: 13px; }
 .state span { color: var(--report-muted); font-size: 12px; line-height: 1.45; }
-.error { border-left-color: #fb7185; }
-.spinner { flex: 0 0 20px; width: 20px; height: 20px; border: 2px solid rgba(104, 211, 145, 0.2); border-top-color: var(--report-green); border-radius: 50%; animation: spin 0.8s linear infinite; }
+.error { border-left-color: var(--danger); }
+.spinner { flex: 0 0 20px; width: 20px; height: 20px; border: 2px solid color-mix(in srgb, var(--report-green) 20%, transparent); border-top-color: var(--report-green); border-radius: 50%; animation: spin 0.8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 .results { border-top: 1px solid var(--report-line); }
@@ -102,9 +102,9 @@
 .repositorySummary span { color: var(--report-green); font-size: 10px; font-weight: 800; }
 .repositorySummary h2 { margin: 4px 0 0; font-size: 19px; letter-spacing: 0; overflow-wrap: anywhere; }
 .repositorySummary p { margin: 7px 0 0; color: var(--report-muted); font-size: 12px; line-height: 1.5; }
-.repositorySummary > a, .match > a { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; min-height: 42px; padding: 0 12px; border: 1px solid #477062; color: var(--report-green); font-size: 11px; font-weight: 800; text-decoration: none; white-space: nowrap; }
+.repositorySummary > a, .match > a { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; min-height: 42px; padding: 0 12px; border: 1px solid var(--report-line); color: var(--report-green); font-size: 11px; font-weight: 800; text-decoration: none; white-space: nowrap; }
 
-.reportActions { display: flex; align-items: center; gap: 8px; min-height: 64px; padding: 10px 24px; border-top: 1px solid var(--report-line); background: #091613; }
+.reportActions { display: flex; align-items: center; gap: 8px; min-height: 64px; padding: 10px 24px; border-top: 1px solid var(--report-line); background: var(--bg-panel-70); }
 .reportActions button { min-height: 42px; padding: 0 13px; border: 1px solid var(--report-line); background: var(--report-surface-strong); color: var(--report-text); cursor: pointer; font: inherit; font-size: 11px; font-weight: 800; }
 .reportActions button:first-child { border-color: var(--report-yellow); color: var(--report-yellow); }
 .reportActions span { margin-left: auto; color: var(--report-muted); font-size: 11px; }
@@ -118,7 +118,7 @@
 .match h3 { margin: 0; font-size: 14px; line-height: 1.4; letter-spacing: 0; }
 .match h3 span { color: var(--report-muted); font-size: 12px; font-weight: 500; }
 .reasons, .evidence { display: flex; flex-wrap: wrap; gap: 5px; }
-.reasons span, .evidence span { padding: 4px 7px; border: 1px solid rgba(104, 211, 145, 0.28); color: #9ce4b7; font-size: 9px; line-height: 1.35; }
+.reasons span, .evidence span { padding: 4px 7px; border: 1px solid color-mix(in srgb, var(--report-green) 28%, transparent); color: var(--mission-link); font-size: 9px; line-height: 1.35; }
 .evidence span { border-color: var(--report-line); color: var(--report-muted); }
 .disclaimer { margin: 0; padding: 18px 24px; color: var(--report-muted); font-size: 10px; line-height: 1.5; }
 

--- a/design-system/devglobe/MASTER.md
+++ b/design-system/devglobe/MASTER.md
@@ -24,6 +24,8 @@ Use the semantic custom properties in `styles/main.css`. Do not introduce raw co
 
 Color must not be the only indicator of status. Maintain at least 4.5:1 contrast for body text and 3:1 for large text and controls.
 
+All navigation destinations use the same canvas, surfaces, text, borders, focus ring, and primary blue action. A feature may use one semantic accent for its subject, such as Hacktoberfest orange, but that accent must not replace the shared page palette.
+
 ### Typography
 
 - Use Manrope for product UI, headings, and body copy.


### PR DESCRIPTION
Shared DevGlobe canvas/surface/text/border/action tokens across Repository Match, Agents, and Hacktoberfest; feature-specific orange retained only for Hacktoberfest semantics.

- Shared DevGlobe canvas/surface/text/border/action token styles across Repository Match, Agents, and Hacktoberfest.
- Feature-specific orange retained only for Hacktoberfest semantics.
- Test suite and production build pass.
- Verified desktop and 375px layouts.