### PR TITLE
chore: prepare editor extension 0.4.0

### DIFF
--- a/docs/prd/vscode-extension.md
+++ b/docs/prd/vscode-extension.md
@@ -95,6 +95,6 @@ DevGlobe records first-party install-click, token, presence, sign-off, and stats
 ## Rollout
 
 1. Validate the VSIX locally and with Extension Development Host.
-2. Deploy the presence and coding-stats APIs before publishing extension version `0.3.0`.
+2. Deploy the presence and coding-stats APIs before publishing each extension release.
 3. Publish an unlisted marketplace preview and verify GitHub authentication, presence expiry, and VS Code forks.
 4. Publish publicly and measure install-to-presence activation and stats return usage.

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.4.0 - 2026-09-09
 
 - Let new installers appear immediately with their verified GitHub name, without requiring an existing DevGlobe profile.
 - Ask for a city and country inside the editor only when no public location is available.
 - Publish a `Ready to code` presence immediately instead of waiting for a source file.
 - Offer a clearer consent-first Go Live flow immediately after installation.
 - Remember the authenticated GitHub login and resume opted-in presence automatically.
-- Wait for a source-code file before publishing presence instead of showing an unknown language.
+- Show `Ready to code` before a source-code file supplies a language.
 - Geocode a public profile location on demand and link to the right setup action when profile data is missing.
 
 ## 0.3.0

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -8,7 +8,7 @@ This extension connects exclusively to [devglobe.dev](https://www.devglobe.dev).
 
 Choose your editor in the [DevGlobe editor directory](https://www.devglobe.dev/plugins), or install [DevGlobe: Live Coding Globe from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery). Choose **Go Live Now** in the first-run prompt and approve GitHub authentication. Your verified GitHub name appears automatically on the [live globe](https://www.devglobe.dev/space); no separate DevGlobe profile is required. You can also use the Command Palette and run `DevGlobe.dev: Go Live on the Developer Globe`.
 
-Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the [version 0.3.0 release package](https://github.com/sajeetharan/devglobe/releases/download/v0.3.0/devglobe-developer-discovery-0.3.0.vsix), then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
+Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the [version 0.4.0 release package](https://github.com/sajeetharan/devglobe/releases/download/v0.4.0/devglobe-developer-discovery-0.4.0.vsix), then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
 
 ## Commands
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devglobe-developer-discovery",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devglobe-developer-discovery",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/vscode": "^1.85.0"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "devglobe-developer-discovery",
   "displayName": "DevGlobe: Live Coding Globe",
   "description": "Show up on the live developer globe while you code, track private coding stats, and discover developers.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "devglobedev",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/lib/editor-distribution.js
+++ b/lib/editor-distribution.js
@@ -1,5 +1,5 @@
 const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
-const VSIX_URL = 'https://github.com/sajeetharan/devglobe/releases/download/v0.3.0/devglobe-developer-discovery-0.3.0.vsix';
+const VSIX_URL = 'https://github.com/sajeetharan/devglobe/releases/download/v0.4.0/devglobe-developer-discovery-0.4.0.vsix';
 
 export const editorChannels = [
   { slug: 'vscode', name: 'VS Code', family: 'VS Code', aliases: ['visual studio code', 'microsoft'], status: 'available', installLabel: 'Install from Marketplace', installUrl: MARKETPLACE_URL, accent: '#23a8f2' },

--- a/tests/editor-distribution.test.js
+++ b/tests/editor-distribution.test.js
@@ -18,7 +18,7 @@ test('only available clients expose installation steps and attributed links', ()
   assert.match(editorInstallSteps(cursor)[2], /verified GitHub name/);
   assert.deepEqual(editorInstallSteps(jetbrains), []);
   assert.equal(attributedInstallUrl(jetbrains), null);
-  assert.match(installUrl.pathname, /v0\.3\.0\/devglobe-developer-discovery-0\.3\.0\.vsix$/);
+  assert.match(installUrl.pathname, /v0\.4\.0\/devglobe-developer-discovery-0\.4\.0\.vsix$/);
   assert.equal(installUrl.searchParams.get('utm_campaign'), 'cursor');
   assert.equal(installUrl.searchParams.get('utm_medium'), 'plugin_directory');
 });


### PR DESCRIPTION
## Summary
- bump the editor extension and lockfile to 0.4.0
- publish the onboarding improvements in the 0.4.0 changelog
- update GitHub Release download URLs and tests to the 0.4.0 VSIX

## Validation
- 8 extension tests pass
- extension syntax check passes
- editor distribution tests pass
- packaged devglobe-developer-discovery-0.4.0.vsix locally (45,445 bytes)