### PR TITLE
Grow the live coding retention loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The timer invokes the collector every minute, matching GitHub's advertised polli
 
 ### Live coding presence and private stats
 
-The `/space` globe receives an opt-in heartbeat from the DevGlobe VS Code extension every 30 seconds. Presence expires after 90 seconds. Daily coding totals, language time, and editor time are derived only from consecutive valid heartbeats and are visible only to the signed-in developer. DevGlobe does not collect source code, file paths, repositories, branches, or keystrokes for this feature.
+The `/space` globe receives an opt-in heartbeat from the DevGlobe editor extension every 30 seconds while the developer is active. Heartbeats pause after one minute without editor activity. Presence is live for 90 seconds and remains visible as recently coding for up to 15 minutes. Daily coding totals, streaks, achievements, language time, and editor time are derived only from consecutive valid heartbeats and are visible only to the signed-in developer. DevGlobe does not collect source code, file paths, repositories, branches, or keystrokes for this feature.
 
 Provision both TTL-enabled containers before enabling the feature in production:
 
@@ -279,7 +279,7 @@ npm run setup-live-presence-container
 npm run setup-coding-stats-container
 ```
 
-Publish `extensions/vscode` version `0.2.0` after the web deployment so the Marketplace commands target available `/space`, `/api/presence`, and `/coding-stats` routes.
+Publish `extensions/vscode` version `0.3.0` after the web deployment so the Marketplace commands target available `/space`, `/api/presence`, and `/coding-stats` routes. The same VSIX supports compatible VS Code forks; Open VSX and vendor marketplace publication require separate publisher credentials.
 
 ### Impact history capture
 

--- a/app/space/page.jsx
+++ b/app/space/page.jsx
@@ -1,8 +1,8 @@
 import LiveDeveloperSpace from '../../components/LiveDeveloperSpace.jsx';
 
 export const metadata = {
-  title: "Who's coding right now | DevGlobe",
-  description: 'See developers who have explicitly chosen to share their current coding presence on DevGlobe.',
+  title: 'Developers coding worldwide | DevGlobe',
+  description: 'See developers who have explicitly chosen to share live and recent coding presence on DevGlobe.',
   alternates: { canonical: '/space' },
 };
 

--- a/components/CodingStatsDashboard.jsx
+++ b/components/CodingStatsDashboard.jsx
@@ -6,6 +6,8 @@ import { track } from '../lib/analytics.js';
 import styles from './CodingStatsDashboard.module.css';
 
 const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
+const WEEKLY_GOAL_KEY = 'devglobe.codingStats.weeklyGoalHours';
+const WEEKLY_GOALS = [5, 10, 20, 40];
 
 function duration(seconds) {
   const minutes = Math.floor(Number(seconds || 0) / 60);
@@ -35,6 +37,8 @@ export default function CodingStatsDashboard() {
   const [status, setStatus] = useState('loading');
   const [stats, setStats] = useState(null);
   const [message, setMessage] = useState('');
+  const [weeklyGoalHours, setWeeklyGoalHours] = useState(5);
+  const [shareStatus, setShareStatus] = useState('');
 
   useEffect(() => {
     track('coding_stats_viewed', { source: 'coding_dashboard' });
@@ -57,6 +61,33 @@ export default function CodingStatsDashboard() {
       });
     return () => controller.abort();
   }, []);
+
+  useEffect(() => {
+    const saved = Number(window.localStorage.getItem(WEEKLY_GOAL_KEY));
+    if (WEEKLY_GOALS.includes(saved)) setWeeklyGoalHours(saved);
+  }, []);
+
+  function updateWeeklyGoal(event) {
+    const hours = Number(event.target.value);
+    if (!WEEKLY_GOALS.includes(hours)) return;
+    setWeeklyGoalHours(hours);
+    window.localStorage.setItem(WEEKLY_GOAL_KEY, String(hours));
+  }
+
+  async function shareSummary() {
+    const channel = navigator.share ? 'native_share' : 'copy_link';
+    const topLanguage = stats.languages[0]?.name;
+    const text = `I coded ${duration(stats.weekSeconds)} this week${topLanguage ? `, led by ${topLanguage}` : ''}, with a ${stats.currentStreak}-day streak on DevGlobe.`;
+    const url = `${window.location.origin}/space?utm_source=coding_stats_share&utm_medium=${channel}`;
+    try {
+      if (navigator.share) await navigator.share({ title: 'My DevGlobe coding week', text, url });
+      else await navigator.clipboard.writeText(`${text} ${url}`);
+      setShareStatus(channel === 'native_share' ? 'Shared' : 'Summary copied');
+      track('coding_stats_shared', { source: 'coding_dashboard', channel });
+    } catch (error) {
+      if (error.name !== 'AbortError') setShareStatus('Unable to share');
+    }
+  }
 
   if (status === 'loading') return <main className={styles.state}><p>Loading your coding activity...</p></main>;
   if (status === 'signed-out') return (
@@ -90,13 +121,17 @@ export default function CodingStatsDashboard() {
           <h1>Your time in motion</h1>
           <span>Calculated from opt-in presence heartbeats. No source code, files, repositories, branches, or keystrokes are collected.</span>
         </div>
-        <a className={styles.secondaryAction} href={MARKETPLACE_URL} target="_blank" rel="noreferrer" onClick={() => track('extension_install_clicked', { source: 'coding_dashboard' })}>Manage VS Code extension</a>
+        <div className={styles.introActions}>
+          {hasActivity ? <button type="button" className={styles.primaryAction} onClick={shareSummary}>Share summary</button> : null}
+          <a className={styles.secondaryAction} href={MARKETPLACE_URL} target="_blank" rel="noreferrer" onClick={() => track('extension_install_clicked', { source: 'coding_dashboard' })}>Manage extension</a>
+          <span role="status" aria-live="polite">{shareStatus}</span>
+        </div>
       </section>
 
       {!hasActivity ? (
         <section className={styles.empty}>
           <h2>Start your first tracked session</h2>
-          <p>Install the extension, run “DevGlobe.dev: Start Sharing Coding Presence,” and keep coding. Your first totals appear after the second heartbeat.</p>
+          <p>Install the extension, choose “DevGlobe.dev: Go Live on the Developer Globe,” and keep coding. Your first totals appear after the second heartbeat.</p>
           <a className={styles.primaryAction} href={MARKETPLACE_URL} target="_blank" rel="noreferrer" onClick={() => track('extension_install_clicked', { source: 'coding_dashboard_empty' })}>Install for VS Code</a>
         </section>
       ) : (
@@ -116,6 +151,37 @@ export default function CodingStatsDashboard() {
                   <b style={{ height: `${day.seconds ? Math.max(8, day.seconds / maximumDay * 100) : 2}%` }} />
                 </i>
               ))}
+            </div>
+          </section>
+
+          <section className={styles.momentum} aria-label="Weekly goal and achievements">
+            <div className={styles.goal}>
+              <div>
+                <h2>Weekly goal</h2>
+                <label>Target
+                  <select value={weeklyGoalHours} onChange={updateWeeklyGoal}>
+                    {WEEKLY_GOALS.map(hours => <option key={hours} value={hours}>{hours} hours</option>)}
+                  </select>
+                </label>
+              </div>
+              <div className={styles.goalProgress}>
+                <span>{duration(stats.weekSeconds)} of {weeklyGoalHours}h</span>
+                <i role="progressbar" aria-label="Weekly coding goal" aria-valuemin="0" aria-valuemax={weeklyGoalHours * 3600} aria-valuenow={Math.min(stats.weekSeconds, weeklyGoalHours * 3600)}>
+                  <b style={{ width: `${Math.min(100, stats.weekSeconds / (weeklyGoalHours * 3600) * 100)}%` }} />
+                </i>
+              </div>
+            </div>
+            <div className={styles.achievements}>
+              <h2>Achievements</h2>
+              <div>
+                {stats.achievements.map(achievement => (
+                  <article key={achievement.id} data-earned={achievement.earned}>
+                    <span>{achievement.earned ? 'Earned' : 'In progress'}</span>
+                    <strong>{achievement.title}</strong>
+                    <p>{achievement.description}</p>
+                  </article>
+                ))}
+              </div>
             </div>
           </section>
 

--- a/components/CodingStatsDashboard.module.css
+++ b/components/CodingStatsDashboard.module.css
@@ -37,7 +37,8 @@
 .intro span { display: block; max-width: 690px; margin-top: 16px; color: var(--text-secondary); font-size: 14px; line-height: 1.7; }
 
 .primaryAction,
-.secondaryAction {
+.secondaryAction,
+.introActions button {
   display: inline-flex;
   min-height: 44px;
   align-items: center;
@@ -48,10 +49,13 @@
   font-size: 13px;
   font-weight: 700;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .primaryAction { background: var(--accent-blue); color: #fff; }
 .secondaryAction { flex: 0 0 auto; color: var(--accent-blue); }
+.introActions { display: flex; flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+.introActions > span { width: 100%; min-height: 18px; margin: 0; text-align: right; }
 .primaryAction:focus-visible,
 .secondaryAction:focus-visible,
 .brand:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 3px; }
@@ -77,6 +81,24 @@
 .chart { display: grid; height: 180px; grid-template-columns: repeat(30, 1fr); align-items: flex-end; gap: 5px; margin-top: 24px; }
 .chart i { display: flex; height: 100%; align-items: flex-end; background: color-mix(in srgb, var(--border) 30%, transparent); }
 .chart b { display: block; width: 100%; min-height: 2px; background: var(--accent-blue); }
+
+.momentum { display: grid; grid-template-columns: minmax(240px, 0.8fr) minmax(0, 1.2fr); gap: 56px; padding: 38px 0; border-bottom: 1px solid var(--border); }
+.goal h2,
+.achievements h2 { margin: 0; font-size: 17px; letter-spacing: 0; }
+.goal > div:first-child { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.goal label { display: flex; align-items: center; gap: 8px; color: var(--text-secondary); font-size: 12px; }
+.goal select { min-height: 36px; padding: 0 28px 0 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-card); color: var(--text-primary); }
+.goalProgress { margin-top: 28px; }
+.goalProgress > span { color: var(--text-secondary); font-size: 12px; }
+.goalProgress > i { display: block; height: 9px; margin-top: 10px; overflow: hidden; background: color-mix(in srgb, var(--border) 60%, transparent); }
+.goalProgress b { display: block; height: 100%; background: var(--accent-blue); }
+.achievements > div { display: grid; grid-template-columns: 1fr 1fr; margin-top: 18px; border-top: 1px solid var(--border); border-left: 1px solid var(--border); }
+.achievements article { min-width: 0; padding: 16px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); opacity: 0.55; }
+.achievements article[data-earned='true'] { opacity: 1; }
+.achievements article span { color: var(--text-secondary); font-size: 10px; font-weight: 700; }
+.achievements article[data-earned='true'] span { color: #22c55e; }
+.achievements article strong { display: block; margin-top: 6px; font-size: 13px; }
+.achievements article p { margin: 4px 0 0; color: var(--text-secondary); font-size: 11px; line-height: 1.5; }
 
 .breakdowns { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; padding-top: 38px; }
 .breakdown { min-width: 0; }
@@ -105,12 +127,15 @@
 @media (max-width: 720px) {
   .page { padding-inline: 16px; }
   .intro { align-items: flex-start; flex-direction: column; padding: 44px 0 30px; }
+  .introActions { width: 100%; justify-content: flex-start; }
+  .introActions > span { text-align: left; }
   .metrics { grid-template-columns: 1fr 1fr; }
   .metrics div { padding: 18px 14px; border-bottom: 1px solid var(--border); }
   .metrics div:nth-child(2) { border-right: 0; }
   .metrics div:nth-last-child(-n + 2) { border-bottom: 0; }
   .metrics div:first-child { padding-left: 14px; }
   .chart { height: 130px; gap: 2px; }
+  .momentum { grid-template-columns: 1fr; gap: 36px; }
   .breakdowns { grid-template-columns: 1fr; gap: 36px; }
   .empty { min-height: 320px; padding: 32px 0; }
 }

--- a/components/LiveDeveloperGlobe.jsx
+++ b/components/LiveDeveloperGlobe.jsx
@@ -12,8 +12,8 @@ const RENDERER_CONFIG = { alpha: true, antialias: true };
 const pointLat = developer => developer.lat;
 const pointLng = developer => developer.lng;
 const pointColor = developer => getLanguageColor(developer.activeLanguage) || '#3b82f6';
-const pointAltitude = () => 0.035;
-const pointRadius = () => 0.65;
+const pointAltitude = developer => developer.presenceState === 'live' ? 0.035 : 0.018;
+const pointRadius = developer => developer.presenceState === 'live' ? 0.65 : 0.38;
 const ringLat = developer => developer.lat;
 const ringLng = developer => developer.lng;
 const ringColor = developer => () => `${pointColor(developer)}b3`;
@@ -78,7 +78,7 @@ const LiveDeveloperGlobe = forwardRef(function LiveDeveloperGlobe({ developers, 
   }, []);
 
   return (
-    <div ref={containerRef} className="live-globe-canvas" aria-label="Interactive globe showing developers currently coding">
+    <div ref={containerRef} className="live-globe-canvas" aria-label="Interactive globe showing live and recent developer activity">
       <GlobeGL
         ref={globeRef}
         width={size.width}
@@ -101,7 +101,7 @@ const LiveDeveloperGlobe = forwardRef(function LiveDeveloperGlobe({ developers, 
         pointAltitude={pointAltitude}
         pointRadius={pointRadius}
         onPointClick={onSelect}
-        ringsData={developers}
+        ringsData={developers.filter(developer => developer.presenceState === 'live')}
         ringLat={ringLat}
         ringLng={ringLng}
         ringColor={ringColor}

--- a/components/LiveDeveloperSpace.jsx
+++ b/components/LiveDeveloperSpace.jsx
@@ -27,6 +27,8 @@ export default function LiveDeveloperSpace() {
   const [platform, setPlatform] = useState('');
   const [selected, setSelected] = useState(null);
   const deferredDevelopers = useDeferredValue(developers);
+  const liveCount = developers.filter(developer => developer.presenceState === 'live').length;
+  const recentCount = developers.length - liveCount;
   const languages = useMemo(() => uniqueValues(developers, 'activeLanguage'), [developers]);
   const platforms = useMemo(() => uniqueValues(developers, 'platform'), [developers]);
   const filtered = useMemo(() => deferredDevelopers
@@ -48,10 +50,10 @@ export default function LiveDeveloperSpace() {
           <span>DevGlobe</span>
         </Link>
         <div className={styles.title}>
-          <h1>Who&apos;s coding right now</h1>
+          <h1>Developers coding worldwide</h1>
           <span className={styles.connection} data-state={connection} role="status">
             <i aria-hidden="true" /> {connection === 'live'
-              ? `${developers.length} live`
+              ? `${liveCount} live, ${recentCount} recent`
               : connection === 'unavailable' ? 'Unavailable' : 'Connecting'}
           </span>
         </div>
@@ -65,18 +67,18 @@ export default function LiveDeveloperSpace() {
         <LiveDeveloperGlobe ref={globeRef} developers={filtered} onSelect={selectDeveloper} />
       </section>
 
-      <aside className={styles.activity} aria-label="Developers online now">
+      <aside className={styles.activity} aria-label="Live and recent developer activity">
         <div className={styles.panelHeading}>
-          <h2>Live activity</h2>
+          <h2>Developer activity</h2>
           <span>{filtered.length}</span>
         </div>
         <div className={styles.activityList}>
           {filtered.map(developer => (
-            <button key={developer.id} type="button" onClick={() => selectDeveloper(developer)} className={styles.activityRow}>
+            <button key={developer.id} type="button" onClick={() => selectDeveloper(developer)} className={styles.activityRow} data-presence={developer.presenceState}>
               <img src={developer.avatarUrl || '/devglobe.png'} alt="" />
               <span>
                 <strong>{developer.name || developer.login}</strong>
-                <small><i style={{ background: getLanguageColor(developer.activeLanguage) || '#3b82f6' }} />{developer.activeLanguage}</small>
+                <small><i style={{ background: getLanguageColor(developer.activeLanguage) || '#3b82f6' }} />{developer.activeLanguage} · {developer.presenceState === 'live' ? 'Live now' : 'Recently coding'}</small>
               </span>
               <time dateTime={developer.lastHeartbeat}>{relativeTime(developer.lastHeartbeat)}</time>
             </button>
@@ -90,7 +92,7 @@ export default function LiveDeveloperSpace() {
         </div>
       </aside>
 
-      <aside className={styles.filters} aria-label="Filter live developers">
+      <aside className={styles.filters} aria-label="Filter developer activity">
         <label>
           <span>Language</span>
           <select value={language} onChange={event => setLanguage(event.target.value)}>
@@ -113,13 +115,14 @@ export default function LiveDeveloperSpace() {
       </aside>
 
       {selected ? (
-        <aside className={styles.selected} aria-live="polite">
+        <aside className={styles.selected} data-presence={selected.presenceState} aria-live="polite">
           <button type="button" className={styles.close} onClick={() => setSelected(null)} aria-label="Close developer details">×</button>
           <img src={selected.avatarUrl || '/devglobe.png'} alt="" />
           <div>
             <strong>{selected.name || selected.login}</strong>
             <span>@{selected.login}</span>
             <p>{selected.activeLanguage} in {selected.editor} on {selected.platform}</p>
+            <small className={styles.presenceLabel}>{selected.presenceState === 'live' ? 'Live now' : 'Recently coding'}</small>
             <small>{selected.location || 'Location not listed'}</small>
           </div>
           <Link href={`/developer/${encodeURIComponent(selected.login)}`}>View profile</Link>

--- a/components/LiveDeveloperSpace.module.css
+++ b/components/LiveDeveloperSpace.module.css
@@ -127,6 +127,8 @@
 .activityRow small { display: flex; align-items: center; gap: 6px; margin-top: 3px; color: var(--text-secondary); font-size: 11px; }
 .activityRow small i { width: 6px; height: 6px; border-radius: 50%; }
 .activityRow time { color: var(--text-muted); font-size: 10px; }
+.activityRow[data-presence='recent'] { opacity: 0.68; }
+.activityRow[data-presence='recent'] img { filter: saturate(0.65); }
 .empty { margin: 0; padding: 22px 16px; color: var(--text-secondary); font-size: 12px; line-height: 1.55; }
 
 .filters {
@@ -181,6 +183,9 @@
 .selected span,
 .selected small { color: var(--text-secondary); font-size: 11px; }
 .selected p { margin: 5px 0 2px; font-size: 11px; }
+.selected .presenceLabel { color: #22c55e; font-weight: 700; }
+.selected[data-presence='recent'] .presenceLabel { color: var(--text-secondary); }
+.selected .presenceLabel:not(:last-child) { margin-bottom: 2px; }
 .selected > a { color: var(--accent-blue); font-size: 11px; font-weight: 700; text-decoration: none; }
 .close {
   position: absolute;

--- a/docs/azure-backend.md
+++ b/docs/azure-backend.md
@@ -39,7 +39,7 @@ npm run setup-live-presence-container
 npm run setup-coding-stats-container
 ```
 
