### PR TITLE
feat: add developer feedback to homepage ribbon

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -926,15 +926,14 @@ export default function Home() {
         onAddMe={handleAddMe}
         onStartTour={handleTourFocusSearch}
       />
-      {!tourStep && (user && claimStatus === 'claimed' ? (
+      {!tourStep && <PlatformActivityBanner />}
+      {!tourStep && user && claimStatus === 'claimed' && (
           <ReturnBriefing
             login={user.login}
             onOpenContributions={() => setShowContributions(true)}
             onOpenWeeklyUpdates={() => setUserMenuRequest(request => request + 1)}
           />
-        ) : (
-          <PlatformActivityBanner />
-        ))}
+      )}
       <SearchBar
         developers={developers}
         onResults={handleSearch}

--- a/components/PlatformActivityBanner.jsx
+++ b/components/PlatformActivityBanner.jsx
@@ -4,6 +4,19 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useGlobalActivityFeed } from './useGlobalActivityFeed.js';
 
+const DEVELOPER_FEEDBACK = [
+  {
+    id: 'reddit-p8m16h9',
+    quote: 'The 3D globe looks really slick in the editor.',
+    url: 'https://www.reddit.com/r/SideProject/comments/1wavcqv/comment/p8m16h9/',
+  },
+  {
+    id: 'reddit-p8l5tt9',
+    quote: 'The globe is a nice hook, but the mission match is prob the sticky part.',
+    url: 'https://www.reddit.com/r/SideProject/comments/1wavcqv/comment/p8l5tt9/',
+  },
+];
+
 function relativeTime(timestamp) {
   const seconds = Math.max(0, Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000));
   if (seconds < 60) return 'just now';
@@ -13,34 +26,50 @@ function relativeTime(timestamp) {
 }
 
 export default function PlatformActivityBanner() {
-  const { activities, error } = useGlobalActivityFeed(true, { intervalMs: 300000 });
+  const { activities } = useGlobalActivityFeed(true, { intervalMs: 300000 });
   const [visibleIndex, setVisibleIndex] = useState(0);
+  const bannerItems = [
+    ...DEVELOPER_FEEDBACK.map(feedback => ({ ...feedback, type: 'feedback' })),
+    ...activities.slice(0, 6).map(activity => ({ ...activity, type: 'activity' })),
+  ];
 
   useEffect(() => {
-    if (activities.length < 2) return undefined;
+    if (bannerItems.length < 2) return undefined;
     const interval = setInterval(() => {
-      setVisibleIndex(current => (current + 1) % Math.min(activities.length, 8));
+      setVisibleIndex(current => (current + 1) % bannerItems.length);
     }, 6000);
     return () => clearInterval(interval);
-  }, [activities.length]);
+  }, [bannerItems.length]);
 
   useEffect(() => {
     setVisibleIndex(0);
   }, [activities[0]?.id]);
 
-  const activity = activities[visibleIndex];
-  if (!activity || error) return null;
+  const item = bannerItems[visibleIndex % bannerItems.length];
 
   return (
-    <aside className="activity-banner" aria-label="Recent platform activity" aria-live="polite">
-      <span className="activity-banner__pulse" aria-hidden="true" />
-      <span className="activity-banner__label">Live</span>
-      <Link href={`/developer/${encodeURIComponent(activity.login)}`} className="activity-banner__actor">
-        {activity.avatarUrl ? <img src={activity.avatarUrl} alt="" /> : <span aria-hidden="true">{activity.login[0].toUpperCase()}</span>}
-        @{activity.login}
-      </Link>
-      <a className="activity-banner__detail" href={activity.url}>{activity.description}</a>
-      <time dateTime={activity.createdAt}>{relativeTime(activity.createdAt)}</time>
+    <aside className="activity-banner" aria-label="Developer feedback and recent platform activity" aria-live="polite">
+      {item.type === 'feedback' ? (
+        <>
+          <span className="activity-banner__feedback-mark" aria-hidden="true">“</span>
+          <span className="activity-banner__label activity-banner__label--feedback">Feedback</span>
+          <strong className="activity-banner__feedback-author">Anonymous developer</strong>
+          <a className="activity-banner__detail" href={item.url} target="_blank" rel="noreferrer">
+            {item.quote}
+          </a>
+        </>
+      ) : (
+        <>
+          <span className="activity-banner__pulse" aria-hidden="true" />
+          <span className="activity-banner__label">Live</span>
+          <Link href={`/developer/${encodeURIComponent(item.login)}`} className="activity-banner__actor">
+            {item.avatarUrl ? <img src={item.avatarUrl} alt="" /> : <span aria-hidden="true">{item.login[0].toUpperCase()}</span>}
+            @{item.login}
+          </Link>
+          <a className="activity-banner__detail" href={item.url}>{item.description}</a>
+          <time dateTime={item.createdAt}>{relativeTime(item.createdAt)}</time>
+        </>
+      )}
     </aside>
   );
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -298,6 +298,23 @@ body {
   text-transform: uppercase;
 }
 
+.activity-banner__feedback-mark {
+  color: var(--accent-blue);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.activity-banner__label--feedback {
+  color: var(--accent-blue);
+}
+
+.activity-banner__feedback-author {
+  flex: 0 0 auto;
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
 .activity-banner__actor {
   display: inline-flex;
   min-width: 0;
@@ -6983,6 +7000,11 @@ body {
   }
   .activity-banner__label {
     display: none;
+  }
+  .activity-banner__feedback-author {
+    max-width: 38%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .activity-banner__actor img,
   .activity-banner__actor > span,

--- a/tests/developer-feedback-banner.test.js
+++ b/tests/developer-feedback-banner.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const bannerSource = await readFile(new URL('../components/PlatformActivityBanner.jsx', import.meta.url), 'utf8');
+const homeSource = await readFile(new URL('../app/page.jsx', import.meta.url), 'utf8');
+
+test('homepage activity ribbon includes anonymized Reddit feedback', () => {
+  assert.match(bannerSource, /The 3D globe looks really slick in the editor\./);
+  assert.match(bannerSource, /The globe is a nice hook, but the mission match is prob the sticky part\./);
+  assert.match(bannerSource, /Anonymous developer/);
+  assert.doesNotMatch(bannerSource, /Outrageous_Ad_4801|NoRelation8434/);
+});
+
+test('feedback ribbon remains visible for signed-in and signed-out visitors', () => {
+  assert.match(homeSource, /\{!tourStep && <PlatformActivityBanner \/>\}/);
+  assert.match(homeSource, /\{!tourStep && user && claimStatus === 'claimed'/);
+});


### PR DESCRIPTION
## Summary
- rotate two anonymized Reddit comments through the existing activity ribbon
- preserve the homepage feature-first layout
- keep feedback visible for signed-in and signed-out visitors

## Validation
- node --test tests/developer-feedback-banner.test.js
- npm run build