### PR TITLE
Show live developers on the home globe

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useDeferredValue, useMemo, useRef } from 'react';
 import { track } from '../lib/analytics.js';
 import Header from '../components/Header.jsx';
 import SearchBar from '../components/SearchBar.jsx';
@@ -22,6 +22,7 @@ import { prepareDeveloperDataset } from '../lib/developer-dataset.js';
 import { acquisitionAttributionProperties, socialAttributionProperties } from '../lib/share-attribution.js';
 import { developerSnapshotUrl, publicApiUrl } from '../lib/public-api.js';
 import { resolveIdentityCardDeveloper } from '../lib/home-actions.js';
+import { useLivePresence } from '../components/useLivePresence.js';
 import dynamic from 'next/dynamic';
 
 const Globe = dynamic(() => import('../components/Globe.jsx'), { ssr: false });
@@ -76,7 +77,19 @@ export default function Home() {
   const [trending, setTrending] = useState(null);
   const [trendingError, setTrendingError] = useState('');
   const [tourStep, setTourStep] = useState(null);
+  const [liveLanguage, setLiveLanguage] = useState('');
+  const [livePlatform, setLivePlatform] = useState('');
   const globeRef = useRef(null);
+  const liveViewActive = sidebarView === 'live';
+  const { developers: liveDevelopers, connection: liveConnection } = useLivePresence(liveViewActive);
+  const deferredLiveDevelopers = useDeferredValue(liveDevelopers);
+  const liveLanguages = useMemo(() => [...new Set(liveDevelopers.map(developer => developer.activeLanguage).filter(Boolean))].sort(), [liveDevelopers]);
+  const livePlatforms = useMemo(() => [...new Set(liveDevelopers.map(developer => developer.platform).filter(Boolean))].sort(), [liveDevelopers]);
+  const filteredLiveDevelopers = useMemo(() => deferredLiveDevelopers
+    .filter(developer => !liveLanguage || developer.activeLanguage === liveLanguage)
+    .filter(developer => !livePlatform || developer.platform === livePlatform)
+    .sort((left, right) => right.lastHeartbeat.localeCompare(left.lastHeartbeat)),
+  [deferredLiveDevelopers, liveLanguage, livePlatform]);
 
   useEffect(() => {
     try {
@@ -733,6 +746,28 @@ export default function Home() {
     setSidebarOpen(true);
   }, [sidebarView]);
 
+  const handleOpenLive = useCallback(() => {
+    if (sidebarView === 'live') {
+      setSidebarOpen(false);
+      setSidebarView('leaderboard');
+      return;
+    }
+    setSelectedCountry('');
+    setAgentGlobeLayerVisible(false);
+    setSidebarView('live');
+    setSidebarOpen(true);
+    track('live_globe_opened', { source: 'home_header', journey: 'live_presence' });
+  }, [sidebarView]);
+
+  const handleSidebarViewChange = useCallback((view) => {
+    if (view === 'live') {
+      setSelectedCountry('');
+      setAgentGlobeLayerVisible(false);
+      track('live_globe_opened', { source: 'home_sidebar', journey: 'live_presence' });
+    }
+    setSidebarView(view);
+  }, []);
+
   const handleOpenAgentNetwork = useCallback(() => {
     setSidebarView('agents');
     setSidebarOpen(true);
@@ -876,6 +911,8 @@ export default function Home() {
         claimStatus={claimStatus}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={handleToggleSidebar}
+        liveOpen={liveViewActive}
+        onOpenLive={handleOpenLive}
         activityOpen={sidebarView === 'activity'}
         onOpenActivity={handleOpenActivity}
         onAddMe={handleAddMe}
@@ -931,6 +968,9 @@ export default function Home() {
           agentRelationshipGraph={agentRelationshipGraph}
           tooltipDisabled={Boolean(selectedDev || compareDevs.length === 2)}
           trendingLogins={trending?.gainers?.slice(0, 10).map(entry => entry.login) || []}
+          liveMode={liveViewActive}
+          liveDevelopers={filteredLiveDevelopers}
+          onSelectLiveDev={developer => handleSelectDevByLogin(developer.login)}
         />
         <Leaderboard
           developers={filtered}
@@ -945,7 +985,7 @@ export default function Home() {
           open={sidebarOpen}
           onClose={handleCloseSidebar}
           activeView={sidebarView}
-          onViewChange={setSidebarView}
+          onViewChange={handleSidebarViewChange}
           agentGlobeLayerVisible={agentGlobeLayerVisible}
           onToggleAgentGlobeLayer={setAgentGlobeLayerVisible}
           onAgentGraphChange={setAgentRelationshipGraph}
@@ -956,6 +996,14 @@ export default function Home() {
           datasetLoading={datasetLoading && !searchActive}
           onOpenContributions={() => setShowContributions(true)}
           onCreateCard={handleCreateCardFromActivity}
+          liveDevelopers={filteredLiveDevelopers}
+          liveConnection={liveConnection}
+          liveLanguage={liveLanguage}
+          livePlatform={livePlatform}
+          liveLanguages={liveLanguages}
+          livePlatforms={livePlatforms}
+          onLiveLanguageChange={setLiveLanguage}
+          onLivePlatformChange={setLivePlatform}
         />
         {sidebarOpen && (
           <div className="sidebar-backdrop" onClick={handleCloseSidebar} />

--- a/components/Globe.jsx
+++ b/components/Globe.jsx
@@ -39,6 +39,9 @@ const devLng = d => d.lng;
 const pointAltitude = d => 0.01 + (d.score / 100) * 0.06;
 const pointRadius = d => 0.3 + (d.score / 100) * 0.7;
 const pointColor = d => getScoreColor(d.score);
+const livePointAltitude = d => d.presenceState === 'live' ? 0.055 : 0.025;
+const livePointRadius = d => d.presenceState === 'live' ? 0.7 : 0.42;
+const livePointColor = d => getLanguageColor(d.activeLanguage) || '#3b82f6';
 const ringMaxRadius = d => d.maxR;
 const ringPropagationSpeed = d => d.propagationSpeed;
 const ringRepeatPeriod = d => d.repeatPeriod;
@@ -288,7 +291,11 @@ const Globe = forwardRef(function Globe({
   agentRelationshipGraph = { nodes: [], developers: [], links: [] },
   tooltipDisabled = false,
   trendingLogins = [],
+  liveMode = false,
+  liveDevelopers = [],
+  onSelectLiveDev,
 }, ref) {
+  const containerRef = useRef(null);
   const globeEl = useRef();
   const tooltipRef = useRef(null);
   const pointerDownPos = useRef(null);
@@ -306,7 +313,19 @@ const Globe = forwardRef(function Globe({
   );
   const [languageFilter, setLanguageFilter] = useState('');
   const [cameraAltitude, setCameraAltitude] = useState(null);
+  const [globeSize, setGlobeSize] = useState({ width: 1, height: 1 });
   const isLight = theme === 'light';
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      setGlobeSize({ width: Math.max(1, width), height: Math.max(1, height) });
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     const expandedLimit = window.innerWidth < 768 ? 1200 : 2500;
@@ -324,6 +343,10 @@ const Globe = forwardRef(function Globe({
   }, []);
 
   const geoDevs = useMemo(() => {
+    if (liveMode) {
+      return liveDevelopers.filter(developer => developer.lat != null && developer.lng != null);
+    }
+
     let list = developers.filter(d => d.lat != null && d.lng != null);
 
     if (selectedCountry) {
@@ -334,7 +357,7 @@ const Globe = forwardRef(function Globe({
     return list
       .sort((a, b) => b.score - a.score)
       .slice(0, pointLimit);
-  }, [developers, pointLimit, selectedCountry]);
+  }, [developers, liveDevelopers, liveMode, pointLimit, selectedCountry]);
 
   // Hexbin clustering (#30) draws aggregated bins, not one mesh per developer,
   // so it can safely use the full filtered dataset instead of the top-N
@@ -349,7 +372,7 @@ const Globe = forwardRef(function Globe({
     return list;
   }, [developers, selectedCountry]);
 
-  const featuredGeoDevs = geoDevs;
+  const featuredGeoDevs = liveMode ? [] : geoDevs;
 
   const agentNodeMarkers = useMemo(() => agentRelationshipGraph.nodes.map(node => ({
     ...node,
@@ -441,8 +464,8 @@ const Globe = forwardRef(function Globe({
   }, [hoverDev]);
 
   const arcsData = useMemo(() => (
-    agentNetworkVisible ? [...agentRelationshipGraph.links, ...collaborationArcs] : collaborationArcs
-  ), [agentNetworkVisible, agentRelationshipGraph.links, collaborationArcs]);
+    liveMode ? [] : agentNetworkVisible ? [...agentRelationshipGraph.links, ...collaborationArcs] : collaborationArcs
+  ), [agentNetworkVisible, agentRelationshipGraph.links, collaborationArcs, liveMode]);
 
   // Rose pulsing rings for the top trending gainers (#24) — layered on top of
   // whichever base ring set (score or agent-network) is currently active.
@@ -468,6 +491,20 @@ const Globe = forwardRef(function Globe({
 
   // Pulsing rings for top 10 developers + active hovered developer's collaborators
   const ringsData = useMemo(() => {
+    if (liveMode) {
+      return geoDevs
+        .filter(developer => developer.presenceState === 'live')
+        .map(developer => ({
+          lat: developer.lat,
+          lng: developer.lng,
+          maxR: 3,
+          propagationSpeed: 1.2,
+          repeatPeriod: 1800,
+          color: livePointColor(developer),
+          login: developer.login,
+        }));
+    }
+
     const base = geoDevs.slice(0, 10).map(d => ({
       lat: d.lat,
       lng: d.lng,
@@ -495,23 +532,24 @@ const Globe = forwardRef(function Globe({
     }
 
     return [...base, ...trendingRings];
-  }, [geoDevs, hoverDev, trendingRings]);
+  }, [geoDevs, hoverDev, liveMode, trendingRings]);
 
   const displayPointAltitude = useCallback(developer => {
-    return pointAltitude(developer);
-  }, []);
+    return liveMode ? livePointAltitude(developer) : pointAltitude(developer);
+  }, [liveMode]);
 
   const displayPointRadius = useCallback(developer => {
-    return pointRadius(developer);
-  }, []);
+    return liveMode ? livePointRadius(developer) : pointRadius(developer);
+  }, [liveMode]);
 
   const displayPointColor = useCallback(developer => {
+    if (liveMode) return livePointColor(developer);
     if (colorMode === 'language') {
       if (languageFilter && developer.topLanguage !== languageFilter) return 'rgba(100, 116, 139, 0.12)';
       return getLanguageColor(developer.topLanguage);
     }
     return pointColor(developer);
-  }, [colorMode, languageFilter]);
+  }, [colorMode, languageFilter, liveMode]);
 
   // Developers per country, keyed the same way the leaderboard filters
   const devCountByCountry = useMemo(() => {
@@ -590,7 +628,7 @@ const Globe = forwardRef(function Globe({
     if (zoomDebounceRef.current) clearTimeout(zoomDebounceRef.current);
   }, []);
 
-  const hexModeActive = cameraAltitude != null
+  const hexModeActive = !liveMode && cameraAltitude != null
     && (hexModeActiveRef.current
       ? cameraAltitude > HEX_EXIT_ALTITUDE  // already clustered: only drop out once well below the enter line
       : cameraAltitude > HEX_ENTER_ALTITUDE); // not yet clustered: need to cross the higher enter line
@@ -655,6 +693,27 @@ const Globe = forwardRef(function Globe({
     setHoverDev(point || null);
 
     if (point) {
+      if (liveMode) {
+        const safe = value => String(value || '').replace(/[&<>"']/g, character => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[character]));
+        tooltip.innerHTML = `
+          <div class="tooltip__header">
+            <img class="tooltip__avatar" src="${safe(point.avatarUrl || '/devglobe.png')}" alt="">
+            <div>
+              <div class="tooltip__name">${safe(point.name || point.login)}</div>
+              <div class="tooltip__login">@${safe(point.login)}</div>
+            </div>
+          </div>
+          <div class="tooltip__score">${point.presenceState === 'live' ? 'Live now' : 'Recently coding'}</div>
+          <div class="tooltip__meta">
+            <span>${safe(point.activeLanguage || 'Language not shared')}</span>
+            <span>· ${safe(point.editor || point.platform || 'Editor not shared')}</span>
+          </div>
+        `;
+        tooltip.classList.add('visible');
+        setAutoRotate(false);
+        return;
+      }
+
       const collabs = point.collaborators?.slice(0, 5) || [];
       const collabHtml = collabs.length > 0 ? `
         <div class="tooltip__collaborators">
@@ -694,11 +753,13 @@ const Globe = forwardRef(function Globe({
       tooltip.classList.remove('visible');
       setAutoRotate(true);
     }
-  }, [setAutoRotate, tooltipDisabled]);
+  }, [liveMode, setAutoRotate, tooltipDisabled]);
 
   const handleClick = useCallback((point) => {
-    if (point) onSelectDev(point);
-  }, [onSelectDev]);
+    if (!point) return;
+    if (liveMode) onSelectLiveDev?.(point);
+    else onSelectDev(point);
+  }, [liveMode, onSelectDev, onSelectLiveDev]);
 
   // Click a hex cluster (#30) to zoom into that region, which drops the
   // camera below the hex exit altitude and dissolves the cluster back into
@@ -806,9 +867,11 @@ const Globe = forwardRef(function Globe({
 
   return (
     <>
-      <div id="globe-container" onPointerDown={handlePointerDown} onClick={handleContainerClick}>
+      <div ref={containerRef} id="globe-container" onPointerDown={handlePointerDown} onClick={handleContainerClick}>
         <GlobeGL
           ref={globeEl}
+          width={globeSize.width}
+          height={globeSize.height}
           globeImageUrl={isLight
             ? 'https://unpkg.com/three-globe@2.31.0/example/img/earth-blue-marble.jpg'
             : 'https://unpkg.com/three-globe@2.31.0/example/img/earth-night.jpg'}
@@ -848,7 +911,7 @@ const Globe = forwardRef(function Globe({
           hexLabel={hexLabel}
           hexTransitionDuration={400}
           onHexClick={handleHexClick}
-          htmlElementsData={hexModeActive
+          htmlElementsData={liveMode ? [] : hexModeActive
             ? (agentNetworkVisible ? [...agentRelationshipGraph.developers, ...agentNodeMarkers] : [])
             : htmlMarkers}
           htmlLat={avatarLat}
@@ -863,7 +926,7 @@ const Globe = forwardRef(function Globe({
           ringPropagationSpeed={ringPropagationSpeed}
           ringRepeatPeriod={ringRepeatPeriod}
           ringColor={ringColor}
-          labelsData={hexModeActive ? [] : labelDevs}
+          labelsData={liveMode || hexModeActive ? [] : labelDevs}
           labelLat={devLat}
           labelLng={devLng}
           labelText={labelText}
@@ -900,7 +963,13 @@ const Globe = forwardRef(function Globe({
           {controlsCollapsed ? 'Map legend ▲' : 'Map legend ▼'}
         </button>
         {!controlsCollapsed && (
-          <>
+          liveMode ? (
+            <div className="globe-legend" aria-label="Live presence legend">
+              <span className="globe-legend__item"><span className="globe-legend__live-dot" />Live now</span>
+              <span className="globe-legend__item"><span className="globe-legend__recent-dot" />Recently coding</span>
+              <span className="globe-legend__item">Colors show active language</span>
+            </div>
+          ) : <>
             <div className="globe-color-mode">
               {!hexModeActive && (
                 <>

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -6,7 +6,7 @@ import UserMenu from './UserMenu.jsx';
 
 const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
 
-export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, userMenuRequest, claimStatus, sidebarOpen, onToggleSidebar, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
+export default function Header({ onHome, theme, onToggleTheme, user, onLogout, onClaim, onEditAiProfile, onOpenIntroductions, onOpenShortlists, onOpenContributions, onOpenSimilar, onOpenProfile, onGenerateCard, completionVersion, userMenuRequest, claimStatus, sidebarOpen, onToggleSidebar, liveOpen, onOpenLive, activityOpen, onOpenActivity, onAddMe, onStartTour }) {
   return (
     <header className="header">
       <button type="button" className="header__brand" onClick={onHome} aria-label="Go to DevGlobe home">
@@ -37,13 +37,20 @@ export default function Header({ onHome, theme, onToggleTheme, user, onLogout, o
           </svg>
           <span className="btn__label">Repo Match</span>
         </a>
-        <a href="/space" className="btn btn--live" aria-label="See developers coding now" title="Live developer globe">
+        <button
+          type="button"
+          className={`btn btn--live${liveOpen ? ' btn--active' : ''}`}
+          onClick={onOpenLive}
+          aria-label={liveOpen ? 'Close live developer view' : 'See developers coding now'}
+          aria-expanded={liveOpen}
+          title="Show live developers on this globe"
+        >
           <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <circle cx="12" cy="12" r="2" />
             <path d="M5.6 18.4a9 9 0 0 1 0-12.8M18.4 5.6a9 9 0 0 1 0 12.8M8.5 15.5a5 5 0 0 1 0-7M15.5 8.5a5 5 0 0 1 0 7" />
           </svg>
           <span className="btn__label">Live now</span>
-        </a>
+        </button>
         <button
           type="button"
           className={`btn btn--activity${activityOpen ? ' btn--active' : ''}`}

--- a/components/Leaderboard.jsx
+++ b/components/Leaderboard.jsx
@@ -11,6 +11,7 @@ import GlobalActivityFeed from './GlobalActivityFeed.jsx';
 import AgentNetworkPanel from './AgentNetworkPanel.jsx';
 import TrendingPanel from './TrendingPanel.jsx';
 import LocalPanel from './LocalPanel.jsx';
+import LivePresencePanel from './LivePresencePanel.jsx';
 
 const ITEM_HEIGHT = 62;
 const BUFFER = 10;
@@ -39,6 +40,14 @@ export default function Leaderboard({
   datasetLoading = false,
   onOpenContributions,
   onCreateCard,
+  liveDevelopers = [],
+  liveConnection = 'idle',
+  liveLanguage = '',
+  livePlatform = '',
+  liveLanguages = [],
+  livePlatforms = [],
+  onLiveLanguageChange,
+  onLivePlatformChange,
 }) {
   const listRef = useRef(null);
   const [scrollTop, setScrollTop] = useState(0);
@@ -144,6 +153,15 @@ export default function Leaderboard({
     <aside className={`sidebar${open ? ' open' : ''}${activeView === 'activity' ? ' sidebar--activity' : ''}`} id="sidebar">
       <div className="sidebar__drag-handle" onClick={onClose} aria-hidden="true" />
       <div className="sidebar__tabs" role="tablist" aria-label="Developer views">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeView === 'live'}
+          className={activeView === 'live' ? 'sidebar__tab sidebar__tab--active' : 'sidebar__tab'}
+          onClick={() => onViewChange?.('live')}
+        >
+          Live
+        </button>
         <button
           type="button"
           role="tab"
@@ -342,6 +360,19 @@ export default function Leaderboard({
         </>
       )}
       {activeView === 'activity' && <GlobalActivityFeed active onOpenContributions={onOpenContributions} onCreateCard={onCreateCard} />}
+      {activeView === 'live' && (
+        <LivePresencePanel
+          developers={liveDevelopers}
+          connection={liveConnection}
+          language={liveLanguage}
+          platform={livePlatform}
+          languages={liveLanguages}
+          platforms={livePlatforms}
+          onLanguageChange={onLiveLanguageChange}
+          onPlatformChange={onLivePlatformChange}
+          onSelectLogin={onSelectDevByLogin}
+        />
+      )}
       {activeView === 'agents' && (
         <AgentNetworkPanel
           globeLayerVisible={agentGlobeLayerVisible}

--- a/components/LivePresencePanel.jsx
+++ b/components/LivePresencePanel.jsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { track } from '../lib/analytics.js';
+import { getLanguageColor } from '../lib/language-colors.js';
+
+const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
+
+function relativeTime(value) {
+  const seconds = Math.max(0, Math.round((Date.now() - Date.parse(value)) / 1000));
+  return seconds < 45 ? 'now' : `${Math.floor(seconds / 60)}m`;
+}
+
+export default function LivePresencePanel({
+  developers,
+  connection,
+  language,
+  platform,
+  languages,
+  platforms,
+  onLanguageChange,
+  onPlatformChange,
+  onSelectLogin,
+}) {
+  const liveCount = developers.filter(developer => developer.presenceState === 'live').length;
+  const recentCount = developers.length - liveCount;
+
+  return (
+    <section className="live-presence-panel" aria-label="Developers coding now">
+      <div className="live-presence-panel__header">
+        <div>
+          <h2>Live coding</h2>
+          <p role="status" aria-live="polite">
+            {connection === 'live'
+              ? `${liveCount} live, ${recentCount} recent`
+              : connection === 'unavailable' ? 'Live presence is unavailable' : 'Connecting to live presence'}
+          </p>
+        </div>
+        <span className="live-presence-panel__signal" data-state={connection} aria-hidden="true" />
+      </div>
+
+      <div className="live-presence-panel__filters" aria-label="Filter live developers">
+        <label>
+          <span>Language</span>
+          <select value={language} onChange={event => onLanguageChange(event.target.value)}>
+            <option value="">All languages</option>
+            {languages.map(value => <option key={value}>{value}</option>)}
+          </select>
+        </label>
+        <label>
+          <span>Platform</span>
+          <select value={platform} onChange={event => onPlatformChange(event.target.value)}>
+            <option value="">All platforms</option>
+            {platforms.map(value => <option key={value}>{value}</option>)}
+          </select>
+        </label>
+      </div>
+
+      <div className="live-presence-panel__list">
+        {developers.map(developer => (
+          <button
+            key={developer.id}
+            type="button"
+            className="live-presence-row"
+            data-presence={developer.presenceState}
+            onClick={() => onSelectLogin(developer.login)}
+          >
+            <img src={developer.avatarUrl || '/devglobe.png'} alt="" />
+            <span className="live-presence-row__identity">
+              <strong>{developer.name || developer.login}</strong>
+              <small>
+                <i style={{ background: getLanguageColor(developer.activeLanguage) || 'var(--accent-blue)' }} aria-hidden="true" />
+                {developer.activeLanguage} · {developer.presenceState === 'live' ? 'Live now' : 'Recently coding'}
+              </small>
+            </span>
+            <time dateTime={developer.lastHeartbeat}>{relativeTime(developer.lastHeartbeat)}</time>
+          </button>
+        ))}
+        {connection === 'live' && developers.length === 0 ? (
+          <p className="live-presence-panel__empty">No developers match these filters.</p>
+        ) : null}
+        {connection === 'unavailable' ? (
+          <p className="live-presence-panel__empty">Live presence is temporarily unavailable. Try again shortly.</p>
+        ) : null}
+      </div>
+
+      <div className="live-presence-panel__join">
+        <strong>Appear on the globe</strong>
+        <span>Opt in from VS Code. Source code and file names stay private.</span>
+        <a
+          href={MARKETPLACE_URL}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => track('extension_install_clicked', { source: 'home_live_panel' })}
+        >
+          Install extension
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/components/useLivePresence.js
+++ b/components/useLivePresence.js
@@ -2,11 +2,17 @@
 
 import { useEffect, useState } from 'react';
 
-export function useLivePresence() {
+export function useLivePresence(enabled = true) {
   const [developers, setDevelopers] = useState([]);
-  const [connection, setConnection] = useState('connecting');
+  const [connection, setConnection] = useState(enabled ? 'connecting' : 'idle');
 
   useEffect(() => {
+    if (!enabled) {
+      setConnection('idle');
+      return undefined;
+    }
+
+    setConnection('connecting');
     const source = new EventSource('/api/sse/developers');
     let initialized = false;
     const initialTimer = setTimeout(() => {
@@ -47,7 +53,7 @@ export function useLivePresence() {
       clearTimeout(initialTimer);
       source.close();
     };
-  }, []);
+  }, [enabled]);
 
   return { developers, connection };
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -3621,15 +3621,25 @@ body {
 
 .sidebar__tabs {
   display: grid;
-  grid-template-columns: repeat(5, 1fr) auto;
+  grid-auto-columns: max-content;
+  grid-auto-flow: column;
   align-items: center;
+  justify-content: space-between;
   gap: 4px;
   padding: 10px 12px;
   border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.sidebar__tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .sidebar__tab {
+  min-width: 0;
   min-height: 32px;
+  padding: 0;
   color: var(--text-muted);
   background: transparent;
   border: 0;
@@ -3643,12 +3653,218 @@ body {
 .sidebar__tab:hover,
 .sidebar__tab:focus-visible {
   color: var(--text-primary);
-  outline: none;
+}
+
+.sidebar__tab:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid #38bdf8;
+  outline-offset: -2px;
 }
 
 .sidebar__tab--active {
   color: #22d3ee;
   border-bottom-color: #22d3ee;
+}
+
+.live-presence-panel {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.live-presence-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.live-presence-panel__header h2 {
+  color: var(--text-primary);
+  font-size: 16px;
+}
+
+.live-presence-panel__header p {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.live-presence-panel__signal {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.live-presence-panel__signal[data-state='live'] {
+  background: var(--accent-github);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-github) 18%, transparent);
+}
+
+.live-presence-panel__filters {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.live-presence-panel__filters label {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.live-presence-panel__filters label > span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.live-presence-panel__filters select {
+  width: 100%;
+  min-width: 0;
+  height: var(--control-height);
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 11px;
+}
+
+.live-presence-panel__list {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.live-presence-row {
+  display: grid;
+  width: 100%;
+  min-height: 58px;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.live-presence-row:hover,
+.live-presence-row:focus-visible {
+  background: var(--bg-hover);
+}
+
+.live-presence-row[data-presence='live'] {
+  box-shadow: inset 3px 0 var(--accent-github);
+}
+
+.live-presence-row > img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.live-presence-row__identity {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.live-presence-row__identity strong,
+.live-presence-row__identity small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-presence-row__identity strong {
+  font-size: 12px;
+}
+
+.live-presence-row__identity small {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.live-presence-row__identity i {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 5px;
+  border-radius: 50%;
+}
+
+.live-presence-row time {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.live-presence-panel__empty {
+  padding: 24px 16px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.live-presence-panel__join {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.live-presence-panel__join strong {
+  font-size: 12px;
+}
+
+.live-presence-panel__join span {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.live-presence-panel__join a {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 2px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-blue);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.globe-legend__live-dot,
+.globe-legend__recent-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.globe-legend__live-dot {
+  background: var(--accent-github);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-github) 20%, transparent);
+}
+
+.globe-legend__recent-dot {
+  border: 1px solid var(--text-secondary);
+  background: transparent;
 }
 
 .agent-network {
@@ -4172,10 +4388,18 @@ body {
 
 .global-activity__views {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-columns: max-content;
+  grid-auto-flow: column;
+  justify-content: space-between;
   gap: 4px;
   padding: 10px 12px;
   border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.global-activity__views::-webkit-scrollbar {
+  display: none;
 }
 
 .global-activity__view {
@@ -6520,6 +6744,10 @@ body {
   .btn--star,
   .btn--sponsor {
     display: none;
+  }
+  .search-bar {
+    left: calc((100vw - 280px) / 2);
+    width: min(720px, calc(100vw - 312px));
   }
   .recent-activity {
     right: 304px;


### PR DESCRIPTION
Summary
- Add a Live sidebar mode with language/platform filters.
- Render live/recent presence on the existing home globe with rings and language colors.
- Connect SSE only while live mode is active and preserve /space.
- Make the shared globe responsive to container resizing.

Testing
- npm test (428 passed)
- npm run build
- Desktop and 375px mobile Playwright validation
- git diff --check origin/main...HEAD