### PR TITLE
Add editor distribution hub

### DIFF
--- a/.github/workflows/publish-editor-extension.yml
+++ b/.github/workflows/publish-editor-extension.yml
@@ -1,0 +1,89 @@
+name: Publish editor extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      github_release:
+        description: Upload the VSIX to its GitHub Release
+        type: boolean
+        default: true
+      marketplace:
+        description: Publish to Visual Studio Marketplace
+        type: boolean
+        default: false
+      open_vsx:
+        description: Publish to Open VSX
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: extensions/vscode
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extensions/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate extension
+        run: |
+          npm test
+          npm run check
+
+      - name: Package VSIX
+        run: npm run package
+
+      - name: Resolve artifact
+        id: artifact
+        shell: bash
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "vsix=devglobe-developer-discovery-$version.vsix" >> "$GITHUB_OUTPUT"
+
+      - name: Upload GitHub Release
+        if: inputs.github_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.artifact.outputs.version }}
+          VSIX: ${{ steps.artifact.outputs.vsix }}
+        run: |
+          gh release view "v$VERSION" >/dev/null 2>&1 || gh release create "v$VERSION" --target "$GITHUB_SHA" --title "DevGlobe editor extension $VERSION" --generate-notes
+          gh release upload "v$VERSION" "$VSIX" --clobber
+
+      - name: Require Marketplace credentials
+        if: inputs.marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: test -n "$VSCE_PAT" || (echo "VSCE_PAT is not configured" && exit 1)
+
+      - name: Publish to Visual Studio Marketplace
+        if: inputs.marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSIX: ${{ steps.artifact.outputs.vsix }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX" -p "$VSCE_PAT"
+
+      - name: Require Open VSX credentials
+        if: inputs.open_vsx
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: test -n "$OVSX_PAT" || (echo "OVSX_PAT is not configured" && exit 1)
+
+      - name: Publish to Open VSX
+        if: inputs.open_vsx
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          VSIX: ${{ steps.artifact.outputs.vsix }}
+        run: npx --yes ovsx publish "$VSIX" -p "$OVSX_PAT"

--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ npm run setup-live-presence-container
 npm run setup-coding-stats-container
 ```
 
-Publish `extensions/vscode` version `0.3.0` after the web deployment so the Marketplace commands target available `/space`, `/api/presence`, and `/coding-stats` routes. The same VSIX supports compatible VS Code forks; Open VSX and vendor marketplace publication require separate publisher credentials.
+The [editor directory](https://www.devglobe.dev/plugins) provides tailored installation paths for VS Code, Cursor, Windsurf, VSCodium, Positron, Void, and Antigravity. Release `v0.3.0` is available from both the Marketplace and [GitHub Releases](https://github.com/sajeetharan/devglobe/releases/tag/v0.3.0). The same VSIX supports compatible VS Code forks; Open VSX publication requires the `devglobedev` namespace and an `OVSX_PAT` repository secret.
+
+Run the **Publish editor extension** workflow manually to validate and package one artifact, then select GitHub Release, Visual Studio Marketplace, or Open VSX destinations. Store publisher credentials only in the `VSCE_PAT` and `OVSX_PAT` GitHub Actions secrets.
 
 ### Impact history capture
 

--- a/app/plugins/[editor]/page.jsx
+++ b/app/plugins/[editor]/page.jsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import EditorInstallLink from '../../../components/EditorInstallLink.jsx';
+import { attributedInstallUrl, editorChannels, editorInstallSteps, getEditorChannel } from '../../../lib/editor-distribution.js';
+import styles from '../plugins.module.css';
+
+export function generateStaticParams() {
+  return editorChannels.map(editor => ({ editor: editor.slug }));
+}
+
+export async function generateMetadata({ params }) {
+  const { editor: slug } = await params;
+  const editor = getEditorChannel(slug);
+  if (!editor) return {};
+  return {
+    title: `${editor.status === 'available' ? 'Install' : 'DevGlobe for'} ${editor.name} | DevGlobe`,
+    description: editor.status === 'available'
+      ? `Connect ${editor.name} to DevGlobe and show your privacy-safe coding presence on the live globe.`
+      : `Follow DevGlobe's progress toward a native ${editor.name} connection.`,
+    alternates: { canonical: `/plugins/${editor.slug}` },
+  };
+}
+
+export default async function EditorPluginPage({ params }) {
+  const { editor: slug } = await params;
+  const editor = getEditorChannel(slug);
+  if (!editor) notFound();
+  const steps = editorInstallSteps(editor);
+  const installUrl = attributedInstallUrl(editor);
+  return (
+    <main className={styles.page} style={{ '--editor-accent': editor.accent }}>
+      <header className={styles.header}>
+        <Link href="/plugins" className={styles.brand}><img src="/devglobe.png" alt="" />All editors</Link>
+        <Link href="/space">View live globe</Link>
+      </header>
+      <section className={styles.editorIntro}>
+        <i aria-hidden="true" />
+        <p>{editor.family}</p>
+        <h1>DevGlobe for {editor.name}</h1>
+        <span>{editor.status === 'available' ? 'Connect your editor, choose Go Live, and appear on the globe while you are actively coding.' : 'This connection needs a native client and is on the distribution roadmap.'}</span>
+        {installUrl ? <EditorInstallLink className={styles.primaryAction} editor={editor.slug} href={installUrl}>{editor.installLabel}</EditorInstallLink> : <Link className={styles.secondaryAction} href="/plugins">Use a supported editor</Link>}
+      </section>
+      {steps.length ? (
+        <ol className={styles.steps}>
+          {steps.map((step, index) => <li key={step}><span>{index + 1}</span><p>{step}</p></li>)}
+        </ol>
+      ) : (
+        <section className={styles.waiting}><h2>Not available yet</h2><p>We will not label an incompatible package as supported. The native client will use the same opt-in heartbeat and privacy rules as the current extension.</p></section>
+      )}
+      <aside className={styles.privacy}>
+        <strong>Your work stays local</strong>
+        <p>Only bounded presence timestamps, editor, platform, and optionally active language are sent. Tracking pauses after one minute without editor activity.</p>
+      </aside>
+    </main>
+  );
+}

