### PR TITLE
Explain developer search matches

### DIFF
--- a/app/api/search/route.js
+++ b/app/api/search/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server.js';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { apiError } from '../../../lib/api-error.js';
+import { attachSearchMatches } from '../../../lib/search-match.js';
 
 const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
 const COSMOS_KEY = process.env.COSMOS_KEY;
@@ -56,7 +57,8 @@ async function getEmbedding(text) {
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
   const q = searchParams.get('q');
-  const mode = searchParams.get('mode') || 'hybrid';
+  const requestedMode = searchParams.get('mode') || 'hybrid';
+  const mode = ['text', 'vector', 'hybrid'].includes(requestedMode) ? requestedMode : 'hybrid';
   const top = searchParams.get('top') || '10';
 
   if (!q) {
@@ -72,7 +74,7 @@ export async function GET(request) {
     // Fallback: search sample data locally (text mode only)
     const data = await getSampleData();
     const limit = Math.min(parseInt(top), 50);
-    const results = searchSampleData(data, q, limit);
+    const results = attachSearchMatches(searchSampleData(data, q, limit), q, 'text');
     return NextResponse.json({ query: q, mode: 'text', count: results.length, results });
   }
 
@@ -166,11 +168,18 @@ export async function GET(request) {
       const k = 60;
       const rrf = new Map();
       const allMap = new Map();
-      vectorRes.resources.forEach((r, i) => { rrf.set(r.login, (rrf.get(r.login) || 0) + 1 / (k + i + 1)); allMap.set(r.login, r); });
-      textRes.resources.forEach((r, i) => { rrf.set(r.login, (rrf.get(r.login) || 0) + 1 / (k + i + 1)); allMap.set(r.login, r); });
+      vectorRes.resources.forEach((r, i) => {
+        rrf.set(r.login, (rrf.get(r.login) || 0) + 1 / (k + i + 1));
+        allMap.set(r.login, { ...allMap.get(r.login), ...r, _searchVectorRank: i });
+      });
+      textRes.resources.forEach((r, i) => {
+        rrf.set(r.login, (rrf.get(r.login) || 0) + 1 / (k + i + 1));
+        allMap.set(r.login, { ...allMap.get(r.login), ...r, _searchTextRank: i });
+      });
       results = [...rrf.entries()].sort((a, b) => b[1] - a[1]).slice(0, limit).map(([login]) => allMap.get(login));
     }
 
+    results = attachSearchMatches(results, q, mode);
     return NextResponse.json({ query: q, mode, count: results.length, results });
   } catch (err) {
     console.error('Search error:', err.message);

--- a/app/openapi.json/route.js
+++ b/app/openapi.json/route.js
@@ -20,6 +20,18 @@ export function GET() {
         },
       },
       schemas: {
+        SearchMatch: {
+          type: 'object',
+          required: ['score', 'label', 'reasons', 'signals', 'method', 'disclaimer'],
+          properties: {
+            score: { type: 'integer', minimum: 0, maximum: 100, description: 'Ordinal discovery relevance, not a probability or suitability rating.' },
+            label: { type: 'string', enum: ['Strong match', 'Good match', 'Related match'] },
+            reasons: { type: 'array', maxItems: 3, items: { type: 'string' } },
+            signals: { type: 'array', items: { type: 'string', enum: ['text', 'semantic'] } },
+            method: { type: 'string', enum: ['text', 'semantic', 'hybrid'] },
+            disclaimer: { type: 'string' },
+          },
+        },
         Error: {
           type: 'object',
           required: ['error', 'code', 'hint'],
@@ -50,12 +62,34 @@ export function GET() {
           summary: 'Search public developer profiles',
           parameters: [
             { name: 'q', in: 'query', required: true, schema: { type: 'string' } },
+            { name: 'mode', in: 'query', schema: { type: 'string', enum: ['text', 'vector', 'hybrid'], default: 'hybrid' } },
             { name: 'top', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 20, default: 10 } },
           ],
           security: [],
           'x-required-scope': 'developers:read',
           responses: {
-            200: { description: 'Public developer search results' },
+            200: {
+              description: 'Public developer search results with explainable ordinal match signals',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      query: { type: 'string' },
+                      mode: { type: 'string' },
+                      count: { type: 'integer' },
+                      results: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: { match: { $ref: '#/components/schemas/SearchMatch' } },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
             400: { $ref: '#/components/responses/BadRequest' },
           },
         },

--- a/components/SearchBar.jsx
+++ b/components/SearchBar.jsx
@@ -6,6 +6,7 @@ import { track, trackSearchAppearances } from '../lib/analytics.js';
 import { countryKey } from '../lib/country.js';
 import { findExactLoginResult, normalizeTextSearchQuery } from '../lib/developer-search.js';
 import { publicApiUrl } from '../lib/public-api.js';
+import { attachSearchMatches } from '../lib/search-match.js';
 import MissionPreview from './MissionPreview.jsx';
 
 const SAMPLES_BY_MODE = {
@@ -142,6 +143,10 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
           if (!controller.signal.aborted) setSearching(false);
         }
       }
+
+      results = results.every(result => result.match)
+        ? results
+        : attachSearchMatches(results, textQuery, 'text');
 
       onResults(results);
       setResultCount(results.length);
@@ -433,6 +438,16 @@ export default function SearchBar({ developers, onResults, onReset, onSelectDeve
                         @{developer.login}
                         {developer.globalRank ? ` · Global #${developer.globalRank}` : ''}
                       </span>
+                      {developer.match && (
+                        <span
+                          className="search-bar__match"
+                          title={developer.match.disclaimer}
+                          aria-label={`${developer.match.score} match score. ${developer.match.reasons[0]}. ${developer.match.disclaimer}`}
+                        >
+                          <b>{developer.match.score} match</b>
+                          <span>{developer.match.reasons[0]}</span>
+                        </span>
+                      )}
                     </span>
                     <span className="search-bar__view-profile">View profile</span>
                   </button>

--- a/docs/prd/explainable-match-scores.md
+++ b/docs/prd/explainable-match-scores.md
@@ -1,0 +1,128 @@
+# PRD: Explainable Match Scores
+
+## Status
+
+- Owner: DevGlobe
+- Stage: MVP implementation
+- Surface: Homepage search, public search API, MCP developer search
+
+## Problem
+
+DevGlobe can rank developers through text, semantic, and hybrid search, but a position in a result list does not tell a user why the developer appeared. Raw vector distance and internal rank-fusion values are not meaningful to most people. This makes discovery feel opaque and makes it harder for humans and AI agents to judge whether a result is worth opening.
+
+## Product Promise
+
+Every developer search result includes a concise relevance score and up to three reasons grounded in public profile fields or the retrieval method. The explanation describes why DevGlobe retrieved the profile. It never claims that a person is suitable for employment, predicts performance, or measures personal worth.
+
+## Goals
+
+- Make text, semantic, and hybrid result ordering understandable at a glance.
+- Use one explanation contract across browser, API, and MCP consumers.
+- Ground reasons in visible public fields and retrieval provenance.
+- Keep explanations bounded, deterministic, and inexpensive to compute.
+- Preserve existing search order, privacy filtering, and response fields.
+
+## Non-goals
+
+- Predicting job performance, culture fit, availability, or hiring suitability.
+- Comparing a developer's personal worth or quality.
+- Exposing embeddings, raw reciprocal-rank-fusion values, or private profile data.
+- Replacing repository-specific matching or profile-similarity explanations.
+- Allowing users to tune scoring weights in the MVP.
+
+## MVP Experience
+
+1. A user searches by username, name, location, language, or natural-language intent.
+2. Each visible result shows an ordinal score from 0 to 100 and its strongest reason.
+3. API and MCP results include the score, label, up to three reasons, contributing signals, method, and disclaimer.
+4. Opening a result continues to use the existing profile workflow.
+
+Example:
+
+```json
+{
+  "match": {
+    "score": 95,
+    "label": "Strong match",
+    "reasons": [
+      "Primary language matches TypeScript",
+      "Matched both semantic similarity and public profile text"
+    ],
+    "signals": ["semantic", "text"],
+    "method": "hybrid",
+    "disclaimer": "Discovery relevance based on public profile signals; not a probability, suitability rating, or hiring recommendation."
+  }
+}
+```
+
+## Scoring Model
+
+The score is an ordinal discovery signal. It supports comparison within one result set and is not calibrated as a probability.
+
+- Exact GitHub login: 100.
+- Exact developer name: 98.
+- Partial login or name: 92-94.
+- Primary-language evidence: up to 88.
+- Location evidence: up to 82.
+- Public profile tag evidence: up to 80.
+- Text, semantic, and hybrid rank contribute a bounded 62-91 baseline.
+- A hybrid result retrieved by both semantic and text search receives a four-point provenance bonus, capped at 98.
+
+Labels are **Strong match** at 85 or above, **Good match** at 72-84, and **Related match** below 72. Score changes must be versioned if later calibration would materially change interpretation.
+
+## Data Contract
+
+`match` is additive to each existing result:
+
+- `score`: integer from 0 to 100.
+- `label`: `Strong match`, `Good match`, or `Related match`.
+- `reasons`: one to three bounded human-readable strings.
+- `signals`: one or both of `text` and `semantic`.
+- `method`: `text`, `semantic`, or `hybrid`.
+- `disclaimer`: stable methodology warning.
+
+Internal vector and text ranks are removed before serialization. Existing consumers that ignore `match` remain compatible.
+
+## Safety And Privacy
+
+- Reasons use public profile fields or retrieval provenance only.
+- Protected or inferred sensitive attributes never contribute.
+- The UI and API identify the score as discovery relevance rather than suitability.
+- Search explanations do not imply availability or consent to contact.
+- Existing nomination visibility filters and consent-gated introduction rules remain unchanged.
+
+## Success Metrics
+
+Primary:
+
+- Search result to profile-open conversion.
+- Percentage of searches where a user opens one of the top three results.
+- Shortlist or identity-card action rate after an explained result.
+- MCP searches followed by a profile or repository-match call.
+
+Guardrails:
+
+- Search latency and payload-size regression.
+- Percentage of explanations using only a generic retrieval reason.
+- User reports of misleading or sensitive explanations.
+- Result ordering changes, with a target of zero for the MVP.
+
+## Rollout
+
+1. Ship the additive contract and homepage result treatment.
+2. Monitor profile-open conversion and generic-reason frequency by search mode.
+3. Review a sample of text, semantic, and hybrid explanations for misleading claims.
+4. Calibrate thresholds only with a versioned offline relevance set.
+5. Consider expanded explanation details after users demonstrate demand.
+
+## Acceptance Criteria
+
+- Local text and API search results use the same explanation module.
+- Vector results identify semantic rank without exposing embeddings.
+- Hybrid results identify whether text, semantic, or both retrieval paths contributed.
+- Internal rank metadata is absent from public responses.
+- Homepage cards show a score and strongest reason without layout overflow.
+- MCP search preserves the API match object after profile hydration.
+- OpenAPI documents the additive match schema and search modes.
+- Unit tests cover exact fields, semantic rank, hybrid provenance, bounds, and immutability.
+- Full tests and the production build pass.

--- a/lib/devglobe-mcp-client.js
+++ b/lib/devglobe-mcp-client.js
@@ -35,7 +35,7 @@ function explainMatch(developer, input = {}) {
   return reasons.length ? reasons : ['Retrieved by GitHub login'];
 }
 
-function projectDeveloper(developer, origin, input) {
+function projectDeveloper(developer, origin, input, searchMatch) {
   const updatedAt = developer.metricsUpdatedAt || null;
   const opportunityPreferences = developer.aiProfile?.opportunityPreferences;
   return {
@@ -46,7 +46,8 @@ function projectDeveloper(developer, origin, input) {
     ...(developer.topLanguage ? { topLanguage: developer.topLanguage } : {}),
     ...(Number.isFinite(Number(developer.score)) ? { score: Number(developer.score) } : {}),
     ...(Number.isInteger(developer.globalRank) ? { globalRank: developer.globalRank } : {}),
-    whyMatched: explainMatch(developer, input),
+    whyMatched: searchMatch?.reasons || explainMatch(developer, input),
+    ...(searchMatch ? { match: searchMatch } : {}),
     publicEvidence: publicEvidence(developer),
     dataFreshness: {
       updatedAt,
@@ -98,19 +99,27 @@ export function createDevGlobeMcpClient({
       searchUrl.searchParams.set('top', String(Math.min(limit, 20)));
       const search = await readJson(await fetchImpl(searchUrl));
 
-      const developers = await Promise.all(search.results.map(async result => {
+      const candidates = await Promise.all(search.results.map(async result => {
         const profileUrl = new URL('/api/developer', publicApiOrigin);
         profileUrl.searchParams.set('id', result.login || result.id);
-        return readJson(await fetchImpl(profileUrl));
+        return {
+          developer: await readJson(await fetchImpl(profileUrl)),
+          searchMatch: result.match,
+        };
       }));
 
-      return developers.filter(developer => {
+      return candidates.filter(({ developer }) => {
         const matchesLocation = !location || developer.location?.toLowerCase().includes(location.toLowerCase());
         const matchesLanguage = !language || developer.topLanguage?.toLowerCase() === language.toLowerCase();
         const matchesAvailability = !availableForAgents || developer.aiProfile?.acceptsAgentRequests === true;
         const matchesOpportunity = !opportunityType || developer.aiProfile?.opportunityPreferences?.types?.includes(opportunityType);
         return matchesLocation && matchesLanguage && matchesAvailability && matchesOpportunity;
-      }).slice(0, limit).map(developer => projectDeveloper(developer, origin, { query, location, language, opportunityType }));
+      }).slice(0, limit).map(({ developer, searchMatch }) => projectDeveloper(
+        developer,
+        origin,
+        { query, location, language, opportunityType },
+        searchMatch,
+      ));
     },
 
     async getDeveloperProfile(login) {

--- a/lib/devglobe-mcp-server.js
+++ b/lib/devglobe-mcp-server.js
@@ -13,6 +13,14 @@ const PROJECT_INFO = {
 };
 
 const evidenceSchema = z.object({ label: z.string(), value: z.number() });
+const searchMatchSchema = z.object({
+  score: z.number().int().min(0).max(100),
+  label: z.enum(['Strong match', 'Good match', 'Related match']),
+  reasons: z.array(z.string()).max(3),
+  signals: z.array(z.enum(['text', 'semantic'])),
+  method: z.enum(['text', 'semantic', 'hybrid']),
+  disclaimer: z.string(),
+});
 const opportunityPreferencesSchema = z.object({
   enabled: z.literal(true),
   types: z.array(z.enum(OPPORTUNITY_TYPES)),
@@ -31,6 +39,7 @@ const developerSchema = z.object({
   score: z.number().optional(),
   globalRank: z.number().int().optional(),
   whyMatched: z.array(z.string()),
+  match: searchMatchSchema.optional(),
   publicEvidence: z.array(evidenceSchema),
   dataFreshness: z.object({ updatedAt: z.string().nullable(), status: z.enum(['reported', 'unknown']) }),
   availableForAgents: z.boolean(),

--- a/lib/search-match.js
+++ b/lib/search-match.js
@@ -1,0 +1,130 @@
+export const SEARCH_MATCH_DISCLAIMER = 'Discovery relevance based on public profile signals; not a probability, suitability rating, or hiring recommendation.';
+
+const STOP_WORDS = new Set(['a', 'an', 'and', 'for', 'in', 'of', 'or', 'the', 'to', 'with']);
+
+function normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function queryTokens(query) {
+  return normalize(query)
+    .replace(/^@/, '')
+    .split(/[^a-z0-9+#.-]+/)
+    .filter(token => (token.length > 1 || token === 'c' || token === 'r') && !STOP_WORDS.has(token));
+}
+
+function containsQueryToken(value, tokens) {
+  const normalized = normalize(value);
+  return normalized && tokens.some(token => normalized.includes(token));
+}
+
+function fieldEvidence(developer, query) {
+  const normalizedQuery = normalize(query).replace(/^@/, '');
+  const tokens = queryTokens(query);
+  const login = normalize(developer.login);
+  const name = normalize(developer.name);
+  const language = normalize(developer.topLanguage);
+  const location = normalize(developer.location);
+  const tags = Array.isArray(developer.specialTags) ? developer.specialTags : [];
+  const reasons = [];
+  let score = 0;
+
+  if (normalizedQuery && login === normalizedQuery) {
+    reasons.push(`Exact GitHub login match: @${developer.login}`);
+    score = 100;
+  } else if (normalizedQuery && name === normalizedQuery) {
+    reasons.push(`Exact developer name match: ${developer.name}`);
+    score = 98;
+  } else if (normalizedQuery && login.includes(normalizedQuery)) {
+    reasons.push(`GitHub login includes “${normalizedQuery}”`);
+    score = 94;
+  } else if (normalizedQuery && name.includes(normalizedQuery)) {
+    reasons.push(`Developer name includes “${normalizedQuery}”`);
+    score = 92;
+  }
+
+  if (language && containsQueryToken(language, tokens)) {
+    reasons.push(`Primary language matches ${developer.topLanguage}`);
+    score = Math.max(score, 88);
+  }
+  if (location && containsQueryToken(location, tokens)) {
+    reasons.push(`Location matches ${developer.location}`);
+    score = Math.max(score, 82);
+  }
+  const matchedTag = tags.find(tag => containsQueryToken(tag, tokens));
+  if (matchedTag) {
+    reasons.push(`Public profile tag matches ${matchedTag}`);
+    score = Math.max(score, 80);
+  }
+
+  return { reasons, score };
+}
+
+function rankScore(mode, rank) {
+  if (mode === 'vector') return Math.max(62, 90 - rank * 3);
+  if (mode === 'hybrid') return Math.max(68, 91 - rank * 2);
+  return Math.max(64, 84 - rank * 2);
+}
+
+function matchLabel(score) {
+  if (score >= 85) return 'Strong match';
+  if (score >= 72) return 'Good match';
+  return 'Related match';
+}
+
+export function explainSearchMatch(developer, query, {
+  mode = 'text',
+  rank = 0,
+  vectorRank = null,
+  textRank = null,
+} = {}) {
+  const boundedRank = Number.isInteger(rank) && rank >= 0 ? rank : 0;
+  const evidence = fieldEvidence(developer, query);
+  const reasons = [...evidence.reasons];
+  const signals = [];
+
+  if (mode === 'vector') {
+    signals.push('semantic');
+    reasons.push(`Semantic profile similarity ranked this result #${boundedRank + 1}`);
+  } else if (mode === 'hybrid') {
+    if (Number.isInteger(vectorRank)) signals.push('semantic');
+    if (Number.isInteger(textRank)) signals.push('text');
+    if (signals.length === 2) {
+      reasons.push('Matched both semantic similarity and public profile text');
+    } else if (signals[0] === 'semantic') {
+      reasons.push('Matched semantic profile similarity');
+    } else {
+      reasons.push('Matched public profile text');
+    }
+  } else {
+    signals.push('text');
+    if (reasons.length === 0) reasons.push('Matched indexed public profile text');
+  }
+
+  let score = Math.max(evidence.score, rankScore(mode, boundedRank));
+  if (mode === 'hybrid' && signals.length === 2) score = Math.min(98, score + 4);
+
+  return {
+    score,
+    label: matchLabel(score),
+    reasons: reasons.slice(0, 3),
+    signals,
+    method: mode === 'vector' ? 'semantic' : mode,
+    disclaimer: SEARCH_MATCH_DISCLAIMER,
+  };
+}
+
+export function attachSearchMatches(results, query, mode = 'text') {
+  return results.map((developer, rank) => {
+    const {
+      _searchVectorRank: vectorRank = null,
+      _searchTextRank: textRank = null,
+      relevance: _relevance,
+      ...publicDeveloper
+    } = developer;
+    return {
+      ...publicDeveloper,
+      match: explainSearchMatch(publicDeveloper, query, { mode, rank, vectorRank, textRank }),
+    };
+  });
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -9715,6 +9715,34 @@ body {
   font-size: 10px;
 }
 
+.search-bar__card-identity .search-bar__match {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  margin-top: 5px;
+  color: var(--text-secondary);
+}
+
+.search-bar__match b {
+  flex: 0 0 auto;
+  padding: 2px 5px;
+  border: 1px solid color-mix(in srgb, var(--accent-github) 45%, var(--border));
+  border-radius: var(--radius-sm);
+  color: var(--accent-github);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+
+.search-bar__card-identity .search-bar__match span {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .search-bar__card-actions {
   display: flex;
   flex-direction: column;

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -46,6 +46,8 @@ test('serves a valid API catalog and OpenAPI description', async () => {
     'introductions:write',
   ]);
   assert.equal(openApi.components.schemas.Error.required.includes('hint'), true);
+  assert.equal(openApi.components.schemas.SearchMatch.properties.score.maximum, 100);
+  assert.deepEqual(openApi.components.schemas.SearchMatch.properties.method.enum, ['text', 'semantic', 'hybrid']);
 });
 
 test('describes the MCP server tools and authentication boundary', async () => {

--- a/tests/remote-mcp.test.js
+++ b/tests/remote-mcp.test.js
@@ -274,10 +274,18 @@ test('MCP logs only allow-listed prompt names', async () => {
 });
 
 test('remote MCP performs anonymous public developer discovery', async () => {
+  const match = {
+    score: 91,
+    label: 'Strong match',
+    reasons: ['Primary language matches JavaScript'],
+    signals: ['text'],
+    method: 'text',
+    disclaimer: 'Discovery relevance only.',
+  };
   const fetchImpl = async url => {
     const parsed = new URL(url);
     if (parsed.pathname === '/api/search') {
-      return Response.json({ results: [{ login: 'open-dev' }] });
+      return Response.json({ results: [{ login: 'open-dev', match }] });
     }
     return Response.json({
       login: 'open-dev',
@@ -299,7 +307,8 @@ test('remote MCP performs anonymous public developer discovery', async () => {
   assert.deepEqual(developers.map(developer => developer.login), ['open-dev']);
   assert.equal(response.result.structuredContent.resultCount, 1);
   assert.equal(response.result.structuredContent.results[0].profileUrl, 'http://localhost:3000/developer/open-dev');
-  assert.match(response.result.structuredContent.results[0].whyMatched[0], /React/);
+  assert.deepEqual(response.result.structuredContent.results[0].whyMatched, match.reasons);
+  assert.deepEqual(response.result.structuredContent.results[0].match, match);
   assert.equal(response.result.structuredContent.results[0].availableForAgents, true);
 });
 

--- a/tests/search-match.test.js
+++ b/tests/search-match.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { attachSearchMatches, explainSearchMatch, SEARCH_MATCH_DISCLAIMER } from '../lib/search-match.js';
+
+test('explains exact login and public field matches without suitability claims', () => {
+  const match = explainSearchMatch({
+    login: 'octocat',
+    name: 'The Octocat',
+    topLanguage: 'TypeScript',
+    location: 'London, UK',
+  }, '@octocat', { mode: 'text' });
+
+  assert.equal(match.score, 100);
+  assert.equal(match.label, 'Strong match');
+  assert.deepEqual(match.signals, ['text']);
+  assert.match(match.reasons[0], /Exact GitHub login/);
+  assert.equal(match.disclaimer, SEARCH_MATCH_DISCLAIMER);
+});
+
+test('explains language and location evidence using visible public fields', () => {
+  const match = explainSearchMatch({
+    login: 'typed-dev',
+    topLanguage: 'TypeScript',
+    location: 'Berlin, Germany',
+  }, 'TypeScript developer in Berlin', { mode: 'text', rank: 2 });
+
+  assert.equal(match.score, 88);
+  assert.deepEqual(match.reasons, [
+    'Primary language matches TypeScript',
+    'Location matches Berlin, Germany',
+  ]);
+});
+
+test('explains one-letter programming language matches', () => {
+  const match = explainSearchMatch({ login: 'kernel-dev', topLanguage: 'C' }, 'C', { mode: 'text' });
+
+  assert.equal(match.score, 88);
+  assert.deepEqual(match.reasons, ['Primary language matches C']);
+});
+
+test('labels semantic rank as an ordinal discovery signal', () => {
+  const first = explainSearchMatch({ login: 'first' }, 'AI agent builder', { mode: 'vector', rank: 0 });
+  const tenth = explainSearchMatch({ login: 'tenth' }, 'AI agent builder', { mode: 'vector', rank: 9 });
+
+  assert.equal(first.score, 90);
+  assert.equal(tenth.score, 63);
+  assert.deepEqual(first.signals, ['semantic']);
+  assert.match(first.reasons[0], /ranked this result #1/);
+});
+
+test('rewards hybrid results supported by semantic and text retrieval', () => {
+  const [result] = attachSearchMatches([{
+    login: 'hybrid-dev',
+    topLanguage: 'Go',
+    _searchVectorRank: 1,
+    _searchTextRank: 3,
+  }], 'Go maintainer', 'hybrid');
+
+  assert.equal(result.match.score, 95);
+  assert.deepEqual(result.match.signals, ['semantic', 'text']);
+  assert.match(result.match.reasons.join(' '), /both semantic similarity and public profile text/);
+  assert.equal('_searchVectorRank' in result, false);
+  assert.equal('_searchTextRank' in result, false);
+});
+
+test('decorating results does not mutate source records', () => {
+  const source = [{ login: 'stable-dev', relevance: 0.14, _searchTextRank: 0 }];
+  const decorated = attachSearchMatches(source, 'stable', 'hybrid');
+
+  assert.notEqual(decorated[0], source[0]);
+  assert.equal(source[0]._searchTextRank, 0);
+  assert.equal(source[0].relevance, 0.14);
+  assert.equal('match' in source[0], false);
+  assert.equal('relevance' in decorated[0], false);
+});


### PR DESCRIPTION
## Summary
- add bounded, explainable relevance scores for text, semantic, and hybrid developer search
- show the strongest public-field or retrieval reason in homepage result cards
- preserve match explanations through the public API, OpenAPI schema, and MCP structured output
- document product scope, safety constraints, scoring model, rollout, and acceptance criteria in the PRD

## Safety
- scores are ordinal discovery signals, not probabilities or suitability ratings
- reasons use public profile fields or retrieval provenance only
- embeddings and internal rank values are never returned

## Validation
- npm test (403 passed)
- npm run build
- focused MCP/OpenAPI/search contract tests
- Playwright desktop and 375px mobile checks