### PR TITLE
Show mission preview after onboarding

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -946,7 +946,7 @@ export default function Home() {
         showAgentPrompt={agentProfileStatus === 'missing' && !tourStep}
         onOpenAgentProfile={() => setShowAiProfile(true)}
         onOpenAgentNetwork={handleOpenAgentNetwork}
-        showMissionPreview={false}
+        showMissionPreview={!tourStep}
       />
       <QuickTour
         step={tourStep}


### PR DESCRIPTION
## Summary
- restore the mission preview below homepage search
- keep it hidden while the guided tour is active

## Validation
- npm run build (passed after npm ci)
- git diff --check