--- a/app/plugins/page.jsx
+++ b/app/plugins/page.jsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import { editorChannels } from '../../lib/editor-distribution.js';
+import styles from './plugins.module.css';
+
+export const metadata = {
+  title: 'Connect your editor | DevGlobe',
+  description: 'Install DevGlobe for VS Code and compatible editors, then appear on the live developer globe while you code.',
+  alternates: { canonical: '/plugins' },
+};
+
+export default function PluginDirectoryPage() {
+  const available = editorChannels.filter(editor => editor.status === 'available');
+  const planned = editorChannels.filter(editor => editor.status === 'planned');
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/space" className={styles.brand}><img src="/devglobe.png" alt="" />DevGlobe</Link>
+        <Link href="/space">View live globe</Link>
+      </header>
+      <section className={styles.intro}>
+        <p>Editor connections</p>
+        <h1>Show up while you code</h1>
+        <span>One private-by-default extension connects compatible editors to the live globe. Pick your editor for the shortest installation path.</span>
+      </section>
+      <section className={styles.directory} aria-labelledby="available-title">
+        <div className={styles.sectionHeading}><h2 id="available-title">Available now</h2><span>{available.length} editors</span></div>
+        <div className={styles.rows}>
+          {available.map(editor => (
+            <Link href={`/plugins/${editor.slug}`} key={editor.slug} className={styles.row} style={{ '--editor-accent': editor.accent }}>
+              <i aria-hidden="true" />
+              <strong>{editor.name}</strong>
+              <span>{editor.slug === 'vscode' ? 'Marketplace' : 'VSIX'}</span>
+              <b>Install</b>
+            </Link>
+          ))}
+        </div>
+      </section>
+      <section className={styles.planned} aria-labelledby="planned-title">
+        <div className={styles.sectionHeading}><h2 id="planned-title">Coming next</h2><span>New native clients</span></div>
+        {planned.map(editor => <div key={editor.slug}><strong>{editor.name}</strong><span>{editor.family} client in development</span></div>)}
+      </section>
+      <aside className={styles.privacy}>
+        <strong>Activity, not contents</strong>
+        <p>DevGlobe never sends source code, file paths, repository names, branches, or keystrokes. Editor events only reset a local inactivity timer.</p>
+      </aside>
+    </main>
+  );
+}