-Set `COSMOS_LIVE_PRESENCE_CONTAINER` only when using a name other than `live-presence`. Each heartbeat has a 90-second item TTL. `GET /api/sse/developers` sends an `init` snapshot, `update` events with `upsert` or `delete`, and 20-second connection heartbeats. Container Apps ingress and any intermediary proxy must leave streaming responses unbuffered and allow connections longer than 20 seconds.
+Set `COSMOS_LIVE_PRESENCE_CONTAINER` only when using a name other than `live-presence`. Each heartbeat remains live for 90 seconds and is retained as recently coding for 15 minutes before its item TTL expires. `GET /api/sse/developers` sends an `init` snapshot, `update` events with `upsert` or `delete`, and 20-second connection heartbeats. Container Apps ingress and any intermediary proxy must leave streaming responses unbuffered and allow connections longer than 20 seconds.
 
 Set `COSMOS_CODING_STATS_CONTAINER` only when using a name other than `coding-stats`. The server derives owner-only daily totals from consecutive heartbeats, caps each interval at the presence TTL, and retains aggregate documents for 400 days. Aggregate writes are best-effort and never make live presence unavailable. The `/api/coding-stats` route requires the signed-in browser session and does not expose another developer's totals.
 

--- a/docs/prd/vscode-extension.md
+++ b/docs/prd/vscode-extension.md
@@ -51,7 +51,7 @@ The extension contributes these commands:
 - Links include `utm_source=vscode_extension&utm_medium=marketplace`.
 - MCP setup copies a configuration pointing to `/mcp`; it never handles agent credentials.
 - URL construction and response normalization are framework-independent and unit tested.
