### PR TITLE
Show active language icons in live presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ npm run setup-live-presence-container
 npm run setup-coding-stats-container
 ```
 
-The [editor directory](https://www.devglobe.dev/plugins) provides tailored installation paths for VS Code, Cursor, Windsurf, VSCodium, Positron, Void, and Antigravity. Release `v0.4.0` is available from both the Marketplace and [GitHub Releases](https://github.com/sajeetharan/devglobe/releases/tag/v0.4.0). The same VSIX supports compatible VS Code forks; Open VSX publication requires the `devglobedev` namespace and an `OVSX_PAT` repository secret.
+The [editor directory](https://www.devglobe.dev/plugins) provides tailored installation paths for VS Code, Cursor, Windsurf, VSCodium, Positron, Void, and Antigravity. Release `v0.6.0` is available from both the Marketplace and [GitHub Releases](https://github.com/sajeetharan/devglobe/releases/tag/v0.6.0). The same VSIX supports compatible VS Code forks; Open VSX publication requires the `devglobedev` namespace and an `OVSX_PAT` repository secret.
 
 Run the **Publish editor extension** workflow manually to validate and package one artifact, then select GitHub Release, Visual Studio Marketplace, or Open VSX destinations. Store publisher credentials only in the `VSCE_PAT` and `OVSX_PAT` GitHub Actions secrets.
 

--- a/components/LanguageBadge.jsx
+++ b/components/LanguageBadge.jsx
@@ -1,0 +1,62 @@
+import { Code2 } from 'lucide-react';
+import {
+  siC,
+  siCplusplus,
+  siDotnet,
+  siGnubash,
+  siGo,
+  siHtml5,
+  siJavascript,
+  siJson,
+  siKotlin,
+  siMarkdown,
+  siOpenjdk,
+  siPhp,
+  siPython,
+  siRuby,
+  siRust,
+  siSwift,
+  siTypescript,
+  siYaml,
+} from 'simple-icons';
+import { getLanguageColor } from '../lib/language-colors.js';
+
+const LANGUAGE_ICONS = new Map([
+  ['c', siC],
+  ['c#', siDotnet],
+  ['c++', siCplusplus],
+  ['go', siGo],
+  ['html', siHtml5],
+  ['java', siOpenjdk],
+  ['javascript', siJavascript],
+  ['json', siJson],
+  ['kotlin', siKotlin],
+  ['markdown', siMarkdown],
+  ['php', siPhp],
+  ['python', siPython],
+  ['ruby', siRuby],
+  ['rust', siRust],
+  ['shell', siGnubash],
+  ['swift', siSwift],
+  ['typescript', siTypescript],
+  ['yaml', siYaml],
+]);
+
+export default function LanguageBadge({ language }) {
+  const label = language || 'Language not shared';
+  const color = getLanguageColor(language);
+  const icon = LANGUAGE_ICONS.get(label.toLowerCase());
+
+  return (
+    <span className="language-badge" style={{ color }}>
+      {icon ? (
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d={icon.path} fill="currentColor" />
+        </svg>
+      ) : (
+        <Code2 aria-hidden="true" />
+      )}
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/components/LiveDeveloperSpace.jsx
+++ b/components/LiveDeveloperSpace.jsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import { track } from '../lib/analytics.js';
 import { getLanguageColor } from '../lib/language-colors.js';
+import LanguageBadge from './LanguageBadge.jsx';
 import { useLivePresence } from './useLivePresence.js';
 import styles from './LiveDeveloperSpace.module.css';
 
@@ -160,7 +161,11 @@ export default function LiveDeveloperSpace() {
               <img src={developer.avatarUrl || '/devglobe.png'} alt="" />
               <span>
                 <strong>{developer.name || developer.login}</strong>
-                <small><i style={{ background: getLanguageColor(developer.activeLanguage) || '#3b82f6' }} />{developer.activeLanguage} · {STATUS_LABELS[developer.codingStatus] || (developer.presenceState === 'live' ? 'Live now' : 'Recently coding')}</small>
+                <small>
+                  <LanguageBadge language={developer.activeLanguage} />
+                  <span aria-hidden="true">·</span>
+                  {STATUS_LABELS[developer.codingStatus] || (developer.presenceState === 'live' ? 'Live now' : 'Recently coding')}
+                </small>
                 {developer.codingAgent ? (
                   <small className={styles.agentIdentity}>{developer.codingAgent}{developer.codingModel ? ` · ${developer.codingModel}` : ''}</small>
                 ) : null}

--- a/components/LiveDeveloperSpace.module.css
+++ b/components/LiveDeveloperSpace.module.css
@@ -129,7 +129,6 @@
 .activityRow > span { min-width: 0; }
 .activityRow strong { display: block; overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .activityRow small { display: flex; align-items: center; gap: 6px; margin-top: 3px; color: var(--text-secondary); font-size: 11px; }
-.activityRow small i { width: 6px; height: 6px; border-radius: 50%; }
 .activityRow .agentIdentity {
   overflow: hidden;
   padding-left: 12px;

--- a/components/LivePresencePanel.jsx
+++ b/components/LivePresencePanel.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { track } from '../lib/analytics.js';
-import { getLanguageColor } from '../lib/language-colors.js';
+import LanguageBadge from './LanguageBadge.jsx';
 
 const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
 
@@ -68,8 +68,9 @@ export default function LivePresencePanel({
             <span className="live-presence-row__identity">
               <strong>{developer.name || developer.login}</strong>
               <small>
-                <i style={{ background: getLanguageColor(developer.activeLanguage) || 'var(--accent-blue)' }} aria-hidden="true" />
-                {developer.activeLanguage} · {developer.presenceState === 'live' ? 'Live now' : 'Recently coding'}
+                <LanguageBadge language={developer.activeLanguage} />
+                <span aria-hidden="true">·</span>
+                {developer.presenceState === 'live' ? 'Live now' : 'Recently coding'}
               </small>
             </span>
             <time dateTime={developer.lastHeartbeat}>{relativeTime(developer.lastHeartbeat)}</time>

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -8,7 +8,7 @@ This extension connects exclusively to [devglobe.dev](https://www.devglobe.dev).
 
 Choose your editor in the [DevGlobe editor directory](https://www.devglobe.dev/plugins), or install [DevGlobe: Live Coding Globe from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery). Choose **Go Live Now** in the first-run prompt and approve GitHub authentication. Your verified GitHub name appears automatically on the [live globe](https://www.devglobe.dev/space); no separate DevGlobe profile is required. You can also use the Command Palette and run `DevGlobe.dev: Go Live on the Developer Globe`.
 
-Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the [version 0.4.0 release package](https://github.com/sajeetharan/devglobe/releases/download/v0.4.0/devglobe-developer-discovery-0.4.0.vsix), then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
+Cursor, Windsurf, VSCodium, Positron, Void, Antigravity, and other compatible VS Code forks can install the same VSIX. Download the [version 0.6.0 release package](https://github.com/sajeetharan/devglobe/releases/download/v0.6.0/devglobe-developer-discovery-0.6.0.vsix), then use the editor's **Install from VSIX** action. Open VSX and vendor marketplace publication require their respective publisher credentials.
 
 ## Commands
 

--- a/extensions/vscode/src/devglobe.js
+++ b/extensions/vscode/src/devglobe.js
@@ -5,10 +5,33 @@ const ATTRIBUTION = Object.freeze({
 const CODING_ACTIVITY_WINDOW_MS = 60_000;
 const NON_CODING_LANGUAGE_IDS = new Set([
   'log',
-  'markdown',
   'plaintext',
   'search-result',
 ]);
+const LANGUAGE_NAMES = Object.freeze({
+  c: 'C',
+  cpp: 'C++',
+  csharp: 'C#',
+  dockerfile: 'Dockerfile',
+  go: 'Go',
+  html: 'HTML',
+  java: 'Java',
+  javascript: 'JavaScript',
+  javascriptreact: 'JavaScript',
+  json: 'JSON',
+  jsonc: 'JSON',
+  kotlin: 'Kotlin',
+  markdown: 'Markdown',
+  php: 'PHP',
+  python: 'Python',
+  ruby: 'Ruby',
+  rust: 'Rust',
+  shellscript: 'Shell',
+  swift: 'Swift',
+  typescript: 'TypeScript',
+  typescriptreact: 'TypeScript',
+  yaml: 'YAML',
+});
 
 function isCodingActivityRecent(lastActivityAt, now = Date.now()) {
   return Number.isFinite(lastActivityAt)
@@ -123,7 +146,8 @@ function normalizeLogin(value) {
 
 function normalizeActiveLanguage(value) {
   const language = String(value || '').trim().toLowerCase();
-  return language && !NON_CODING_LANGUAGE_IDS.has(language) ? language : '';
+  if (!language || NON_CODING_LANGUAGE_IDS.has(language)) return '';
+  return LANGUAGE_NAMES[language] || `${language[0].toUpperCase()}${language.slice(1)}`;
 }
 
 function normalizeResults(payload) {

--- a/extensions/vscode/src/extension.js
+++ b/extensions/vscode/src/extension.js
@@ -75,7 +75,9 @@ function createPresenceController(context) {
   let activeHeartbeatDone = null;
   let stopping = false;
   let agentRefreshTimer = null;
+  let languageRefreshTimer = null;
   let lastPublishedAgentIdentity = null;
+  let lastPublishedLanguage = null;
 
   function showOfflineStatus() {
     status.command = 'devglobedev.startPresence';
@@ -198,6 +200,7 @@ function createPresenceController(context) {
       }
       const payload = await response.json();
       lastPublishedAgentIdentity = agentIdentity;
+      lastPublishedLanguage = currentConfiguration.shareActiveLanguage ? language : 'Hidden';
       for (const wave of Array.isArray(payload.waves) ? payload.waves : []) {
         lastWaveSeenAt = !lastWaveSeenAt || wave.sentAt > lastWaveSeenAt ? wave.sentAt : lastWaveSeenAt;
         await context.globalState.update(LAST_WAVE_SEEN_KEY, lastWaveSeenAt);
@@ -328,6 +331,18 @@ function createPresenceController(context) {
     }, 150);
   }
 
+  function scheduleLanguageRefresh() {
+    if (languageRefreshTimer) clearTimeout(languageRefreshTimer);
+    languageRefreshTimer = setTimeout(() => {
+      languageRefreshTimer = null;
+      const current = configuration();
+      const language = current.shareActiveLanguage ? activeLanguage() || 'Ready to code' : 'Hidden';
+      if (language === lastPublishedLanguage || !current.presenceEnabled) return;
+      lastActivityAt = Date.now();
+      heartbeatWithRetry(false, true).catch(handleBackgroundError);
+    }, 150);
+  }
+
   async function startFocus(minutes) {
     const now = new Date();
     focusStartedAt = now.toISOString();
@@ -344,7 +359,10 @@ function createPresenceController(context) {
   }
 
   context.subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor(recordActivity),
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      recordActivity();
+      scheduleLanguageRefresh();
+    }),
     vscode.window.onDidChangeTextEditorSelection(recordActivity),
     vscode.workspace.onDidChangeTextDocument(recordActivity),
     vscode.workspace.onDidSaveTextDocument(recordActivity),
@@ -367,6 +385,7 @@ function createPresenceController(context) {
     {
       dispose: () => {
         if (agentRefreshTimer) clearTimeout(agentRefreshTimer);
+        if (languageRefreshTimer) clearTimeout(languageRefreshTimer);
         return stop(false, false);
       },
     },

--- a/extensions/vscode/test/devglobe.test.js
+++ b/extensions/vscode/test/devglobe.test.js
@@ -66,13 +66,17 @@ test('builds attributed profile, card, setup, activation, and search URLs', () =
   assert.equal(search.searchParams.get('top'), '10');
 });
 
-test('normalizes source-code languages and identifies non-code editors', () => {
+test('normalizes active languages and identifies non-code editors', () => {
   assert.equal(normalizeActiveLanguage(), '');
   assert.equal(normalizeActiveLanguage('plaintext'), '');
-  assert.equal(normalizeActiveLanguage('markdown'), '');
   assert.equal(normalizeActiveLanguage('log'), '');
-  assert.equal(normalizeActiveLanguage(' TypeScript '), 'typescript');
-  assert.equal(normalizeActiveLanguage('python'), 'python');
+  assert.equal(normalizeActiveLanguage('markdown'), 'Markdown');
+  assert.equal(normalizeActiveLanguage(' TypeScript '), 'TypeScript');
+  assert.equal(normalizeActiveLanguage('typescriptreact'), 'TypeScript');
+  assert.equal(normalizeActiveLanguage('jsonc'), 'JSON');
+  assert.equal(normalizeActiveLanguage('shellscript'), 'Shell');
+  assert.equal(normalizeActiveLanguage('python'), 'Python');
+  assert.equal(normalizeActiveLanguage('terraform'), 'Terraform');
 });
 
 test('creates a VS Code Streamable HTTP MCP configuration', () => {

--- a/lib/editor-distribution.js
+++ b/lib/editor-distribution.js
@@ -1,5 +1,5 @@
 const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=devglobedev.devglobe-developer-discovery';
-const VSIX_URL = 'https://github.com/sajeetharan/devglobe/releases/download/v0.4.0/devglobe-developer-discovery-0.4.0.vsix';
+const VSIX_URL = 'https://github.com/sajeetharan/devglobe/releases/download/v0.6.0/devglobe-developer-discovery-0.6.0.vsix';
 
 export const editorChannels = [
   { slug: 'vscode', name: 'VS Code', family: 'VS Code', aliases: ['visual studio code', 'microsoft'], status: 'available', installLabel: 'Install from Marketplace', installUrl: MARKETPLACE_URL, accent: '#23a8f2' },

--- a/lib/language-colors.js
+++ b/lib/language-colors.js
@@ -14,6 +14,7 @@ export const LANGUAGE_COLORS = {
   PHP: '#4f5d95',
   Swift: '#f05138',
   Kotlin: '#a97bff',
+  Markdown: '#083fa1',
   'C#': '#178600',
   Shell: '#89e051',
   HTML: '#e34c26',
@@ -23,5 +24,8 @@ export const LANGUAGE_FALLBACK_COLOR = '#94a3b8';
 
 export function getLanguageColor(language) {
   if (!language) return LANGUAGE_FALLBACK_COLOR;
-  return LANGUAGE_COLORS[language] || LANGUAGE_FALLBACK_COLOR;
+  const normalized = String(language).trim().toLowerCase();
+  const match = Object.entries(LANGUAGE_COLORS)
+    .find(([name]) => name.toLowerCase() === normalized);
+  return match?.[1] || LANGUAGE_FALLBACK_COLOR;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -3818,16 +3818,31 @@ body {
 }
 
 .live-presence-row__identity small {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   color: var(--text-muted);
   font-size: 10px;
 }
 
-.live-presence-row__identity i {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  margin-right: 5px;
-  border-radius: 50%;
+.language-badge {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  font-weight: 700;
+}
+
+.language-badge svg {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+}
+
+.language-badge > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .live-presence-row time {

--- a/tests/editor-distribution.test.js
+++ b/tests/editor-distribution.test.js
@@ -18,7 +18,7 @@ test('only available clients expose installation steps and attributed links', ()
   assert.match(editorInstallSteps(cursor)[2], /verified GitHub name/);
   assert.deepEqual(editorInstallSteps(jetbrains), []);
   assert.equal(attributedInstallUrl(jetbrains), null);
-  assert.match(installUrl.pathname, /v0\.4\.0\/devglobe-developer-discovery-0\.4\.0\.vsix$/);
+  assert.match(installUrl.pathname, /v0\.6\.0\/devglobe-developer-discovery-0\.6\.0\.vsix$/);
   assert.equal(installUrl.searchParams.get('utm_campaign'), 'cursor');
   assert.equal(installUrl.searchParams.get('utm_medium'), 'plugin_directory');
 });

--- a/tests/language-colors.test.js
+++ b/tests/language-colors.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getLanguageColor,
+  LANGUAGE_COLORS,
+  LANGUAGE_FALLBACK_COLOR,
+} from '../lib/language-colors.js';
+
+test('matches language colors regardless of editor ID casing', () => {
+  assert.equal(getLanguageColor('TypeScript'), LANGUAGE_COLORS.TypeScript);
+  assert.equal(getLanguageColor('typescript'), LANGUAGE_COLORS.TypeScript);
+  assert.equal(getLanguageColor(' JAVASCRIPT '), LANGUAGE_COLORS.JavaScript);
+  assert.equal(getLanguageColor('markdown'), LANGUAGE_COLORS.Markdown);
+});
+
+test('uses the fallback color for missing and unknown languages', () => {
+  assert.equal(getLanguageColor('Ready to code'), LANGUAGE_FALLBACK_COLOR);
+  assert.equal(getLanguageColor(''), LANGUAGE_FALLBACK_COLOR);
+});


### PR DESCRIPTION
## Summary
- normalize and immediately refresh active editor languages
- show distinct language icons and colors, including Markdown
- update GitHub VSIX links to release 0.6.0

## Validation
- extension tests: 8 passed
- extension syntax checks passed
- targeted site tests: 35 passed
- production Next.js build passed