### PR TITLE
Explain why missions match developers

### DIFF
--- a/app/api/mission-preview/route.js
+++ b/app/api/mission-preview/route.js
@@ -35,7 +35,7 @@ function clientHash(request) {
 
 async function getPublicProfile(container, login) {
   const { resources } = await container.items.query({
-    query: `SELECT TOP 1 c.login, c.name, c.avatarUrl, c.topLanguage, c.languages
+    query: `SELECT TOP 1 c.login, c.name, c.avatarUrl, c.topLanguage, c.languages, c.totalCommits
       FROM c
       WHERE LOWER(c.login) = @login
         AND (NOT IS_DEFINED(c.nomination) OR c.nomination.status = 'approved')`,
@@ -115,7 +115,7 @@ export function createMissionPreviewHandler(dependencies = {}) {
 
     return NextResponse.json({
       profile: { login: profile.login, name: profile.name || profile.login, avatarUrl: profile.avatarUrl || null },
-      mission: buildMissionPreview(opportunities[0]),
+      mission: buildMissionPreview(opportunities[0], profile),
     }, { headers: { 'Cache-Control': 'private, no-store' } });
   } catch (error) {
     if (error instanceof MissionPreviewError || error instanceof SyntaxError) {

--- a/components/MissionPreview.jsx
+++ b/components/MissionPreview.jsx
@@ -92,10 +92,18 @@ export default function MissionPreview({ signedIn = false, onOpenActivity }) {
             </div>
             <span className="mission-preview__scope">Suggested scope · {result.mission.durationMinutes} min</span>
           </div>
-          {result.mission.opportunity.reasons?.length > 0 && (
-            <ul aria-label="Why this mission matched">
-              {result.mission.opportunity.reasons.map(reason => <li key={reason}>{reason}</li>)}
-            </ul>
+          {result.mission.matchEvidence?.length > 0 && (
+            <section className="mission-preview__evidence" aria-labelledby="mission-match-evidence-title">
+              <h3 id="mission-match-evidence-title">Why this matched you</h3>
+              <dl>
+                {result.mission.matchEvidence.map(item => (
+                  <div key={item.label}>
+                    <dt>{item.label}</dt>
+                    <dd>{item.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
           )}
           <div className="mission-preview__actions">
             <p>Previewing does not reserve this issue. Actual effort depends on repository context and maintainer feedback.</p>

--- a/lib/mission-preview.js
+++ b/lib/mission-preview.js
@@ -17,11 +17,42 @@ export function previewPreferences(profile) {
   return normalizeContributionPreferences({ difficulty: 'beginner', availableMinutes: 30 }, fallbackLanguages);
 }
 
-export function buildMissionPreview(opportunity) {
+function missionMatchEvidence(opportunity, profile) {
+  const evidence = [];
+  const profileLanguages = new Set([
+    profile?.topLanguage,
+    ...(profile?.languages || []).map(language => language?.name),
+  ].filter(Boolean).map(language => language.toLowerCase()));
+
+  if (opportunity.language && profileLanguages.has(opportunity.language.toLowerCase())) {
+    evidence.push({ label: 'Language', value: `${opportunity.language} in your public profile` });
+  }
+
+  const contributionCount = Number(profile?.totalCommits);
+  if (Number.isFinite(contributionCount) && contributionCount > 0) {
+    evidence.push({
+      label: 'Recent contributions',
+      value: `${contributionCount.toLocaleString('en-US')} in the latest public snapshot`,
+    });
+  }
+
+  const difficultyLabel = (opportunity.labels || []).find(label => [
+    'good first issue', 'first-timers-only', 'beginner', 'easy',
+    'help wanted', 'intermediate', 'advanced', 'challenging', 'expert',
+  ].includes(label.toLowerCase()));
+  if (difficultyLabel) {
+    evidence.push({ label: 'Issue difficulty', value: difficultyLabel });
+  }
+
+  return evidence;
+}
+
+export function buildMissionPreview(opportunity, profile = {}) {
   if (!opportunity) return null;
   return {
     type: missionType(opportunity),
     durationMinutes: opportunity.estimatedMinutes,
     opportunity,
+    matchEvidence: missionMatchEvidence(opportunity, profile),
   };
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1222,8 +1222,12 @@ body {
 .mission-preview__issue { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px; }
 .mission-preview__issue strong { overflow: hidden; color: var(--text-primary); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .mission-preview__scope { flex: 0 0 auto; padding: 4px 6px; border: 1px solid rgba(34, 211, 238, 0.35); border-radius: 3px; color: var(--mission-link) !important; font-weight: 700; }
-.mission-preview__result ul { display: flex; grid-column: 2; flex-wrap: wrap; gap: 5px; margin: 0; padding: 0; list-style: none; }
-.mission-preview__result li { padding: 3px 5px; border: 1px solid rgba(74, 222, 128, 0.3); border-radius: 3px; color: var(--mission-match); font-size: 8px; }
+.mission-preview__evidence { display: grid; grid-column: 1 / -1; grid-template-columns: 180px minmax(0, 1fr); gap: 18px; padding: 10px 0; border-block: 1px solid var(--border); }
+.mission-preview__evidence h3 { margin: 0; color: var(--text-primary); font-size: 10px; line-height: 1.4; }
+.mission-preview__evidence dl { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 0; }
+.mission-preview__evidence dl > div { display: grid; min-width: 0; gap: 3px; }
+.mission-preview__evidence dt { color: var(--mission-match); font-size: 8px; font-weight: 700; }
+.mission-preview__evidence dd { margin: 0; color: var(--text-secondary); font-size: 9px; line-height: 1.4; overflow-wrap: anywhere; }
 .mission-preview__actions { display: flex; grid-column: 1 / -1; align-items: center; justify-content: flex-end; gap: 7px; }
 .mission-preview__actions p { margin: 0 auto 0 0; color: var(--text-muted); font-size: 8px; line-height: 1.4; }
 .mission-preview__actions :is(a, button) { display: inline-grid; place-items: center; padding: 7px 10px; text-decoration: none; }
@@ -1241,7 +1245,8 @@ body {
   }
   .mission-preview__intro p { display: none; }
   .mission-preview__result { grid-template-columns: minmax(0, 1fr); }
-  .mission-preview__result ul { grid-column: 1; }
+  .mission-preview__evidence { grid-template-columns: minmax(0, 1fr); gap: 7px; }
+  .mission-preview__evidence dl { grid-template-columns: minmax(0, 1fr); }
   .mission-preview__actions { grid-column: 1; flex-wrap: wrap; justify-content: stretch; }
   .mission-preview__actions p { width: 100%; }
   .mission-preview__actions :is(a, button) { flex: 1 1 auto; }

--- a/tests/mission-preview.test.js
+++ b/tests/mission-preview.test.js
@@ -6,7 +6,7 @@ import { createMissionPreviewHandler } from '../app/api/mission-preview/route.js
 
 const NOW = new Date('2026-08-26T10:00:00.000Z');
 
-function developerContainer(profile = { login: 'octocat', name: 'The Octocat', avatarUrl: 'avatar', topLanguage: 'JavaScript', claimed: true }) {
+function developerContainer(profile = { login: 'octocat', name: 'The Octocat', avatarUrl: 'avatar', topLanguage: 'JavaScript', totalCommits: 128, claimed: true }) {
   return { items: { query: () => ({ fetchAll: async () => ({ resources: profile ? [profile] : [] }) }) } };
 }
 
@@ -65,12 +65,26 @@ test('uses profile languages and safe defaults for sparse profiles', () => {
 });
 
 test('builds a read-only preview without mission lifecycle state', () => {
-  const opportunity = { id: '123', title: 'Improve README', labels: ['documentation'], estimatedMinutes: 15 };
-  const preview = buildMissionPreview(opportunity);
+  const opportunity = {
+    id: '123',
+    title: 'Improve README',
+    language: 'JavaScript',
+    labels: ['documentation', 'good first issue'],
+    estimatedMinutes: 15,
+  };
+  const preview = buildMissionPreview(opportunity, {
+    topLanguage: 'JavaScript',
+    totalCommits: 128,
+  });
 
   assert.equal(preview.type, 'Improve documentation');
   assert.equal(preview.durationMinutes, 15);
   assert.equal(preview.opportunity, opportunity);
+  assert.deepEqual(preview.matchEvidence, [
+    { label: 'Language', value: 'JavaScript in your public profile' },
+    { label: 'Recent contributions', value: '128 in the latest public snapshot' },
+    { label: 'Issue difficulty', value: 'good first issue' },
+  ]);
   assert.equal(Object.hasOwn(preview, 'status'), false);
   assert.equal(Object.hasOwn(preview, 'id'), false);
 });
@@ -94,6 +108,7 @@ test('returns one public read-only mission without claimed profile fields', asyn
   assert.equal(response.status, 200);
   assert.deepEqual(Object.keys(body.profile).sort(), ['avatarUrl', 'login', 'name']);
   assert.equal(body.mission.durationMinutes, 15);
+  assert.deepEqual(body.mission.matchEvidence.map(item => item.label), ['Language', 'Recent contributions', 'Issue difficulty']);
   assert.equal(Object.hasOwn(body.mission, 'status'), false);
 });
 


### PR DESCRIPTION
## Summary
- show labeled language, contribution, and difficulty evidence in mission previews
- keep raw profile metrics out of the public response
- add responsive styling and focused coverage

## Validation
- node --test tests/mission-preview.test.js
- npm run build
- git diff --check