--- a/app/plugins/plugins.module.css
+++ b/app/plugins/plugins.module.css
@@ -1,0 +1,58 @@
+.page {
+  --editor-accent: #3b82f6;
+  min-height: 100svh;
+  padding: 0 max(24px, calc((100vw - 1040px) / 2)) 72px;
+  background:
+    linear-gradient(color-mix(in srgb, var(--border) 18%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--border) 18%, transparent) 1px, transparent 1px),
+    var(--bg-primary);
+  background-size: 44px 44px;
+  color: var(--text-primary);
+}
+
+.header { display: flex; min-height: 64px; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); }
+.header a { color: var(--text-secondary); font-size: 13px; font-weight: 700; text-decoration: none; }
+.header a:hover { color: var(--text-primary); }
+.brand { display: inline-flex; align-items: center; gap: 9px; color: var(--text-primary) !important; }
+.brand img { width: 28px; height: 28px; }
+.intro, .editorIntro { max-width: 760px; padding: clamp(72px, 11vw, 132px) 0 64px; }
+.intro > p, .editorIntro > p { margin: 0 0 14px; color: var(--text-secondary); font-size: 14px; }
+.intro h1, .editorIntro h1 { max-width: 720px; margin: 0; font-size: clamp(42px, 7vw, 82px); line-height: 0.98; letter-spacing: 0; }
+.intro > span, .editorIntro > span { display: block; max-width: 650px; margin-top: 24px; color: var(--text-secondary); font-size: 17px; line-height: 1.65; }
+.directory, .planned, .waiting { border-top: 1px solid var(--border); }
+.sectionHeading { display: flex; align-items: baseline; justify-content: space-between; padding: 20px 0; }
+.sectionHeading h2, .waiting h2 { margin: 0; font-size: 18px; letter-spacing: 0; }
+.sectionHeading span { color: var(--text-muted); font-size: 12px; }
+.rows { border-bottom: 1px solid var(--border); }
+.row { display: grid; grid-template-columns: 14px 1fr auto auto; align-items: center; gap: 18px; min-height: 68px; border-top: 1px solid var(--border); color: inherit; text-decoration: none; }
+.row > i, .editorIntro > i { width: 10px; height: 10px; border-radius: 50%; background: var(--editor-accent); box-shadow: 0 0 20px color-mix(in srgb, var(--editor-accent) 65%, transparent); }
+.row strong { font-size: 16px; }
+.row > span { color: var(--text-muted); font-size: 12px; }
+.row > b { min-width: 72px; color: var(--editor-accent); font-size: 12px; text-align: right; }
+.row:hover strong { color: var(--editor-accent); }
+.planned { margin-top: 72px; }
+.planned > div:not(.sectionHeading) { display: grid; grid-template-columns: 1fr 1fr; padding: 18px 0; border-top: 1px solid var(--border); }
+.planned span, .waiting p { color: var(--text-secondary); }
+.privacy { display: grid; grid-template-columns: 220px 1fr; gap: 32px; margin-top: 72px; padding: 26px 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+.privacy p { max-width: 650px; margin: 0; color: var(--text-secondary); line-height: 1.65; }
+.editorIntro { position: relative; }
+.editorIntro > i { display: block; width: 18px; height: 18px; margin-bottom: 26px; }
+.primaryAction, .secondaryAction { display: inline-flex; min-height: 46px; align-items: center; margin-top: 30px; padding: 0 20px; border: 1px solid var(--editor-accent); border-radius: 6px; color: var(--editor-accent); font-size: 13px; font-weight: 800; text-decoration: none; }
+.primaryAction:hover, .secondaryAction:hover { background: color-mix(in srgb, var(--editor-accent) 10%, transparent); }
+.steps { margin: 0; padding: 0; border-top: 1px solid var(--border); list-style: none; }
+.steps li { display: grid; grid-template-columns: 48px 1fr; align-items: center; min-height: 76px; border-bottom: 1px solid var(--border); }
+.steps li > span { color: var(--editor-accent); font-weight: 800; }
+.steps p { margin: 0; font-size: 15px; }
+.waiting { padding: 28px 0; }
+.waiting p { max-width: 680px; line-height: 1.6; }
+.page a:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 4px; }
+
+@media (max-width: 640px) {
+  .page { padding-right: 18px; padding-left: 18px; }
+  .intro, .editorIntro { padding: 62px 0 48px; }
+  .intro h1, .editorIntro h1 { font-size: 44px; }
+  .intro > span, .editorIntro > span { font-size: 15px; }
+  .row { grid-template-columns: 12px minmax(0, 1fr) auto; gap: 12px; }
+  .row > span { display: none; }
+  .planned > div:not(.sectionHeading), .privacy { grid-template-columns: 1fr; gap: 7px; }
+}

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { getCosmosContainer } from '../lib/cosmos.js';
+import { editorChannels } from '../lib/editor-distribution.js';
 import { getSiteUrl } from '../lib/site.js';
 
 const siteUrl = getSiteUrl();