-- Presence uses a scoped token in VS Code `SecretStorage`, a 30-second heartbeat, and a 90-second server TTL.
+- Presence uses a scoped token in VS Code `SecretStorage` and a 30-second heartbeat. A heartbeat is live for 90 seconds and remains visible as recently coding for up to 15 minutes.
 - Daily totals are derived server-side from consecutive valid heartbeats and retained for 400 days.
 
 ## Privacy and Security
@@ -91,6 +91,6 @@ DevGlobe records first-party install-click, token, presence, sign-off, and stats
 ## Rollout
 
 1. Validate the VSIX locally and with Extension Development Host.
-2. Deploy the presence and coding-stats APIs before publishing extension version `0.2.0`.
+2. Deploy the presence and coding-stats APIs before publishing extension version `0.3.0`.
 3. Publish an unlisted marketplace preview and verify GitHub authentication, presence expiry, and VS Code forks.
 4. Publish publicly and measure install-to-presence activation and stats return usage.

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.0
+
+- Pause presence heartbeats after one minute without editor activity and resume automatically when coding continues.
+- Detect Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and VS Code Insiders.
+- Keep a one-click Go Live action visible in the status bar when presence is off.
+- Link to private weekly goals, achievements, streaks, and shareable aggregate summaries.
+
+## 0.2.0
+
+- Opt in to the live developer globe using VS Code GitHub authentication.
+- Build private daily coding totals and language/editor breakdowns from bounded heartbeats.
+- Open the live globe and private coding dashboard from VS Code.
+
 ## 0.1.0
 
 - Search public DevGlobe developer profiles from the Command Palette.

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -8,6 +8,8 @@ This extension connects exclusively to [devglobe.dev](https://www.devglobe.dev).
 
 Install [DevGlobe: Live Coding Globe from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery). Choose **Go Live** in the first-run prompt, approve GitHub authentication, and open the live globe to see your presence. You can also use the Command Palette and run `DevGlobe.dev: Go Live on the Developer Globe`.
 
+Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the release package, then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
+
 ## Commands
 
 - `DevGlobe.dev: Find a Developer`
@@ -21,11 +23,11 @@ Install [DevGlobe: Live Coding Globe from the VS Code Marketplace](https://marke
 
 Set `devglobedev.githubLogin` in VS Code settings to enable personal profile and card commands. `devglobedev.baseUrl` defaults to `https://www.devglobe.dev`.
 
-Live presence is off by default. Starting it uses VS Code's GitHub authentication, then sends a heartbeat every 30 seconds while the extension is running. Private daily totals and language/editor breakdowns are calculated from those heartbeats. Set `devglobedev.presence.shareActiveLanguage` to `false` to hide the active language.
+Live presence is off by default. Starting it uses the editor's GitHub authentication, then sends a heartbeat every 30 seconds while you are active. Heartbeats pause after one minute without editor activity and resume when you continue coding. Private daily totals, streaks, weekly goals, achievements, and language/editor breakdowns are calculated from those heartbeats. Set `devglobedev.presence.shareActiveLanguage` to `false` to hide the active language.
 
 ## Privacy
 
-The extension makes a public API request when you run a search command. If you explicitly enable live presence, it sends the active language, editor name, operating system, and session timestamps. It does not send source code, file paths, repository names, branches, or keystrokes. Globe coordinates come from your existing public DevGlobe profile, not device geolocation. The DevGlobe presence token is stored in VS Code SecretStorage.
+The extension makes a public API request when you run a search command. If you explicitly enable live presence, it sends the active language, editor name, operating system, and session timestamps. Editor events only reset an in-memory inactivity timer; the events and their contents are not transmitted. It does not send source code, file paths, repository names, branches, or keystrokes. Globe coordinates come from your existing public DevGlobe profile, not device geolocation. The DevGlobe presence token is stored in VS Code SecretStorage.
 
 ## Development
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devglobe-developer-discovery",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devglobe-developer-discovery",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/vscode": "^1.85.0"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "devglobe-developer-discovery",
   "displayName": "DevGlobe: Live Coding Globe",
   "description": "Show up on the live developer globe while you code, track private coding stats, and discover developers.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "devglobedev",
   "license": "MIT",
   "icon": "images/icon.png",
@@ -113,7 +113,8 @@
   },
   "scripts": {
     "test": "node --test test/*.test.js",
-    "check": "node --check src/extension.js && node --check src/devglobe.js"
+    "check": "node --check src/extension.js && node --check src/devglobe.js",
+    "package": "npx --yes @vscode/vsce package"
   },
   "devDependencies": {
     "@types/vscode": "^1.85.0"

--- a/extensions/vscode/src/devglobe.js
+++ b/extensions/vscode/src/devglobe.js
@@ -2,6 +2,25 @@ const ATTRIBUTION = Object.freeze({
   utm_source: 'vscode_extension',
   utm_medium: 'marketplace',
 });
+const CODING_ACTIVITY_WINDOW_MS = 60_000;
+
+function isCodingActivityRecent(lastActivityAt, now = Date.now()) {
+  return Number.isFinite(lastActivityAt)
+    && now >= lastActivityAt
+    && now - lastActivityAt <= CODING_ACTIVITY_WINDOW_MS;
+}
+
+function editorName(appName) {
+  const name = String(appName || '').toLowerCase();
+  if (name.includes('cursor')) return 'Cursor';
+  if (name.includes('windsurf')) return 'Windsurf';
+  if (name.includes('vscodium')) return 'VSCodium';
+  if (name.includes('positron')) return 'Positron';
+  if (name.includes('void')) return 'Void';
+  if (name.includes('antigravity')) return 'Antigravity';
+  if (name.includes('insider')) return 'VS Code Insiders';
+  return 'VS Code';
+}
 
 function resolveBaseUrl(value) {
   const candidate = String(value || '').trim().replace(/\/$/, '');
@@ -114,9 +133,12 @@ function normalizeResults(payload) {
 }
 
 module.exports = {
+  CODING_ACTIVITY_WINDOW_MS,
   agentSetupUrl,
   codingStatsUrl,
+  editorName,
   identityCardUrl,
+  isCodingActivityRecent,
   liveGlobeUrl,
   mcpConfiguration,
   normalizeLogin,

--- a/extensions/vscode/src/extension.js
+++ b/extensions/vscode/src/extension.js
@@ -2,7 +2,9 @@ const vscode = require('vscode');
 const {
   agentSetupUrl,
   codingStatsUrl,
+  editorName,
   identityCardUrl,
+  isCodingActivityRecent,
   liveGlobeUrl,
   mcpConfiguration,
   normalizeLogin,
@@ -38,15 +40,36 @@ function activeLanguage() {
 
 function createPresenceController(context) {
   const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 20);
-  status.command = 'devglobedev.stopPresence';
-  status.text = '$(radio-tower) DevGlobe live';
-  status.tooltip = 'Coding presence is visible on DevGlobe. Click to stop sharing.';
   context.subscriptions.push(status);
 
   let timer = null;
   let starting = null;
   let sessionStartedAt = null;
+  let lastActivityAt = 0;
   let sending = false;
+
+  function showOfflineStatus() {
+    status.command = 'devglobedev.startPresence';
+    status.text = '$(globe) DevGlobe: Go live';
+    status.tooltip = 'Show up on the live developer globe while you code.';
+    status.show();
+  }
+
+  function showLiveStatus() {
+    status.command = 'devglobedev.stopPresence';
+    status.text = '$(radio-tower) DevGlobe live';
+    status.tooltip = 'Coding presence is visible on DevGlobe. Click to stop sharing.';
+    status.show();
+  }
+
+  function showIdleStatus() {
+    status.command = 'devglobedev.stopPresence';
+    status.text = '$(debug-pause) DevGlobe idle';
+    status.tooltip = 'Heartbeats pause after one minute without editor activity. Start coding to resume.';
+    status.show();
+  }
+
+  showOfflineStatus();
 
   async function exchangeToken(interactive) {
     const githubSession = await vscode.authentication.getSession('github', ['read:user'], {
@@ -72,6 +95,10 @@ function createPresenceController(context) {
 
   async function heartbeat(interactive = false) {
     if (sending || !configuration().presenceEnabled) return false;
+    if (!isCodingActivityRecent(lastActivityAt)) {
+      showIdleStatus();
+      return false;
+    }
     sending = true;
     try {
       let bearer = await token(interactive);
@@ -81,7 +108,7 @@ function createPresenceController(context) {
         headers: { Authorization: `Bearer ${bearer}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
           activeLanguage: configuration().shareActiveLanguage ? activeLanguage() : 'Hidden',
-          editor: 'VS Code',
+          editor: editorName(vscode.env.appName),
           platform: platformName(),
           sessionStartedAt,
         }),
@@ -98,7 +125,7 @@ function createPresenceController(context) {
         const payload = await response.json().catch(() => ({}));
         throw new Error(payload.error || `DevGlobe presence failed with HTTP ${response.status}.`);
       }
-      status.show();
+      showLiveStatus();
       return true;
     } finally {
       sending = false;
@@ -110,6 +137,7 @@ function createPresenceController(context) {
     if (starting) return starting;
     starting = (async () => {
       sessionStartedAt = new Date().toISOString();
+      lastActivityAt = Date.now();
       const online = await heartbeat(interactive);
       if (!online || !configuration().presenceEnabled) return false;
       timer = setInterval(() => heartbeat(false).catch(() => {}), HEARTBEAT_INTERVAL_MS);
@@ -122,10 +150,11 @@ function createPresenceController(context) {
     }
   }
 
-  async function stop(notifyServer = true) {
+  async function stop(notifyServer = true, keepAction = true) {
     if (timer) clearInterval(timer);
     timer = null;
-    status.hide();
+    if (keepAction) showOfflineStatus();
+    else status.hide();
     if (!notifyServer) return;
     const bearer = await context.secrets.get(PRESENCE_TOKEN_KEY);
     if (!bearer) return;
@@ -136,14 +165,26 @@ function createPresenceController(context) {
     }).catch(() => {});
   }
 
+  function recordActivity() {
+    const wasActive = isCodingActivityRecent(lastActivityAt);
+    lastActivityAt = Date.now();
+    if (configuration().presenceEnabled && !wasActive) heartbeat(false).catch(() => {});
+  }
+
   context.subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor(() => heartbeat(false).catch(() => {})),
+    vscode.window.onDidChangeActiveTextEditor(recordActivity),
+    vscode.window.onDidChangeTextEditorSelection(recordActivity),
+    vscode.workspace.onDidChangeTextDocument(recordActivity),
+    vscode.workspace.onDidSaveTextDocument(recordActivity),
+    vscode.window.onDidChangeWindowState(event => {
+      if (event.focused) recordActivity();
+    }),
     vscode.workspace.onDidChangeConfiguration(event => {
       if (!event.affectsConfiguration('devglobedev.presence')) return;
       if (configuration().presenceEnabled) start(true).catch(() => {});
       else stop().catch(() => {});
     }),
-    { dispose: () => stop(false) },
+    { dispose: () => stop(false, false) },
   );
   return { start, stop };
 }

--- a/extensions/vscode/test/devglobe.test.js
+++ b/extensions/vscode/test/devglobe.test.js
@@ -1,9 +1,12 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
+  CODING_ACTIVITY_WINDOW_MS,
   agentSetupUrl,
   codingStatsUrl,
+  editorName,
   identityCardUrl,
+  isCodingActivityRecent,
   liveGlobeUrl,
   mcpConfiguration,
   normalizeLogin,
@@ -14,6 +17,22 @@ const {
   resolveBaseUrl,
   searchUrl,
 } = require('../src/devglobe');
+
+test('detects compatible VS Code editor families', () => {
+  assert.equal(editorName('Visual Studio Code'), 'VS Code');
+  assert.equal(editorName('Visual Studio Code - Insiders'), 'VS Code Insiders');
+  assert.equal(editorName('Cursor'), 'Cursor');
+  assert.equal(editorName('Windsurf'), 'Windsurf');
+  assert.equal(editorName('VSCodium'), 'VSCodium');
+});
+
+test('treats editor activity as current for one minute', () => {
+  assert.equal(CODING_ACTIVITY_WINDOW_MS, 60_000);
+  assert.equal(isCodingActivityRecent(1_000, 61_000), true);
+  assert.equal(isCodingActivityRecent(1_000, 61_001), false);
+  assert.equal(isCodingActivityRecent(0, 1_000), true);
+  assert.equal(isCodingActivityRecent(Number.NaN, 1_000), false);
+});
 
 test('validates production and local base URLs', () => {
   assert.equal(resolveBaseUrl('https://www.devglobe.dev/'), 'https://www.devglobe.dev');

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -9,6 +9,7 @@ const ENGAGEMENT_EVENT_MAP = {
 	agent_workflow_copied: 'agent_workflow_copied',
 	agent_profile_shared: 'profile_shared',
 	card_generated: 'card_generated',
+	coding_stats_shared: 'coding_stats_shared',
 	coding_stats_viewed: 'coding_stats_viewed',
 	claim_completed: 'profile_claimed',
 	comparison_started: 'comparison_started',

--- a/lib/coding-stats.js
+++ b/lib/coding-stats.js
@@ -1,4 +1,4 @@
-import { LIVE_PRESENCE_TTL_SECONDS } from './live-presence.js';
+import { LIVE_PRESENCE_ACTIVE_SECONDS } from './live-presence.js';
 
 export const CODING_STATS_RETENTION_DAYS = 400;
 
@@ -19,7 +19,7 @@ export function buildCodingDelta(previous, current) {
   const endedAt = Date.parse(current.lastHeartbeat || '');
   const seconds = Math.floor((endedAt - startedAt) / 1000);
   const day = utcDay(current.lastHeartbeat);
-  if (!day || day !== utcDay(previous.lastHeartbeat) || seconds <= 0 || seconds > LIVE_PRESENCE_TTL_SECONDS) return null;
+  if (!day || day !== utcDay(previous.lastHeartbeat) || seconds <= 0 || seconds > LIVE_PRESENCE_ACTIVE_SECONDS) return null;
 
   return {
     login: current.login,
@@ -71,6 +71,35 @@ function sumDimensions(days, field) {
     .sort((left, right) => right.seconds - left.seconds || left.name.localeCompare(right.name));
 }
 
+export function buildCodingAchievements({ allSeconds, weekSeconds, currentStreak }) {
+  return [
+    {
+      id: 'first-hour',
+      title: 'First hour',
+      description: 'Track one hour of focused coding.',
+      earned: allSeconds >= 60 * 60,
+    },
+    {
+      id: 'five-hour-week',
+      title: 'Five-hour week',
+      description: 'Code for five hours in seven days.',
+      earned: weekSeconds >= 5 * 60 * 60,
+    },
+    {
+      id: 'three-day-streak',
+      title: 'Three-day streak',
+      description: 'Record activity three days in a row.',
+      earned: currentStreak >= 3,
+    },
+    {
+      id: 'seven-day-streak',
+      title: 'Seven-day streak',
+      description: 'Record activity seven days in a row.',
+      earned: currentStreak >= 7,
+    },
+  ];
+}
+
 export function buildCodingStats(documents, now = new Date()) {
   const currentDay = utcDay(now);
   const byDay = new Map(documents.map(document => [document.day, document]));
@@ -93,7 +122,7 @@ export function buildCodingStats(documents, now = new Date()) {
     cursor.setUTCDate(cursor.getUTCDate() - 1);
   }
 
-  return {
+  const summary = {
     todaySeconds: Number(byDay.get(currentDay)?.activeSeconds || 0),
     weekSeconds: total(last7Days),
     monthSeconds: total(timeline),
@@ -103,4 +132,5 @@ export function buildCodingStats(documents, now = new Date()) {
     editors: sumDimensions(recentDays, 'editors').slice(0, 5),
     timeline,
   };
+  return { ...summary, achievements: buildCodingAchievements(summary) };
 }

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -10,6 +10,7 @@ export const ENGAGEMENT_EVENTS = new Set([
   'agent_setup_started',
   'agent_workflow_copied',
   'card_generated',
+  'coding_stats_shared',
   'coding_stats_viewed',
   'comparison_started',
   'extension_install_clicked',

--- a/lib/live-presence-store.js
+++ b/lib/live-presence-store.js
@@ -1,5 +1,5 @@
 import { getCosmosContainer } from './cosmos.js';
-import { isLivePresenceActive } from './live-presence.js';
+import { presenceActivityState } from './live-presence.js';
 
 export function getLivePresenceContainer() {
   return getCosmosContainer(process.env.COSMOS_LIVE_PRESENCE_CONTAINER || 'live-presence');
@@ -50,5 +50,7 @@ export async function listLivePresence(container = getLivePresenceContainer(), n
       c.activeLanguage, c.editor, c.platform, c.sessionStartedAt, c.lastHeartbeat
       FROM c WHERE c.type = 'live-presence'`,
   }).fetchAll();
-  return resources.filter(developer => isLivePresenceActive(developer, now));
+  return resources
+    .map(developer => ({ ...developer, presenceState: presenceActivityState(developer, now) }))
+    .filter(developer => developer.presenceState);
 }

--- a/lib/live-presence.js
+++ b/lib/live-presence.js
@@ -1,7 +1,9 @@
 const LOGIN_PATTERN = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
 const MAX_FIELD_LENGTH = 80;
 
-export const LIVE_PRESENCE_TTL_SECONDS = 90;
+export const LIVE_PRESENCE_ACTIVE_SECONDS = 90;
+export const LIVE_PRESENCE_RECENT_SECONDS = 15 * 60;
+export const LIVE_PRESENCE_TTL_SECONDS = LIVE_PRESENCE_RECENT_SECONDS;
 export const LIVE_PRESENCE_MIN_INTERVAL_SECONDS = 10;
 
 function boundedText(value, maximum = MAX_FIELD_LENGTH) {
@@ -44,7 +46,16 @@ export function normalizeLivePresence({ heartbeat, profile, now = new Date() }) 
 export function isLivePresenceActive(presence, now = Date.now()) {
   const lastHeartbeat = Date.parse(presence?.lastHeartbeat || '');
   return Number.isFinite(lastHeartbeat)
-    && now - lastHeartbeat < LIVE_PRESENCE_TTL_SECONDS * 1000;
+    && now - lastHeartbeat < LIVE_PRESENCE_ACTIVE_SECONDS * 1000;
+}
+
+export function presenceActivityState(presence, now = Date.now()) {
+  const lastHeartbeat = Date.parse(presence?.lastHeartbeat || '');
+  if (!Number.isFinite(lastHeartbeat)) return null;
+  const age = now - lastHeartbeat;
+  if (age < LIVE_PRESENCE_ACTIVE_SECONDS * 1000) return 'live';
+  if (age < LIVE_PRESENCE_RECENT_SECONDS * 1000) return 'recent';
+  return null;
 }
 
 export function presenceRetryAfter(presence, now = Date.now()) {
@@ -61,7 +72,9 @@ export function diffLivePresence(previous, next) {
 
   for (const developer of next) {
     const existing = before.get(developer.id);
-    if (!existing || existing.lastHeartbeat !== developer.lastHeartbeat) {
+    if (!existing
+      || existing.lastHeartbeat !== developer.lastHeartbeat
+      || existing.presenceState !== developer.presenceState) {
       updates.push({ type: 'upsert', developer });
     }
   }

--- a/tests/coding-stats.test.js
+++ b/tests/coding-stats.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCodingDelta, buildCodingStats, mergeCodingDay } from '../lib/coding-stats.js';
+import { buildCodingAchievements, buildCodingDelta, buildCodingStats, mergeCodingDay } from '../lib/coding-stats.js';
 
 const first = {
   login: 'octocat',
@@ -44,6 +44,15 @@ test('builds owner dashboard totals, dimensions, timeline, and streak', () => {
   assert.equal(result.todaySeconds, 180);
   assert.equal(result.weekSeconds, 360);
   assert.equal(result.currentStreak, 3);
+  assert.equal(result.achievements.find(item => item.id === 'three-day-streak').earned, true);
+  assert.equal(result.achievements.find(item => item.id === 'first-hour').earned, false);
   assert.deepEqual(result.languages[0], { name: 'TypeScript', seconds: 300 });
   assert.equal(result.timeline.length, 30);
+});
+
+test('derives achievements from aggregate totals without source activity', () => {
+  const achievements = buildCodingAchievements({ allSeconds: 3600, weekSeconds: 18000, currentStreak: 7 });
+  assert.equal(achievements.length, 4);
+  assert.equal(achievements.every(item => item.earned), true);
+  assert.equal(achievements.some(item => 'file' in item || 'repository' in item), false);
 });

--- a/tests/engagement.test.js
+++ b/tests/engagement.test.js
@@ -396,7 +396,7 @@ test('accepts bounded community campaign sources', () => {
 });
 
 test('accepts the extension activation funnel without target identities', () => {
-  for (const eventName of ['extension_install_clicked', 'presence_token_issued', 'presence_started', 'presence_heartbeat_received', 'presence_stopped', 'coding_stats_viewed']) {
+  for (const eventName of ['extension_install_clicked', 'presence_token_issued', 'presence_started', 'presence_heartbeat_received', 'presence_stopped', 'coding_stats_viewed', 'coding_stats_shared']) {
     assert.deepEqual(normalizeEngagementEvent({
       eventName,
       properties: { source: 'vscode_extension', login: 'must-not-survive' },

--- a/tests/live-presence.test.js
+++ b/tests/live-presence.test.js
@@ -1,10 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  LIVE_PRESENCE_ACTIVE_SECONDS,
+  LIVE_PRESENCE_RECENT_SECONDS,
   LIVE_PRESENCE_TTL_SECONDS,
   diffLivePresence,
   isLivePresenceActive,
   normalizeLivePresence,
+  presenceActivityState,
   presenceRetryAfter,
 } from '../lib/live-presence.js';
 
@@ -51,6 +54,17 @@ test('expires presence after the heartbeat window', () => {
   assert.equal(isLivePresenceActive(presence, now.getTime() + 90_000), false);
 });
 
+test('classifies live and recently coding presence independently of storage retention', () => {
+  const presence = { lastHeartbeat: now.toISOString() };
+  assert.equal(LIVE_PRESENCE_ACTIVE_SECONDS, 90);
+  assert.equal(LIVE_PRESENCE_RECENT_SECONDS, 900);
+  assert.equal(LIVE_PRESENCE_TTL_SECONDS, LIVE_PRESENCE_RECENT_SECONDS);
+  assert.equal(presenceActivityState(presence, now.getTime() + 89_000), 'live');
+  assert.equal(presenceActivityState(presence, now.getTime() + 90_000), 'recent');
+  assert.equal(presenceActivityState(presence, now.getTime() + 899_000), 'recent');
+  assert.equal(presenceActivityState(presence, now.getTime() + 900_000), null);
+});
+
 test('rate limits heartbeat bursts without delaying the normal interval', () => {
   const presence = { lastHeartbeat: now.toISOString() };
   assert.equal(presenceRetryAfter(presence, now.getTime() + 9_000), 1);
@@ -67,5 +81,13 @@ test('diffs changed and removed developers for SSE updates', () => {
   assert.deepEqual(diffLivePresence(previous, next), [
     { type: 'upsert', developer: next[0] },
     { type: 'delete', developerId: 'offline' },
+  ]);
+});
+
+test('diffs a transition from live to recently coding', () => {
+  const previous = [{ id: 'octo-cat', lastHeartbeat: now.toISOString(), presenceState: 'live' }];
+  const next = [{ id: 'octo-cat', lastHeartbeat: now.toISOString(), presenceState: 'recent' }];
+  assert.deepEqual(diffLivePresence(previous, next), [
+    { type: 'upsert', developer: next[0] },
   ]);
 });


### PR DESCRIPTION
## Summary
- distinguish developers coding live from those recently active on the globe
- pause extension heartbeats after local inactivity and support common VS Code forks
- add private weekly goals, achievements, and aggregate-only sharing
- prepare and document extension release 0.3.0

## Privacy
- editor activity only updates an in-memory idle timer
- no source, paths, repositories, branches, keystrokes, or raw identity telemetry are added

## Validation
- npm test (426 passed)
- npm run build
- extension npm test (7 passed)
- extension npm run check
- extension npm run package
- desktop and 390px mobile dashboard interaction checks
- git diff --check