### PR TITLE
fix: classify malformed MCP requests

### DIFF
--- a/lib/mcp-observability.js
+++ b/lib/mcp-observability.js
@@ -1,6 +1,17 @@
 import { createHmac } from 'node:crypto';
 
-const METHODS = new Set(['initialize', 'tools/list', 'tools/call', 'resources/list', 'resources/read', 'prompts/list', 'prompts/get']);
+const METHODS = new Set([
+  'initialize',
+  'notifications/initialized',
+  'ping',
+  'tools/list',
+  'tools/call',
+  'resources/list',
+  'resources/read',
+  'resources/templates/list',
+  'prompts/list',
+  'prompts/get',
+]);
 const RESOURCES = new Set(['devglobe://project']);
 const PROMPTS = new Set(['find-developers', 'find-collaborators', 'find-contribution']);
 const TOOLS = new Set([
@@ -42,7 +53,13 @@ export function describeMcpRequest(body, userAgent = '') {
   const resource = method === 'resources/read' && RESOURCES.has(body?.params?.uri) ? body.params.uri : null;
   const prompt = method === 'prompts/get' && PROMPTS.has(body?.params?.name) ? body.params.name : null;
   const client = classifyMcpClient(body?.params?.clientInfo?.name, userAgent);
-  return { method, tool, resource, prompt, client };
+  const requestedTool = typeof body?.params?.name === 'string' ? body.params.name.trim() : '';
+  const requestErrorCode = method === 'tools/call' && !requestedTool
+    ? 'invalid_request'
+    : method === 'tools/call' && !tool
+      ? 'not_found'
+      : null;
+  return { method, tool, resource, prompt, client, requestErrorCode };
 }
 
 export function createMcpCallerHash(request, secret = process.env.ENGAGEMENT_HASH_SECRET || process.env.SESSION_SECRET, now = new Date()) {

--- a/lib/remote-mcp.js
+++ b/lib/remote-mcp.js
@@ -130,12 +130,13 @@ export async function handleRemoteMcpRequest(request, {
   const response = await transport.handleRequest(request);
   const responseBody = await response.clone().json().catch(() => null);
   const toolError = readToolError(responseBody);
+  const { requestErrorCode, ...requestDimensions } = requestDescription;
   metricRecorder({
-    ...requestDescription,
+    ...requestDimensions,
     outcome: response.status >= 400 || responseBody?.error || responseBody?.result?.isError ? 'error' : 'success',
     durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
     callerHash: createMcpCallerHash(request),
-    errorCode: toolError?.code || classifyProtocolError(responseBody),
+    errorCode: toolError?.code || classifyProtocolError(responseBody) || requestErrorCode,
     resultCount: responseBody?.result?.structuredContent?.resultCount,
   });
   return withSecurityHeaders(response, request.headers.get('origin'));

--- a/tests/remote-mcp.test.js
+++ b/tests/remote-mcp.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { handleMcpOptions, handleRemoteMcpRequest } from '../lib/remote-mcp.js';
-import { createMcpCallerHash, recordMcpMetric } from '../lib/mcp-observability.js';
+import { createMcpCallerHash, describeMcpRequest, recordMcpMetric } from '../lib/mcp-observability.js';
 
 const MCP_HEADERS = {
   Accept: 'application/json, text/event-stream',
@@ -228,9 +228,20 @@ test('MCP classifies malformed and unknown requests with bounded error codes', a
   await handleRemoteMcpRequest(mcpRequest({
     jsonrpc: '2.0', id: 18, method: 'unknown/method', params: {},
   }), { metricRecorder: metric => metrics.push(metric) });
+  await handleRemoteMcpRequest(mcpRequest({
+    jsonrpc: '2.0', id: 19, method: 'tools/call', params: { name: 'private_tool', arguments: {} },
+  }), { metricRecorder: metric => metrics.push(metric) });
 
   assert.equal(metrics[0].errorCode, 'invalid_request');
   assert.equal(metrics[1].errorCode, 'not_found');
+  assert.equal(metrics[2].errorCode, 'not_found');
+  assert.equal(metrics[2].tool, null);
+});
+
+test('MCP telemetry distinguishes bounded handshake methods', () => {
+  for (const method of ['notifications/initialized', 'ping', 'resources/templates/list']) {
+    assert.equal(describeMcpRequest({ jsonrpc: '2.0', method }, 'test-agent').method, method);
+  }
 });
 
 test('MCP logs only allow-listed prompt names', async () => {


### PR DESCRIPTION
## Summary
- classify nameless MCP tool calls as invalid requests
- classify unknown tool names as not found
- preserve common MCP handshake methods in bounded telemetry

## Validation
- node --test tests/remote-mcp.test.js (18 passed)
- npm run build

Malformed external calls are still rejected; this fixes their telemetry classification.