@@ -52,6 +53,18 @@ export function buildSitemapEntries(profileLogins, lastModified = new Date()) {
       changeFrequency: 'always',
       priority: 0.8,
     },
+    {
+      url: `${siteUrl}/plugins`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    ...editorChannels.map(editor => ({
+      url: `${siteUrl}/plugins/${editor.slug}`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: editor.status === 'available' ? 0.8 : 0.5,
+    })),
     ...logins.map(login => ({
       url: `${siteUrl}/developer/${encodeURIComponent(login)}`,
       changeFrequency: 'daily',

--- a/components/EditorInstallLink.jsx
+++ b/components/EditorInstallLink.jsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { track } from '../lib/analytics.js';
+
+export default function EditorInstallLink({ className, editor, href, children }) {
+  return (
+    <a
+      className={className}
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() => track('extension_install_clicked', { source: 'plugin_directory', action: editor })}
+    >
+      {children}
+    </a>
+  );
+}

--- a/components/LiveDeveloperSpace.jsx
+++ b/components/LiveDeveloperSpace.jsx
@@ -9,7 +9,6 @@ import { useLivePresence } from './useLivePresence.js';
 import styles from './LiveDeveloperSpace.module.css';
 
 const LiveDeveloperGlobe = dynamic(() => import('./LiveDeveloperGlobe.jsx'), { ssr: false });
-const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
 
 function uniqueValues(developers, field) {
   return [...new Set(developers.map(developer => developer[field]).filter(Boolean))].sort();
@@ -110,7 +109,7 @@ export default function LiveDeveloperSpace() {
         <div className={styles.join}>
           <strong>Share your presence</strong>
           <span>Opt in from VS Code. No code, paths, repositories, branches, or keystrokes are sent.</span>
-          <a href={MARKETPLACE_URL} target="_blank" rel="noreferrer" onClick={() => track('extension_install_clicked', { source: 'live_globe' })}>Install extension</a>
+          <Link href="/plugins" onClick={() => track('extension_install_clicked', { source: 'live_globe' })}>Choose editor</Link>
         </div>
       </aside>
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -6,9 +6,9 @@ This extension connects exclusively to [devglobe.dev](https://www.devglobe.dev).
 
 ## Install
 
-Install [DevGlobe: Live Coding Globe from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery). Choose **Go Live** in the first-run prompt, approve GitHub authentication, and open the live globe to see your presence. You can also use the Command Palette and run `DevGlobe.dev: Go Live on the Developer Globe`.
+Choose your editor in the [DevGlobe editor directory](https://www.devglobe.dev/plugins), or install [DevGlobe: Live Coding Globe from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery). Choose **Go Live** in the first-run prompt, approve GitHub authentication, and open the live globe to see your presence. You can also use the Command Palette and run `DevGlobe.dev: Go Live on the Developer Globe`.
 
-Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the release package, then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
+Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the [version 0.3.0 release package](https://github.com/sajeetharan/devglobe/releases/download/v0.3.0/devglobe-developer-discovery-0.3.0.vsix), then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
 
 ## Commands
 
@@ -48,4 +48,4 @@ Package a release candidate from this directory with:
 npx @vscode/vsce package
 ```
 
-Marketplace publication requires `devglobedev` publisher credentials and must use a version not already published.
+The **Publish editor extension** GitHub Actions workflow validates and packages one VSIX, then can publish that exact artifact to GitHub Releases, Visual Studio Marketplace, and Open VSX. Marketplace publication requires the `VSCE_PAT` repository secret. Open VSX publication requires the `devglobedev` namespace and an `OVSX_PAT` repository secret. Each registry requires a version not already published.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -114,7 +114,8 @@
   "scripts": {
     "test": "node --test test/*.test.js",
     "check": "node --check src/extension.js && node --check src/devglobe.js",
-    "package": "npx --yes @vscode/vsce package"
+    "package": "npx --yes @vscode/vsce package",
+    "publish:open-vsx": "npx --yes ovsx publish"
   },
   "devDependencies": {
     "@types/vscode": "^1.85.0"

--- a/lib/editor-distribution.js
+++ b/lib/editor-distribution.js
@@ -1,0 +1,35 @@
+const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
+const VSIX_URL = 'https://github.com/sajeetharan/devglobe/releases/download/v0.3.0/devglobe-developer-discovery-0.3.0.vsix';
+
+export const editorChannels = [
+  { slug: 'vscode', name: 'VS Code', family: 'VS Code', status: 'available', installLabel: 'Install from Marketplace', installUrl: MARKETPLACE_URL, accent: '#23a8f2' },
+  { slug: 'cursor', name: 'Cursor', family: 'VS Code', status: 'available', installLabel: 'Download VSIX', installUrl: VSIX_URL, accent: '#d8ff4f' },
+  { slug: 'windsurf', name: 'Windsurf', family: 'VS Code', status: 'available', installLabel: 'Download VSIX', installUrl: VSIX_URL, accent: '#46d8bd' },
+  { slug: 'vscodium', name: 'VSCodium', family: 'VS Code', status: 'available', installLabel: 'Download VSIX', installUrl: VSIX_URL, accent: '#2f80ed' },
+  { slug: 'positron', name: 'Positron', family: 'VS Code', status: 'available', installLabel: 'Download VSIX', installUrl: VSIX_URL, accent: '#ffcb4c' },
+  { slug: 'void', name: 'Void', family: 'VS Code', status: 'available', installLabel: 'Download VSIX', installUrl: VSIX_URL, accent: '#ef5350' },
+  { slug: 'antigravity', name: 'Antigravity', family: 'VS Code', status: 'available', installLabel: 'Download VSIX', installUrl: VSIX_URL, accent: '#ff7a45' },
+  { slug: 'jetbrains', name: 'JetBrains IDEs', family: 'JetBrains', status: 'planned', accent: '#ff4f80' },
+  { slug: 'cli', name: 'CLI agents', family: 'Terminal', status: 'planned', accent: '#62d58b' },
+];
+
+export function getEditorChannel(slug) {
+  return editorChannels.find(editor => editor.slug === slug) || null;
+}
+
+export function editorInstallSteps(editor) {
+  if (!editor || editor.status !== 'available') return [];
+  if (editor.slug === 'vscode') {
+    return ['Open the Marketplace listing.', 'Choose Install and allow VS Code to open.', 'Choose Go Live in the DevGlobe status item.'];
+  }
+  return ['Download the latest VSIX from GitHub Releases.', `Open ${editor.name} and run “Extensions: Install from VSIX…”.`, 'Choose the downloaded DevGlobe VSIX, then use the status item to Go Live.'];
+}
+
+export function attributedInstallUrl(editor) {
+  if (!editor?.installUrl) return null;
+  const url = new URL(editor.installUrl);
+  url.searchParams.set('utm_source', 'devglobe');
+  url.searchParams.set('utm_medium', 'plugin_directory');
+  url.searchParams.set('utm_campaign', editor.slug);
+  return url.toString();
+}

--- a/tests/editor-distribution.test.js
+++ b/tests/editor-distribution.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { attributedInstallUrl, editorChannels, editorInstallSteps, getEditorChannel } from '../lib/editor-distribution.js';
+
+test('defines unique canonical editor channels', () => {
+  const slugs = editorChannels.map(editor => editor.slug);
+  assert.equal(new Set(slugs).size, slugs.length);
+  assert.equal(getEditorChannel('cursor')?.status, 'available');
+  assert.equal(getEditorChannel('jetbrains')?.status, 'planned');
+  assert.equal(getEditorChannel('unknown'), null);
+});
+
+test('only available clients expose installation steps and attributed links', () => {
+  const cursor = getEditorChannel('cursor');
+  const jetbrains = getEditorChannel('jetbrains');
+  const installUrl = new URL(attributedInstallUrl(cursor));
+  assert.equal(editorInstallSteps(cursor).length, 3);
+  assert.deepEqual(editorInstallSteps(jetbrains), []);
+  assert.equal(attributedInstallUrl(jetbrains), null);
+  assert.match(installUrl.pathname, /v0\.3\.0\/devglobe-developer-discovery-0\.3\.0\.vsix$/);
+  assert.equal(installUrl.searchParams.get('utm_campaign'), 'cursor');
+  assert.equal(installUrl.searchParams.get('utm_medium'), 'plugin_directory');
+});

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -10,6 +10,9 @@ test('includes every existing indexable acquisition route', () => {
   assert.ok(paths.includes('/leaderboard'));
   assert.ok(paths.includes('/repository-match'));
   assert.ok(paths.includes('/space'));
+  assert.ok(paths.includes('/plugins'));
+  assert.ok(paths.includes('/plugins/cursor'));
+  assert.ok(paths.includes('/plugins/jetbrains'));
   assert.ok(paths.includes('/developer/octocat'));
   assert.ok(!paths.includes('/share/octocat'));
   assert.ok(paths.includes('/developer/octo%20cat'));


### PR DESCRIPTION
## Summary
- add canonical install pages for VS Code, Cursor, Windsurf, VSCodium, Positron, Void, and Antigravity
- publish truthful roadmap pages for JetBrains and CLI clients
- attribute install clicks without identity or editor activity details
- add a dispatch-only workflow for GitHub Release, Marketplace, and Open VSX publishing
- link the live globe to editor selection and index all routes

## Release
- created v0.3.0 with the tested VSIX attached
- Open VSX remains opt-in until the OVSX_PAT repository secret and namespace are configured

## Validation
- npm test: 411 passed
- npm run build: 86 routes/pages, editor routes prerendered
- extension tests: 7 passed
- extension syntax checks passed
- desktop and 390px browser checks passed
- git diff --check